### PR TITLE
feat(ci): Multi-branch SFTP deploy + auto-version/changelog/release pipeline

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,95 @@
+<!--
+WebMS Intra — Pull Request Template
+Fill in the sections below. The security checklist is required for ALL PRs.
+The PR Security Checks workflow will run on push and also flag heuristic
+issues automatically; this checklist is your manual review pass.
+-->
+
+## Summary
+
+<!-- 1-3 sentences: what does this PR do and why. -->
+
+## Scope of changes
+
+- [ ] Backend (PHP under `web/`)
+- [ ] Frontend (CSS/JS under `web/public_html/assets/`)
+- [ ] SQL migrations (`web/sql/`)
+- [ ] CI / workflows (`.github/workflows/`)
+- [ ] Documentation (CHANGELOG, DEV_NOTES, README, in-app help)
+- [ ] Other: _____
+
+## Test plan
+
+<!-- Checklist of how you / a reviewer can verify this works. -->
+
+- [ ] Verified locally on `php -S` dev server
+- [ ] Tested the golden path
+- [ ] Tested at least one edge case
+- [ ] Verified no regressions in related apps
+
+## Security review
+
+**Every PR must complete this checklist.** Tick each row consciously.
+
+### Input handling
+
+- [ ] All user input from `$_GET` / `$_POST` / `$_REQUEST` / `$_COOKIE` / URL params is validated and type-coerced before use
+- [ ] No user input is interpolated directly into SQL — mysqli prepared statements with `bind_param` are used throughout
+- [ ] No user input reaches `eval`, `exec`, `shell_exec`, `system`, `passthru`, `popen`, `proc_open`
+- [ ] File-upload paths validate extension allowlist, size cap, and server-side MIME
+
+### Output handling
+
+- [ ] All variables echoed into HTML are passed through `htmlspecialchars($v, ENT_QUOTES, 'UTF-8')`
+- [ ] No `innerHTML =` of user-derived strings in JS — use `textContent` or DOM APIs
+- [ ] JSON responses set `Content-Type: application/json` and use `json_encode` (not string concat)
+
+### State-changing requests
+
+- [ ] Every `POST`, `PUT`, `PATCH`, `DELETE` handler calls `Auth::verifyCsrf($_POST['csrf_token'] ?? '')` before any side-effect
+- [ ] Forms with `method="post"` include `<input type="hidden" name="csrf_token" value="<?= ... ?>">`
+- [ ] CSRF tokens are read once and rotated after sensitive actions (login, password change)
+
+### AuthN / AuthZ
+
+- [ ] Sensitive routes call `Auth::requireLogin()` (or the route is correctly flagged `isProtected=1` in `tblRoutes`)
+- [ ] Admin-only routes call `App::isAdmin() === true` (or `isRootAdmin` for super-admin paths) before any work
+- [ ] Site-aware routes call `App::isSiteAdmin()` / `App::isUmbrellaAdmin()` as appropriate
+- [ ] Open redirects: any `$_GET['redirect']` is validated against an allowlist before `header('Location: …')`
+
+### Secrets / credentials
+
+- [ ] No DB credentials, API keys, tokens, encryption keys, or passwords are committed in code or config
+- [ ] Sensitive settings written to `tblSettings` set `isSensitive=1` so they're encrypted at rest
+- [ ] No `var_dump` / `print_r` of credentials, sessions, or full `$_SERVER` left in production paths
+- [ ] No new files were added to `web/_auth_keys/`, `web/_uploads/`, or `web/_backups/`. **If any were, justify here:** ____
+
+### Dependencies
+
+- [ ] No new vendored library was added without committing the source under `web/vendor/` (or fetching it via `tools/download-X.sh`)
+- [ ] If `tools/download-dompdf.sh` (or similar) was updated: the new version was checked for known CVEs
+
+### Logging
+
+- [ ] No `Logger::activity` or `Logger::error` call logs raw credentials, full session data, OAuth state, or CSRF tokens
+- [ ] Errors leak to logs (not to users) — production env hides messages; dev env can show them
+
+### Migrations
+
+- [ ] Each new SQL file uses `IF NOT EXISTS` / `ON DUPLICATE KEY UPDATE` so it can be re-run safely
+- [ ] No `DROP`, `TRUNCATE`, `DELETE` without explicit comment justifying it
+- [ ] If a column type or constraint changed: there's a rollback / forward path documented in the migration
+
+## Deployment notes
+
+- [ ] No manual server steps required to deploy this — OR — manual steps are listed below
+- [ ] Targets: alpha → ☐ &nbsp;&nbsp; beta → ☐ &nbsp;&nbsp; main → ☐
+- [ ] Tag a release? `v____` (only if this PR ships to `main` AND warrants a tag)
+
+## Related issues
+
+<!-- Closes #N, refs #N, etc. -->
+
+---
+
+<sub>This PR template is enforced by repo convention, not by CI. The PR Security Checks workflow runs additional automated heuristic scans on top of this manual review.</sub>

--- a/.github/workflows/auto-merge-alpha.yml
+++ b/.github/workflows/auto-merge-alpha.yml
@@ -1,0 +1,96 @@
+# =============================================================================
+# WebMS-Intra — Auto-Merge Alpha PRs
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
+#
+# PURPOSE
+# -------
+# Enables GitHub's native "auto-merge" feature on any PR whose base branch
+# is `alpha`. GitHub will merge as soon as required status checks pass and
+# any required reviews are satisfied. Failed checks leave the PR open.
+#
+# REQUIREMENTS (one-time repo configuration)
+# ------------------------------------------
+#   1. Settings -> General -> "Allow auto-merge" must be enabled.
+#   2. (Recommended) Branch protection on `alpha` requiring at least one
+#      status check, otherwise auto-merge fires immediately with no gate.
+#
+# MERGE STRATEGY
+# --------------
+# Squash merge (`--squash`). Change to `--merge` or `--rebase` if preferred.
+#
+# DEPLOY DISPATCH BRIDGE
+# ----------------------
+# GitHub suppresses workflow triggers for pushes attributed to GITHUB_TOKEN
+# (anti-recursion). After auto-merge lands on alpha, this workflow explicitly
+# dispatches deploy.yml so the alpha environment updates.
+# =============================================================================
+
+name: Auto-Merge Alpha PRs
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
+    branches:
+      - alpha
+
+permissions:
+  contents: write
+  pull-requests: write
+  actions: write
+
+# Coalesce repeated synchronise events on the same PR
+concurrency:
+  group: auto-merge-alpha-pr-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  enable-auto-merge:
+    name: Enable auto-merge on alpha PRs
+    runs-on: ubuntu-latest
+
+    # Drafts cannot auto-merge — skip them
+    if: github.event.pull_request.draft == false
+
+    steps:
+      - name: Enable auto-merge (squash)
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: gh pr merge --auto --squash "$PR_URL"
+
+      # ---------------------------------------------------------------------
+      # Bridge GitHub's anti-recursion rule: after merge, dispatch deploy.yml
+      # explicitly. Polls up to ~60 min and exits cleanly if the PR closes
+      # without merging.
+      # ---------------------------------------------------------------------
+      - name: Wait for merge and dispatch deploy
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          REPO: ${{ github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          set -euo pipefail
+          for i in $(seq 1 120); do
+            STATE=$(gh pr view "$PR_NUMBER" --repo "$REPO" --json state -q .state)
+            case "$STATE" in
+              MERGED)
+                echo "PR #$PR_NUMBER merged — dispatching deploy.yml on alpha"
+                gh workflow run deploy.yml --repo "$REPO" --ref alpha
+                exit 0
+                ;;
+              CLOSED)
+                echo "PR #$PR_NUMBER closed without merging — skipping deploy"
+                exit 0
+                ;;
+            esac
+            echo "PR #$PR_NUMBER state=$STATE (poll $i/120) — sleeping 30s"
+            sleep 30
+          done
+          echo "::error::Timed out waiting for PR #$PR_NUMBER to reach a terminal state"
+          exit 1

--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -1,0 +1,184 @@
+# =============================================================================
+# WebMS-Intra — Automatic Changelog Generation
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
+#
+# PURPOSE
+# -------
+# Generates / updates CHANGELOG.md from commit messages since the last v* tag
+# on push to alpha, beta, or main. Commits the result with [skip ci] so the
+# update itself does not retrigger the workflow.
+#
+# Excludes meta commits (CI bot bumps, [skip ci], changelog updates) from
+# the generated section. Per-branch sections use the heading format:
+#   ## [VERSION] - YYYY-MM-DD (branch)
+# so alpha/beta/main entries for the same version can coexist.
+# =============================================================================
+
+name: Changelog
+
+on:
+  push:
+    branches:
+      - alpha
+      - beta
+      - main
+    paths:
+      - 'web/**'
+
+concurrency:
+  group: changelog-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  changelog:
+    name: Generate changelog
+    runs-on: ubuntu-latest
+
+    # Skip if the triggering commit was a CI automation commit
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      # -----------------------------------------------------------------------
+      # Read current portal version from web/core/App.php
+      # -----------------------------------------------------------------------
+      - name: Read current version
+        id: version
+        run: |
+          VERSION_FILE="web/core/App.php"
+          VERSION=$(grep -oP "static string \\\$version\s*=\s*'\K[^']+" "$VERSION_FILE" 2>/dev/null || echo "Unreleased")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Version: $VERSION"
+
+      # -----------------------------------------------------------------------
+      # Determine commit range (since last v* tag, or all history)
+      # -----------------------------------------------------------------------
+      - name: Determine commit range
+        id: range
+        run: |
+          LAST_TAG=$(git describe --tags --abbrev=0 --match 'v*' 2>/dev/null || echo "")
+          if [[ -n "$LAST_TAG" ]]; then
+            echo "range=${LAST_TAG}..HEAD" >> "$GITHUB_OUTPUT"
+            echo "Range: ${LAST_TAG}..HEAD"
+          else
+            echo "range=HEAD" >> "$GITHUB_OUTPUT"
+            echo "No previous v* tags — using full history"
+          fi
+
+      # -----------------------------------------------------------------------
+      # Build the entry text and splice into CHANGELOG.md
+      # -----------------------------------------------------------------------
+      - name: Generate CHANGELOG.md
+        id: generate
+        env:
+          CL_VERSION: ${{ steps.version.outputs.version }}
+          CL_RANGE: ${{ steps.range.outputs.range }}
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          DATE=$(date +%Y-%m-%d)
+          HEADER="## [${CL_VERSION}] - ${DATE} (${BRANCH})"
+          FILTER_OUT='(\[skip ci\]|^chore: bump version|^chore: update changelog)'
+
+          MSGS=$(git log "${CL_RANGE}" --pretty=format:"%s" -- 'web/' 2>/dev/null \
+            | grep -vE "$FILTER_OUT" \
+            | sort -u \
+            | sed '/^$/d' \
+            | sed 's/^/- /' || true)
+
+          if [[ -z "$MSGS" ]]; then
+            echo "No changelog-worthy commits in range"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Write the entry to a temp file (avoids shell-quoting headaches)
+          {
+            echo "$HEADER"
+            echo "$MSGS"
+          } > /tmp/cl_entry.txt
+
+          # Splice into CHANGELOG.md. The Python helper:
+          #   - creates the file if missing
+          #   - removes any existing section that matches "[VERSION] ... (branch)"
+          #   - inserts the new entry right after the top "# Changelog" header
+          python3 - "$CL_VERSION" "$BRANCH" <<'PYEOF'
+          import os, re, sys
+          version, branch = sys.argv[1], sys.argv[2]
+          path = 'CHANGELOG.md'
+          with open('/tmp/cl_entry.txt', 'r') as f:
+              entry = f.read().rstrip() + '\n'
+
+          if not os.path.exists(path):
+              with open(path, 'w') as f:
+                  f.write('# Changelog\n\n' + entry + '\n')
+              sys.exit(0)
+
+          with open(path, 'r') as f:
+              content = f.read()
+
+          # Strip any prior section for this version+branch
+          pattern = (
+              r'## \[' + re.escape(version) + r'\][^\n]*\('
+              + re.escape(branch) + r'\)[^\n]*\n(?:(?!^## \[).*\n?)*'
+          )
+          content = re.sub(pattern, '', content, flags=re.MULTILINE)
+
+          # Insert after the first "# " heading (and following blank line)
+          if content.startswith('# '):
+              first_nl = content.find('\n')
+              insert_at = first_nl + 1
+              if content[insert_at:insert_at + 1] == '\n':
+                  insert_at += 1
+              new = content[:insert_at] + '\n' + entry + '\n' + content[insert_at:]
+          else:
+              new = entry + '\n' + content
+
+          with open(path, 'w') as f:
+              f.write(new)
+          PYEOF
+
+          echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          echo "Updated CHANGELOG.md"
+
+      # -----------------------------------------------------------------------
+      # Commit + push with [skip ci]; retry on race with version-bump.yml
+      # -----------------------------------------------------------------------
+      - name: Commit changelog
+        if: steps.generate.outputs.has_changes == 'true'
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add CHANGELOG.md
+          if git diff --cached --quiet; then
+            echo "No changelog changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: update changelog for ${{ steps.version.outputs.version }} [skip ci]"
+
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${BRANCH}"; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt — rebasing and retrying"
+            git fetch origin "${BRANCH}"
+            git rebase "origin/${BRANCH}"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to push changelog after 5 attempts"
+          exit 1

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,84 +1,376 @@
-# ===============================
-# GitHub Action - FTP Deploy
-# ===============================
-# Single-branch deployment model:
-#   - Push to main  -> deploys web/ to server root (dev, automatic)
-#   - Tagged v*     -> deploys web/ to server root (production, automatic)
-#   - Manual        -> choice of target (override)
+# =============================================================================
+# WebMS-Intra — Deploy via SFTP
 #
-# Only the web/ directory is deployed to the server. Repo-level files
-# (.github, .claude, README, etc.) are NOT uploaded.
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
 #
-# The remote server structure is:
-#   portal.millrdsdacambridge.uk/
-#     ├── core/              ← PHP framework (above web root)
-#     ├── vendor/            ← Self-hosted libraries
-#     ├── sql/               ← Migrations
-#     ├── _auth_keys/        ← Credentials (not deployed — managed on server)
-#     ├── _libraries/        ← Self-hosted libs like dompdf (not deployed)
-#     ├── public_html/       ← Production web root (app controllers + assets)
-#     ├── public_html_dev/   ← Dev web root (Gatekeeper-protected)
-#     └── ...
+# PURPOSE
+# -------
+# Multi-branch SFTP deployment to DreamHost. Mirrors the iHymns deployment
+# model, adapted for the WebMS-Intra web/ + public_html layout.
 #
-# Required secrets: DH_HOST, DH_USER, DH_PASS
-# -----------------------------------------------
-name: Deploy to DreamHost
+# CHANNEL MODEL
+# -------------
+# Three branches map to three web roots on a SINGLE shared remote base:
+#
+#   main   -> web/public_html/  ->  <base>/public_html/        (production)
+#   beta   -> web/public_html/  ->  <base>/public_html_beta/   (beta)
+#   alpha  -> web/public_html/  ->  <base>/public_html_dev/    (alpha / dev)
+#
+# Everything else inside web/ (core/, vendor/, sql/, _includes/, _functions/)
+# uploads to the SHARED <base>/ directory on every branch. Whichever branch
+# pushed last wins for shared code — protect main with branch rules if this
+# matters for your workflow.
+#
+# Excluded from every upload (server-managed):
+#   _auth_keys/  _uploads/  _backups/  _libraries/  .DS_Store
+#
+# SECRETS REQUIRED
+# ----------------
+#   SFTP_HOST          DreamHost SFTP server (e.g. iad1-shared-XXX.dreamhost.com)
+#   SFTP_USER          DreamHost SFTP user
+#   SFTP_BASE_PATH     Shared remote base (e.g. /home/USER/portal.millrdsdacambridge.uk)
+#
+# Optional secrets:
+#   SFTP_PORT          Defaults to 22 if missing or non-numeric
+#   SFTP_KEY           SSH private key (preferred over password)
+#   SFTP_PASSWORD      Fallback password used only when SFTP_KEY is empty
+#
+# VARIABLES
+# ---------
+#   vars.SFTP_ENABLED  Must be 'true' to enable deployment (kill switch)
+#
+# COMMIT FLAGS
+# ------------
+#   [skip ci]      Skip this workflow entirely
+#   [deploy all]   Force full sync regardless of change detection
+# =============================================================================
+
+name: Deploy via SFTP
 
 on:
   push:
-    branches: [ main ]
-    tags: [ 'v*' ]
+    branches:
+      - main
+      - beta
+      - alpha
+    paths:
+      - 'web/**'
+      - '.github/workflows/deploy.yml'
   workflow_dispatch:
     inputs:
       target:
-        description: "Deploy target"
+        description: "Override deploy target (alpha / beta / main). Leave blank to use the current branch."
         required: false
-        default: "dev"
         type: choice
+        default: ""
         options:
-          - dev
-          - live
+          - ""
+          - alpha
+          - beta
+          - main
+
+permissions:
+  contents: read
 
 jobs:
   deploy:
     runs-on: ubuntu-latest
+    if: vars.SFTP_ENABLED == 'true'
 
-    # Remote base path — web/ contents are synced to this directory
+    # Shared lftp exclude flags. Patterns with wildcards are single-quoted in
+    # YAML so they pass through the shell as literal regexes for lftp.
     env:
-      FTP_HOST: ${{ secrets.DH_HOST }}
-      FTP_USER: ${{ secrets.DH_USER }}
-      FTP_PASS: ${{ secrets.DH_PASS }}
-      REMOTE_BASE: portal.millrdsdacambridge.uk
+      LFTP_EXCLUDES: >-
+        --exclude ^\.DS_Store$
+        --exclude ^Thumbs\.db$
+        --exclude ^\.git/
+        --exclude ^\.github/
+        --exclude ^\.gitkeep$
+        --exclude ^\.gitignore$
+        --exclude ^\.gitattributes$
+        --exclude ^README\.md$
+        --exclude ^DEV_NOTES\.md$
+        --exclude ^CHANGELOG\.md$
+        --exclude ^CLAUDE\.md$
+        --exclude ^\.htpasswd
+        --exclude ^\.vscode/
+        --exclude ^\.idea/
+        --exclude ^\.editorconfig$
+        --exclude \.swp$
+        --exclude \.swo$
+        --exclude ~$
+      # NOTE: _libraries/ is INTENTIONALLY not excluded — dompdf is fetched
+      # at build time by tools/download-dompdf.sh into web/_libraries/dompdf/
+      # and needs to ride along with the shared upload. The shared mirror runs
+      # without --delete, so any other server-managed contents of _libraries/
+      # are preserved.
+      WEB_ROOT_EXCLUDES: >-
+        --exclude ^_auth_keys/
+        --exclude ^_uploads/
+        --exclude ^_backups/
+        --exclude ^public_html/
+        --exclude ^public_html_dev/
+        --exclude ^public_html_beta/
+        --exclude ^public_html_landing/
+        --exclude ^public_html_redir/
+        --exclude ^private_html/
 
     steps:
-      - name: Checkout repo
+      # -- Checkout code --
+      - name: Checkout code
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          ref: ${{ github.ref_name }}
 
-      - name: Select target path
-        id: set-path
+      # -- Resolve target channel + remote sub-path --
+      - name: Determine target channel
+        id: target
         run: |
-          echo "::group::Select remote path"
-          # All targets deploy to the same base — the server structure
-          # inside web/ determines which web root is used
-          echo "path=${REMOTE_BASE}" >> $GITHUB_OUTPUT
-          echo "::endgroup::"
+          MANUAL_TARGET="${{ github.event.inputs.target }}"
+          if [[ -n "$MANUAL_TARGET" ]]; then
+            CHANNEL="$MANUAL_TARGET"
+            echo "Manual dispatch override: $CHANNEL"
+          else
+            CHANNEL="${{ github.ref_name }}"
+          fi
 
+          case "$CHANNEL" in
+            main)
+              echo "channel=live"               >> "$GITHUB_OUTPUT"
+              echo "public_dir=public_html"     >> "$GITHUB_OUTPUT"
+              ;;
+            beta)
+              echo "channel=beta"               >> "$GITHUB_OUTPUT"
+              echo "public_dir=public_html_beta">> "$GITHUB_OUTPUT"
+              ;;
+            alpha)
+              echo "channel=alpha"              >> "$GITHUB_OUTPUT"
+              echo "public_dir=public_html_dev" >> "$GITHUB_OUTPUT"
+              ;;
+            *)
+              echo "::error::Unknown channel: $CHANNEL"
+              exit 1
+              ;;
+          esac
+
+      # -- Lint PHP (every file) — blocks deploy on syntax errors --
       - name: Lint PHP
         run: |
-          echo "::group::PHP Lint"
-          find ./web -type f -name "*.php" -not -path "*/vendor/*" -print0 | xargs -0 -n1 -P4 php -l
+          echo "::group::PHP lint"
+          find ./web -type f -name "*.php" \
+            -not -path "*/vendor/*" \
+            -not -path "*/_libraries/*" \
+            -print0 \
+          | xargs -0 -n1 -P4 php -l
           echo "::endgroup::"
 
-      - name: Sync web/ to server via lftp
-        uses: sebastianpopp/ftp-action@v1
-        with:
-          host:   ${{ env.FTP_HOST }}
-          user:   ${{ env.FTP_USER }}
-          pass:   ${{ env.FTP_PASS }}
-          local:  ./web/
-          remote: ${{ steps.set-path.outputs.path }}
-          args:   "--verbose --parallel=4 --delete --exclude _auth_keys/ --exclude _uploads/ --exclude _backups/ --exclude _libraries/ --exclude .DS_Store"
+      # -- Change detection (skip deploy when nothing relevant changed) --
+      - name: Detect deployable changes
+        id: changes
+        run: |
+          COMMIT_MSG=$(git log -1 --pretty=format:"%s")
+          if echo "$COMMIT_MSG" | grep -q "\[deploy all\]"; then
+            echo "Force full deploy via [deploy all] flag"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # workflow_dispatch always deploys
+          if [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            echo "Manual dispatch — deploying"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          CHANGED=$(git diff --name-only HEAD~5 HEAD -- 'web/' 2>/dev/null \
+            | grep -vE 'README\.md|DEV_NOTES\.md|CHANGELOG\.md|\.DS_Store|\.gitkeep|\.gitignore' \
+            | sort -u || true)
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "No deployable changes in web/ — skipping"
+            echo "has_changes=false" >> "$GITHUB_OUTPUT"
+          else
+            echo "Changed files:"
+            echo "$CHANGED"
+            echo "has_changes=true" >> "$GITHUB_OUTPUT"
+          fi
+
+      # -- Fetch pinned dompdf into web/_libraries/dompdf/ so it gets uploaded
+      #    as part of the shared web/ sync. Skips if already present at the
+      #    pinned version. See tools/download-dompdf.sh for the pin.
+      - name: Fetch dompdf (pinned)
+        if: steps.changes.outputs.has_changes == 'true'
+        run: bash tools/download-dompdf.sh
+
+      # -- Install lftp --
+      - name: Install lftp
+        if: steps.changes.outputs.has_changes == 'true'
+        run: sudo apt-get update -qq && sudo apt-get install -y -qq lftp
+
+      # -- Resolve SFTP port (default 22 on missing / non-numeric) --
+      - name: Resolve SFTP port
+        if: steps.changes.outputs.has_changes == 'true'
+        id: port
+        env:
+          RAW_PORT: ${{ secrets.SFTP_PORT }}
+        run: |
+          TRIMMED=$(echo "$RAW_PORT" | tr -d '[:space:]')
+          if [[ "$TRIMMED" =~ ^[0-9]+$ ]] && [[ "$TRIMMED" -ge 1 ]] && [[ "$TRIMMED" -le 65535 ]]; then
+            echo "port=$TRIMMED" >> "$GITHUB_OUTPUT"
+          else
+            echo "port=22" >> "$GITHUB_OUTPUT"
+          fi
+
+      # -- Choose auth method: SSH key preferred, password fallback --
+      - name: Choose auth method
+        if: steps.changes.outputs.has_changes == 'true'
+        id: auth
+        env:
+          SFTP_KEY: ${{ secrets.SFTP_KEY }}
+          SFTP_PASSWORD: ${{ secrets.SFTP_PASSWORD }}
+        run: |
+          if [[ -n "$SFTP_KEY" ]]; then
+            echo "method=key" >> "$GITHUB_OUTPUT"
+          elif [[ -n "$SFTP_PASSWORD" ]]; then
+            echo "method=password" >> "$GITHUB_OUTPUT"
+          else
+            echo "::error::Neither SFTP_KEY nor SFTP_PASSWORD is configured"
+            exit 1
+          fi
+
+      # -- Stage SSH key on disk if we'll use key auth --
+      - name: Stage SSH key
+        if: steps.changes.outputs.has_changes == 'true' && steps.auth.outputs.method == 'key'
+        env:
+          SFTP_KEY: ${{ secrets.SFTP_KEY }}
+        run: |
+          mkdir -p ~/.ssh && chmod 700 ~/.ssh
+          echo "$SFTP_KEY" > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+
+      # ========================================================================
+      # 1) Upload web/public_html/  ->  <base>/<public_dir>/   (per branch)
+      # ========================================================================
+
+      - name: Deploy public_html via SFTP (SSH key)
+        if: steps.changes.outputs.has_changes == 'true' && steps.auth.outputs.method == 'key'
+        env:
+          SFTP_HOST: ${{ secrets.SFTP_HOST }}
+          SFTP_USER: ${{ secrets.SFTP_USER }}
+          SFTP_PORT: ${{ steps.port.outputs.port }}
+          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
+          PUBLIC_DIR: ${{ steps.target.outputs.public_dir }}
+        run: |
+          REMOTE="${BASE_PATH%/}/${PUBLIC_DIR}/"
+          echo "Deploying web/public_html/ -> $REMOTE"
+          cat > /tmp/lftp_public.txt <<LFTP_EOF
+          set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
+          open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
+          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES web/public_html/ ${REMOTE}
+          bye
+          LFTP_EOF
+          lftp -f /tmp/lftp_public.txt
+
+      - name: Deploy public_html via SFTP (password)
+        if: steps.changes.outputs.has_changes == 'true' && steps.auth.outputs.method == 'password'
+        env:
+          SFTP_HOST: ${{ secrets.SFTP_HOST }}
+          SFTP_USER: ${{ secrets.SFTP_USER }}
+          SFTP_PASS: ${{ secrets.SFTP_PASSWORD }}
+          SFTP_PORT: ${{ steps.port.outputs.port }}
+          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
+          PUBLIC_DIR: ${{ steps.target.outputs.public_dir }}
+        run: |
+          REMOTE="${BASE_PATH%/}/${PUBLIC_DIR}/"
+          echo "Deploying web/public_html/ -> $REMOTE"
+          lftp -u "${SFTP_USER},${SFTP_PASS}" \
+            -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
+                mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
+                $LFTP_EXCLUDES \
+                web/public_html/ ${REMOTE}; bye" \
+            "sftp://${SFTP_HOST}:${SFTP_PORT}"
+
+      # ========================================================================
+      # 2) Upload everything else in web/  ->  <base>/   (shared)
+      #    Excludes _auth_keys/, _uploads/, _backups/, _libraries/, and the
+      #    public_html_* trees (they go through step 1 above per branch).
+      #    Uses --no-delete so server-managed siblings (private_html,
+      #    public_html_landing, etc.) are preserved.
+      # ========================================================================
+
+      - name: Deploy shared web/ via SFTP (SSH key)
+        if: steps.changes.outputs.has_changes == 'true' && steps.auth.outputs.method == 'key'
+        env:
+          SFTP_HOST: ${{ secrets.SFTP_HOST }}
+          SFTP_USER: ${{ secrets.SFTP_USER }}
+          SFTP_PORT: ${{ steps.port.outputs.port }}
+          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
+        run: |
+          REMOTE="${BASE_PATH%/}/"
+          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE"
+          cat > /tmp/lftp_shared.txt <<LFTP_EOF
+          set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
+          open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
+          mirror --reverse --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE}
+          bye
+          LFTP_EOF
+          lftp -f /tmp/lftp_shared.txt
+
+      - name: Deploy shared web/ via SFTP (password)
+        if: steps.changes.outputs.has_changes == 'true' && steps.auth.outputs.method == 'password'
+        env:
+          SFTP_HOST: ${{ secrets.SFTP_HOST }}
+          SFTP_USER: ${{ secrets.SFTP_USER }}
+          SFTP_PASS: ${{ secrets.SFTP_PASSWORD }}
+          SFTP_PORT: ${{ steps.port.outputs.port }}
+          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
+        run: |
+          REMOTE="${BASE_PATH%/}/"
+          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE"
+          lftp -u "${SFTP_USER},${SFTP_PASS}" \
+            -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
+                mirror --reverse --verbose --only-newer --no-empty-dirs \
+                $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES \
+                web/ ${REMOTE}; bye" \
+            "sftp://${SFTP_HOST}:${SFTP_PORT}"
+
+      # -- Wipe SSH key from disk --
+      - name: Clean up SSH key
+        if: always() && steps.auth.outputs.method == 'key'
+        run: rm -f ~/.ssh/deploy_key
+
+      # ========================================================================
+      # Health check (post-deploy probe). Non-blocking: a 404 / non-2xx is
+      # logged but doesn't fail the run, since dev/beta channels may not have
+      # the health route mapped during early bring-up.
+      # ========================================================================
 
       - name: Health check
+        if: steps.changes.outputs.has_changes == 'true' && steps.target.outputs.channel == 'live'
         run: |
-          curl -fsSL "https://portal.millrdsdacambridge.uk/health" || echo "Health endpoint not responding; continuing"
+          curl -fsSL --max-time 15 "https://portal.millrdsdacambridge.uk/health" \
+            || echo "::warning::Health endpoint did not return 2xx — investigate after deploy"
+
+      # ========================================================================
+      # Summary
+      # ========================================================================
+
+      - name: Deployment summary
+        if: steps.changes.outputs.has_changes == 'true'
+        run: |
+          {
+            echo "### Deployment complete"
+            echo "- Branch: \`${{ github.ref_name }}\`"
+            echo "- Channel: \`${{ steps.target.outputs.channel }}\`"
+            echo "- Public dir: \`${{ steps.target.outputs.public_dir }}/\`"
+            echo "- Auth: ${{ steps.auth.outputs.method }}"
+            echo "- Commit: ${{ github.sha }}"
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Skip summary
+        if: steps.changes.outputs.has_changes == 'false'
+        run: |
+          echo "### No deployment needed" >> "$GITHUB_STEP_SUMMARY"
+          echo "No deployable files changed in \`web/\`." >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -323,11 +323,23 @@ jobs:
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
 
       # ========================================================================
-      # 2) Upload everything else in web/  ->  <base>/   (shared)
-      #    Excludes _auth_keys/, _uploads/, _backups/, _libraries/, and the
-      #    public_html_* trees (they go through step 1 above per branch).
-      #    Uses --no-delete so server-managed siblings (private_html,
-      #    public_html_landing, etc.) are preserved.
+      # 2) Upload everything else in web/  ->  <REMOTE_SHARED>/   (shared)
+      #
+      #    Excluded entirely (server-managed or per-branch — see envs above):
+      #      _auth_keys/  _uploads/  _backups/      ← server-managed contents
+      #      public_html/  public_html_dev/  public_html_beta/
+      #      public_html_landing/  public_html_redir/  private_html/
+      #
+      #    Uses --delete: the repo is the source of truth for the shared
+      #    dirs (core/, vendor/, sql/, _includes/, _functions/,
+      #    _libraries/dompdf/). Removing a file from the repo removes it
+      #    from the server on next deploy. The excludes ensure server-only
+      #    state (credentials, uploads, backups, other web roots) is
+      #    NEVER touched.
+      #
+      #    Before mirroring, mkd -p creates _auth_keys/, _uploads/,
+      #    _backups/ on the server if they don't exist yet — so the app
+      #    has writable target dirs without ever uploading their contents.
       # ========================================================================
 
       - name: Deploy shared web/ via SFTP (SSH key)
@@ -339,11 +351,14 @@ jobs:
           REMOTE:    ${{ steps.target.outputs.remote_shared }}
         run: |
           REMOTE_DIR="${REMOTE%/}/"
-          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE_DIR"
+          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions, _libraries/dompdf) -> $REMOTE_DIR"
           cat > /tmp/lftp_shared.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE_DIR}
+          mkdir -p -f ${REMOTE_DIR}_auth_keys
+          mkdir -p -f ${REMOTE_DIR}_uploads
+          mkdir -p -f ${REMOTE_DIR}_backups
+          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE_DIR}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_shared.txt
@@ -358,10 +373,13 @@ jobs:
           REMOTE:    ${{ steps.target.outputs.remote_shared }}
         run: |
           REMOTE_DIR="${REMOTE%/}/"
-          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE_DIR"
+          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions, _libraries/dompdf) -> $REMOTE_DIR"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-                mirror --reverse --verbose --only-newer --no-empty-dirs \
+                mkdir -p -f ${REMOTE_DIR}_auth_keys; \
+                mkdir -p -f ${REMOTE_DIR}_uploads; \
+                mkdir -p -f ${REMOTE_DIR}_backups; \
+                mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
                 $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES \
                 web/ ${REMOTE_DIR}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,12 +29,22 @@
 # ----------------
 #   SFTP_HOST          DreamHost SFTP server (e.g. iad1-shared-XXX.dreamhost.com)
 #   SFTP_USER          DreamHost SFTP user
-#   SFTP_BASE_PATH     Shared remote base (e.g. /home/USER/portal.millrdsdacambridge.uk)
+#   SFTP_LIVE_PATH     Absolute remote path for the main branch's public_html
+#                      (e.g. /home/USER/portal.millrdsdacambridge.uk/public_html)
+#   SFTP_BETA_PATH     Absolute remote path for the beta branch's public_html_beta
+#                      (e.g. /home/USER/portal.millrdsdacambridge.uk/public_html_beta)
+#   SFTP_DEV_PATH      Absolute remote path for the alpha branch's public_html_dev
+#                      (e.g. /home/USER/portal.millrdsdacambridge.uk/public_html_dev)
 #
 # Optional secrets:
 #   SFTP_PORT          Defaults to 22 if missing or non-numeric
 #   SFTP_KEY           SSH private key (preferred over password)
 #   SFTP_PASSWORD      Fallback password used only when SFTP_KEY is empty
+#
+# Shared assets (core/, vendor/, sql/, _includes/, _functions/, _libraries/dompdf/)
+# upload to the PARENT directory of whichever per-branch path applies — so all
+# three branches typically share one parent (the iHymns model). If you want full
+# isolation, point the three paths at different parents.
 #
 # VARIABLES
 # ---------
@@ -124,9 +134,16 @@ jobs:
           fetch-depth: 0
           ref: ${{ github.ref_name }}
 
-      # -- Resolve target channel + remote sub-path --
+      # -- Resolve target channel + remote paths --
+      # Each branch maps to its own full remote path secret (iHymns model).
+      # The shared upload target is dirname(per-branch path), so when all three
+      # share one parent the shared core/vendor/sql land in the same place.
       - name: Determine target channel
         id: target
+        env:
+          LIVE_PATH: ${{ secrets.SFTP_LIVE_PATH }}
+          BETA_PATH: ${{ secrets.SFTP_BETA_PATH }}
+          DEV_PATH:  ${{ secrets.SFTP_DEV_PATH }}
         run: |
           MANUAL_TARGET="${{ github.event.inputs.target }}"
           if [[ -n "$MANUAL_TARGET" ]]; then
@@ -138,22 +155,37 @@ jobs:
 
           case "$CHANNEL" in
             main)
-              echo "channel=live"               >> "$GITHUB_OUTPUT"
-              echo "public_dir=public_html"     >> "$GITHUB_OUTPUT"
+              REMOTE_PUBLIC="$LIVE_PATH"
+              echo "channel=live" >> "$GITHUB_OUTPUT"
               ;;
             beta)
-              echo "channel=beta"               >> "$GITHUB_OUTPUT"
-              echo "public_dir=public_html_beta">> "$GITHUB_OUTPUT"
+              REMOTE_PUBLIC="$BETA_PATH"
+              echo "channel=beta" >> "$GITHUB_OUTPUT"
               ;;
             alpha)
-              echo "channel=alpha"              >> "$GITHUB_OUTPUT"
-              echo "public_dir=public_html_dev" >> "$GITHUB_OUTPUT"
+              REMOTE_PUBLIC="$DEV_PATH"
+              echo "channel=alpha" >> "$GITHUB_OUTPUT"
               ;;
             *)
               echo "::error::Unknown channel: $CHANNEL"
               exit 1
               ;;
           esac
+
+          if [[ -z "$REMOTE_PUBLIC" ]]; then
+            echo "::error::SFTP path secret for channel '$CHANNEL' is empty (set SFTP_LIVE_PATH / SFTP_BETA_PATH / SFTP_DEV_PATH)"
+            exit 1
+          fi
+
+          # Strip trailing slash for tidy paths
+          REMOTE_PUBLIC="${REMOTE_PUBLIC%/}"
+          REMOTE_SHARED="$(dirname "$REMOTE_PUBLIC")"
+
+          echo "remote_public=$REMOTE_PUBLIC" >> "$GITHUB_OUTPUT"
+          echo "remote_shared=$REMOTE_SHARED" >> "$GITHUB_OUTPUT"
+
+          echo "  public path: $REMOTE_PUBLIC"
+          echo "  shared path: $REMOTE_SHARED"
 
       # -- Lint PHP (every file) — blocks deploy on syntax errors --
       - name: Lint PHP
@@ -260,15 +292,14 @@ jobs:
           SFTP_HOST: ${{ secrets.SFTP_HOST }}
           SFTP_USER: ${{ secrets.SFTP_USER }}
           SFTP_PORT: ${{ steps.port.outputs.port }}
-          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
-          PUBLIC_DIR: ${{ steps.target.outputs.public_dir }}
+          REMOTE:    ${{ steps.target.outputs.remote_public }}
         run: |
-          REMOTE="${BASE_PATH%/}/${PUBLIC_DIR}/"
-          echo "Deploying web/public_html/ -> $REMOTE"
+          REMOTE_DIR="${REMOTE%/}/"
+          echo "Deploying web/public_html/ -> $REMOTE_DIR"
           cat > /tmp/lftp_public.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES web/public_html/ ${REMOTE}
+          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES web/public_html/ ${REMOTE_DIR}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_public.txt
@@ -280,16 +311,15 @@ jobs:
           SFTP_USER: ${{ secrets.SFTP_USER }}
           SFTP_PASS: ${{ secrets.SFTP_PASSWORD }}
           SFTP_PORT: ${{ steps.port.outputs.port }}
-          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
-          PUBLIC_DIR: ${{ steps.target.outputs.public_dir }}
+          REMOTE:    ${{ steps.target.outputs.remote_public }}
         run: |
-          REMOTE="${BASE_PATH%/}/${PUBLIC_DIR}/"
-          echo "Deploying web/public_html/ -> $REMOTE"
+          REMOTE_DIR="${REMOTE%/}/"
+          echo "Deploying web/public_html/ -> $REMOTE_DIR"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
                 mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
                 $LFTP_EXCLUDES \
-                web/public_html/ ${REMOTE}; bye" \
+                web/public_html/ ${REMOTE_DIR}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
 
       # ========================================================================
@@ -306,14 +336,14 @@ jobs:
           SFTP_HOST: ${{ secrets.SFTP_HOST }}
           SFTP_USER: ${{ secrets.SFTP_USER }}
           SFTP_PORT: ${{ steps.port.outputs.port }}
-          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
+          REMOTE:    ${{ steps.target.outputs.remote_shared }}
         run: |
-          REMOTE="${BASE_PATH%/}/"
-          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE"
+          REMOTE_DIR="${REMOTE%/}/"
+          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE_DIR"
           cat > /tmp/lftp_shared.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE}
+          mirror --reverse --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE_DIR}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_shared.txt
@@ -325,15 +355,15 @@ jobs:
           SFTP_USER: ${{ secrets.SFTP_USER }}
           SFTP_PASS: ${{ secrets.SFTP_PASSWORD }}
           SFTP_PORT: ${{ steps.port.outputs.port }}
-          BASE_PATH: ${{ secrets.SFTP_BASE_PATH }}
+          REMOTE:    ${{ steps.target.outputs.remote_shared }}
         run: |
-          REMOTE="${BASE_PATH%/}/"
-          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE"
+          REMOTE_DIR="${REMOTE%/}/"
+          echo "Deploying shared web/ (core, vendor, sql, _includes, _functions) -> $REMOTE_DIR"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
                 mirror --reverse --verbose --only-newer --no-empty-dirs \
                 $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES \
-                web/ ${REMOTE}; bye" \
+                web/ ${REMOTE_DIR}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
 
       # -- Wipe SSH key from disk --

--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -1,0 +1,211 @@
+# =============================================================================
+# WebMS-Intra — PR Security Checks
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
+#
+# PURPOSE
+# -------
+# Defence-in-depth security gate that runs on every PR targeting alpha,
+# beta, or main. Each step is non-blocking (continues on failure) EXCEPT
+# the PHP lint step which is a hard gate. A summary comment is posted on
+# the PR with any findings.
+#
+# Checks performed:
+#   1. PHP lint (hard gate)                       — syntax error blocks merge
+#   2. Secrets scan (gitleaks)                    — high-confidence credentials
+#   3. SQL-injection heuristic grep                — $_GET/POST/REQUEST inside query strings
+#   4. XSS heuristic grep                          — echo of user input without htmlspecialchars
+#   5. CSRF heuristic grep                         — POST forms without csrf_token field
+#   6. Hardcoded-paths sanity check                — absolute /Users / /home paths in code
+#   7. Dangerous PHP functions                     — eval, exec, shell_exec, system, passthru
+#   8. Server-managed dirs touched?                — flag if PR touches _auth_keys/_uploads/_backups
+#
+# These are HEURISTICS — false positives are expected. Review the findings,
+# don't blindly fail the merge.
+# =============================================================================
+
+name: PR Security Checks
+
+on:
+  pull_request:
+    branches:
+      - main
+      - beta
+      - alpha
+
+permissions:
+  contents: read
+  pull-requests: write
+
+concurrency:
+  group: pr-security-${{ github.event.pull_request.number }}
+  cancel-in-progress: true
+
+jobs:
+  security:
+    name: Static security checks
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout PR head
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # =====================================================================
+      # 1) PHP lint — HARD GATE
+      # =====================================================================
+      - name: PHP lint (hard gate)
+        run: |
+          echo "::group::PHP syntax check"
+          find ./web -type f -name "*.php" \
+            -not -path "*/vendor/*" \
+            -not -path "*/_libraries/*" \
+            -print0 \
+          | xargs -0 -n1 -P4 php -l
+          echo "::endgroup::"
+
+      # =====================================================================
+      # 2) Secrets scan via gitleaks
+      # =====================================================================
+      - name: Scan for committed secrets (gitleaks)
+        id: gitleaks
+        continue-on-error: true
+        uses: gitleaks/gitleaks-action@v2
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITLEAKS_ENABLE_COMMENTS: 'true'
+          GITLEAKS_ENABLE_UPLOAD_ARTIFACT: 'true'
+
+      # =====================================================================
+      # 3-8) Custom heuristic grep checks
+      # =====================================================================
+      - name: Heuristic anti-pattern scan
+        id: heuristics
+        continue-on-error: true
+        run: |
+          set +e
+          REPORT=/tmp/security-report.md
+          : > "$REPORT"
+
+          # Files changed in this PR (vs. base)
+          BASE_SHA="${{ github.event.pull_request.base.sha }}"
+          HEAD_SHA="${{ github.sha }}"
+          CHANGED=$(git diff --name-only "$BASE_SHA" "$HEAD_SHA" -- 'web/**/*.php' 2>/dev/null || true)
+
+          if [[ -z "$CHANGED" ]]; then
+            echo "No PHP files changed in web/ — skipping heuristic checks"
+            echo "no_changes=true" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          echo "Scanning these PHP files changed in this PR:"
+          echo "$CHANGED"
+          echo
+
+          HITS=0
+          add_section() {
+            local title="$1"
+            local body="$2"
+            if [[ -n "$body" ]]; then
+              {
+                echo "### $title"
+                echo
+                echo '```'
+                echo "$body"
+                echo '```'
+                echo
+              } >> "$REPORT"
+              HITS=$((HITS + 1))
+            fi
+          }
+
+          # ---- 3) SQL injection heuristic --------------------------------
+          # mysqli->query or mysqli_query with string interpolation of $_GET/POST/REQUEST/COOKIE
+          SQLI=$(echo "$CHANGED" | xargs -r grep -nE '(mysqli_query|->query)\s*\(\s*[^,)]*\$_(GET|POST|REQUEST|COOKIE)' 2>/dev/null || true)
+          add_section "SQL injection candidates (mysqli->query / mysqli_query with \$_GET/POST/REQUEST/COOKIE)" "$SQLI"
+
+          # ---- 4) XSS heuristic -------------------------------------------
+          # echo or print of $_GET/POST/REQUEST/COOKIE without htmlspecialchars on the same line
+          XSS=$(echo "$CHANGED" | xargs -r grep -nE '(echo|print)\s+[^;]*\$_(GET|POST|REQUEST|COOKIE)' 2>/dev/null \
+              | grep -v 'htmlspecialchars\|htmlentities\|h(' || true)
+          add_section "Possible unescaped output of user input" "$XSS"
+
+          # ---- 5) CSRF heuristic -----------------------------------------
+          # form method=post lacking a csrf_token hidden input within 30 lines
+          CSRF_FILES=$(echo "$CHANGED" | xargs -r grep -lE '<form[^>]*method\s*=\s*["'\'']?post' 2>/dev/null || true)
+          CSRF_MISSING=""
+          for f in $CSRF_FILES; do
+            if ! grep -qE 'csrf_token|csrf\b' "$f"; then
+              CSRF_MISSING="${CSRF_MISSING}${f}: contains <form method=POST> but no csrf_token field found"$'\n'
+            fi
+          done
+          add_section "POST forms without an apparent CSRF token field" "$CSRF_MISSING"
+
+          # ---- 6) Hardcoded absolute paths -------------------------------
+          PATHS=$(echo "$CHANGED" | xargs -r grep -nE "(['\"])(/Users/|/home/[^/]+/|C:\\\\)" 2>/dev/null || true)
+          add_section "Hardcoded absolute filesystem paths (use PORTAL_ROOT / DIRECTORY_SEPARATOR instead)" "$PATHS"
+
+          # ---- 7) Dangerous PHP functions --------------------------------
+          DANGER=$(echo "$CHANGED" | xargs -r grep -nE '\b(eval|exec|shell_exec|system|passthru|popen|proc_open)\s*\(' 2>/dev/null || true)
+          add_section "Dangerous PHP functions (review carefully — only allow if user input is fully sanitised)" "$DANGER"
+
+          # ---- 8) Server-managed dirs touched? ---------------------------
+          SERVER_TOUCH=$(echo "$CHANGED" | grep -E '^web/(_auth_keys|_uploads|_backups)/' || true)
+          add_section "PR touches server-managed dirs (_auth_keys / _uploads / _backups) — confirm this is intentional" "$SERVER_TOUCH"
+
+          echo "hits=$HITS" >> "$GITHUB_OUTPUT"
+          echo "Total finding sections: $HITS"
+
+          if [[ -s "$REPORT" ]]; then
+            cat "$REPORT"
+          fi
+
+      # =====================================================================
+      # Post a single summary comment back to the PR
+      # =====================================================================
+      - name: Post findings to PR
+        if: always() && steps.heuristics.outputs.no_changes != 'true'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+          HITS: ${{ steps.heuristics.outputs.hits }}
+        run: |
+          REPORT=/tmp/security-report.md
+          COMMENT=/tmp/comment.md
+
+          {
+            echo "## PR Security Checks"
+            echo
+            if [[ "${HITS:-0}" == "0" ]]; then
+              echo "✅ No heuristic findings on the files changed in this PR."
+            else
+              echo "⚠️ **${HITS} category(ies) of findings** — these are heuristics, please review each:"
+              echo
+              cat "$REPORT"
+            fi
+            echo
+            echo "<sub>Generated by \`.github/workflows/pr-security.yml\`. These checks are non-blocking on the merge gate; PHP lint is the only hard gate. False positives are expected — confirm before acting.</sub>"
+          } > "$COMMENT"
+
+          gh pr comment "$PR_NUMBER" --repo "$REPO" --body-file "$COMMENT"
+
+      # =====================================================================
+      # Summary in the Actions UI
+      # =====================================================================
+      - name: Job summary
+        if: always()
+        run: |
+          {
+            echo "### PR Security Checks"
+            echo
+            echo "- PHP lint: passed (hard gate)"
+            echo "- gitleaks: see step output / artifact"
+            if [[ "${{ steps.heuristics.outputs.no_changes }}" == "true" ]]; then
+              echo "- Heuristic scans: no PHP files changed in web/ — skipped"
+            else
+              echo "- Heuristic scans: ${{ steps.heuristics.outputs.hits }} finding category(ies)"
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,131 @@
+# =============================================================================
+# WebMS-Intra — GitHub Releases
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
+#
+# PURPOSE
+# -------
+# When a `v*` tag is pushed, automatically create a GitHub Release. Release
+# notes are extracted from CHANGELOG.md (the section matching the tagged
+# version, regardless of (alpha)/(beta)/(main) branch suffix). Tags
+# containing -beta or -rc are marked as pre-releases.
+#
+# USAGE
+# -----
+#   git tag -a v0.5.0 -m "Phase 4 launch"
+#   git push origin v0.5.0
+# =============================================================================
+
+name: Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+concurrency:
+  group: release-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Create GitHub Release
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # Extract version from tag (strip leading 'v')
+      # -----------------------------------------------------------------------
+      - name: Extract version from tag
+        id: tag
+        run: |
+          TAG="${{ github.ref_name }}"
+          VERSION="${TAG#v}"
+          echo "tag=$TAG"         >> "$GITHUB_OUTPUT"
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "Tag: $TAG (version $VERSION)"
+
+      # -----------------------------------------------------------------------
+      # Pre-release detection (-beta or -rc in tag)
+      # -----------------------------------------------------------------------
+      - name: Detect pre-release
+        id: prerelease
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          if echo "$TAG" | grep -qiE '\-beta|\-rc'; then
+            echo "is_prerelease=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "is_prerelease=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      # -----------------------------------------------------------------------
+      # Pull the section for this version out of CHANGELOG.md.
+      # Concatenates all per-branch sections (alpha/beta/main) for this
+      # version into one release-notes blob.
+      # -----------------------------------------------------------------------
+      - name: Extract release notes from CHANGELOG.md
+        id: notes
+        run: |
+          VERSION="${{ steps.tag.outputs.version }}"
+          NOTES_FILE="/tmp/release_notes.md"
+
+          if [[ ! -f CHANGELOG.md ]]; then
+            echo "No CHANGELOG.md — using default notes"
+            echo "Release ${VERSION}" > "$NOTES_FILE"
+          else
+            python3 - "$VERSION" <<'PYEOF' > "$NOTES_FILE"
+            import re, sys
+            version = sys.argv[1]
+            with open('CHANGELOG.md', 'r') as f:
+                content = f.read()
+            # Capture every "## [VERSION] ..." section until the next "## ["
+            pattern = (
+                r'## \[' + re.escape(version) + r'\][^\n]*\n'
+                r'(?:(?!^## \[).*\n?)*'
+            )
+            matches = re.findall(pattern, content, flags=re.MULTILINE)
+            if matches:
+                print('\n'.join(m.rstrip() for m in matches))
+            else:
+                print(f'Release {version}')
+            PYEOF
+          fi
+
+          echo "----- release notes -----"
+          cat "$NOTES_FILE"
+          echo "-------------------------"
+          echo "notes_file=$NOTES_FILE" >> "$GITHUB_OUTPUT"
+
+      # -----------------------------------------------------------------------
+      # Create the GitHub Release
+      # -----------------------------------------------------------------------
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.tag.outputs.tag }}"
+          PRERELEASE="${{ steps.prerelease.outputs.is_prerelease }}"
+          NOTES_FILE="${{ steps.notes.outputs.notes_file }}"
+
+          GH_ARGS=(
+            "release" "create" "$TAG"
+            "--title" "WebMS-Intra $TAG"
+            "--notes-file" "$NOTES_FILE"
+          )
+
+          if [[ "$PRERELEASE" == "true" ]]; then
+            GH_ARGS+=("--prerelease")
+          fi
+
+          echo "Creating release: gh ${GH_ARGS[*]}"
+          gh "${GH_ARGS[@]}"
+          echo "Release $TAG created"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -1,0 +1,177 @@
+# =============================================================================
+# WebMS-Intra — Automatic Semantic Version Bump
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
+#
+# PURPOSE
+# -------
+# Auto-bumps the portal version on push to `alpha` or `beta`. Writes the
+# new value back to web/core/App.php and commits with [skip ci] so the
+# bump itself does not retrigger the workflow.
+#
+# BUMP RULES
+# ----------
+#   alpha push  ->  PATCH bump  (always)
+#   beta push   ->  Conventional Commits:
+#                     - "BREAKING CHANGE" or "!:" -> MAJOR (X.0.0)
+#                     - starts with "feat("       -> MINOR (x.Y.0)
+#                     - everything else           -> PATCH (x.y.Z)
+#
+# Production releases are NOT auto-bumped — tag manually via `git tag vX.Y.Z`
+# on main, which fires release.yml.
+#
+# SOURCE OF TRUTH
+# ---------------
+#   web/core/App.php  ->  private static string $version = 'X.Y.Z';
+# =============================================================================
+
+name: Version Bump
+
+on:
+  push:
+    branches:
+      - alpha
+      - beta
+    paths:
+      - 'web/**'
+      - 'CHANGELOG.md'
+
+concurrency:
+  group: version-bump-${{ github.ref_name }}
+  cancel-in-progress: true
+
+permissions:
+  contents: write
+
+jobs:
+  bump:
+    name: Bump version on ${{ github.ref_name }}
+    runs-on: ubuntu-latest
+
+    # Skip self-triggered bumps and changelog auto-commits
+    if: "!contains(github.event.head_commit.message, '[skip ci]')"
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          fetch-depth: 0
+
+      # -----------------------------------------------------------------------
+      # Read current $version from web/core/App.php
+      # -----------------------------------------------------------------------
+      - name: Read current version
+        id: current
+        run: |
+          VERSION_FILE="web/core/App.php"
+          # Matches: private static string $version = 'X.Y.Z';
+          CURRENT=$(grep -oP "static string \\\$version\s*=\s*'\K[^']+" "$VERSION_FILE")
+          if [[ -z "$CURRENT" ]]; then
+            echo "::error::Could not read version from $VERSION_FILE"
+            exit 1
+          fi
+          echo "current=$CURRENT" >> "$GITHUB_OUTPUT"
+          echo "Current version: $CURRENT"
+
+      # -----------------------------------------------------------------------
+      # Determine bump type from branch + commit message
+      # -----------------------------------------------------------------------
+      - name: Determine bump type
+        id: bump
+        run: |
+          BRANCH="${{ github.ref_name }}"
+          COMMIT_MSG="${{ github.event.head_commit.message }}"
+          echo "Branch:  $BRANCH"
+          echo "Commit:  $COMMIT_MSG"
+
+          if [[ "$BRANCH" == "alpha" ]]; then
+            # alpha always bumps patch
+            echo "type=patch" >> "$GITHUB_OUTPUT"
+            echo "Bump type: PATCH (alpha rule)"
+          else
+            # beta uses Conventional Commits
+            if echo "$COMMIT_MSG" | grep -qiE 'BREAKING CHANGE|!:'; then
+              echo "type=major" >> "$GITHUB_OUTPUT"
+              echo "Bump type: MAJOR (conventional commits)"
+            elif echo "$COMMIT_MSG" | grep -qE '^feat(\(|:)'; then
+              echo "type=minor" >> "$GITHUB_OUTPUT"
+              echo "Bump type: MINOR (conventional commits)"
+            else
+              echo "type=patch" >> "$GITHUB_OUTPUT"
+              echo "Bump type: PATCH (conventional commits)"
+            fi
+          fi
+
+      # -----------------------------------------------------------------------
+      # Compute the new SemVer string
+      # -----------------------------------------------------------------------
+      - name: Calculate new version
+        id: new_version
+        run: |
+          CURRENT="${{ steps.current.outputs.current }}"
+          BUMP_TYPE="${{ steps.bump.outputs.type }}"
+
+          # Strip any pre-release suffix (everything after the first hyphen)
+          BASE_VERSION=$(echo "$CURRENT" | sed 's/-.*//')
+          IFS='.' read -r MAJOR MINOR PATCH <<< "$BASE_VERSION"
+
+          case "$BUMP_TYPE" in
+            major) MAJOR=$((MAJOR + 1)); MINOR=0; PATCH=0 ;;
+            minor) MINOR=$((MINOR + 1)); PATCH=0 ;;
+            patch) PATCH=$((PATCH + 1)) ;;
+          esac
+
+          NEW="${MAJOR}.${MINOR}.${PATCH}"
+          echo "version=$NEW" >> "$GITHUB_OUTPUT"
+          echo "New version: $NEW (was $CURRENT)"
+
+      # -----------------------------------------------------------------------
+      # Write the bumped version into App.php
+      # -----------------------------------------------------------------------
+      - name: Update version in App.php
+        run: |
+          VERSION_FILE="web/core/App.php"
+          OLD="${{ steps.current.outputs.current }}"
+          NEW="${{ steps.new_version.outputs.version }}"
+
+          # Replace inside: private static string $version = 'X.Y.Z';
+          sed -i "s|\(static string \\\$version\s*=\s*'\)${OLD}'|\1${NEW}'|" "$VERSION_FILE"
+
+          # Verify
+          grep "static string \$version" "$VERSION_FILE"
+
+      # -----------------------------------------------------------------------
+      # Commit + push with [skip ci]; retry if changelog.yml lands first
+      # -----------------------------------------------------------------------
+      - name: Commit version bump
+        env:
+          BRANCH: ${{ github.ref_name }}
+        run: |
+          NEW="${{ steps.new_version.outputs.version }}"
+
+          git config user.name  "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add web/core/App.php
+          if git diff --cached --quiet; then
+            echo "No changes to commit"
+            exit 0
+          fi
+
+          git commit -m "chore: bump version to ${NEW} [skip ci]"
+
+          for attempt in 1 2 3 4 5; do
+            if git push origin "HEAD:${BRANCH}"; then
+              echo "Pushed on attempt $attempt"
+              exit 0
+            fi
+            echo "Push rejected on attempt $attempt — rebasing and retrying"
+            git fetch origin "${BRANCH}"
+            git rebase "origin/${BRANCH}"
+            sleep $((attempt * 2))
+          done
+
+          echo "::error::Failed to push version bump after 5 attempts"
+          exit 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,47 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+Automated sections are appended by `.github/workflows/changelog.yml` per push
+to `alpha`, `beta`, and `main` using the heading format
+`## [VERSION] - YYYY-MM-DD (branch)`.
+
+## [Unreleased] — CI/CD overhaul
+
+### Added — Multi-branch SFTP deploy + auto-versioning
+
+- **`alpha` / `beta` / `main` branch model** replacing the single-branch
+  FTP deploy. `main` → `public_html/`, `beta` → `public_html_beta/`,
+  `alpha` → `public_html_dev/`. Shared `core/`, `vendor/`, `sql/` deploy to
+  the same remote base from every branch.
+- **`.github/workflows/deploy.yml`** rewritten to SFTP (lftp),
+  SSH-key-preferred with password fallback, per-branch target resolution,
+  change detection, `[deploy all]` / `[skip ci]` flags, and a
+  `vars.SFTP_ENABLED` kill switch. New secrets: `SFTP_HOST`, `SFTP_USER`,
+  `SFTP_BASE_PATH`, plus `SFTP_KEY` and/or `SFTP_PASSWORD`.
+- **`.github/workflows/version-bump.yml`** auto-bumps `web/core/App.php`
+  `$version` on push: alpha = PATCH always; beta = Conventional Commits.
+- **`.github/workflows/changelog.yml`** auto-appends CHANGELOG entries from
+  commit messages since the last `v*` tag.
+- **`.github/workflows/release.yml`** creates a GitHub Release on `v*` tag,
+  extracting notes from CHANGELOG.md. Tags with `-beta` / `-rc` are pre-release.
+- **`.github/workflows/auto-merge-alpha.yml`** enables GitHub auto-merge on
+  PRs whose base is `alpha` and dispatches `deploy.yml` once merged.
+
+### Added — dompdf at build time
+
+- **`tools/download-dompdf.sh`** — idempotent fetch of pinned dompdf v3.1.5.
+- `deploy.yml` runs the fetch script before SFTP so dompdf rides along in
+  the shared upload; manual server-side install is no longer needed.
+
+### Fixed
+
+- **`web/core/bootstrap.php`** — environment detection now matches the new
+  `public_html_beta/` directory name (previously only `beta_html`); ordering
+  documented to avoid the `public_html` substring trap that would
+  misclassify dev/beta as prod.
+
+---
+
 ## [0.8.2] - 2026-03-08
 
 ### Added — Installation & Upgrade System (Issue #84)

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -143,15 +143,34 @@ ssh -i ~/.ssh/webms_intra_deploy -p 22 <SFTP_USER>@<SFTP_HOST> 'pwd; ls'
 
 ### 3. Set the GitHub repo secrets
 
+| Secret           | Required | Example value                                                              |
+| ---------------- | -------- | -------------------------------------------------------------------------- |
+| `SFTP_HOST`      | yes      | `iad1-shared-XX-XX.dreamhost.com`                                          |
+| `SFTP_USER`      | yes      | `dh_abcd1234`                                                              |
+| `SFTP_LIVE_PATH` | yes      | `/home/dh_abcd1234/portal.millrdsdacambridge.uk/public_html`               |
+| `SFTP_BETA_PATH` | yes      | `/home/dh_abcd1234/portal.millrdsdacambridge.uk/public_html_beta`          |
+| `SFTP_DEV_PATH`  | yes      | `/home/dh_abcd1234/portal.millrdsdacambridge.uk/public_html_dev`           |
+| `SFTP_PORT`      | no       | `22` (default if omitted)                                                  |
+| `SFTP_KEY`       | one of   | full contents of `~/.ssh/webms_intra_deploy` (private key, preferred)      |
+| `SFTP_PASSWORD`  | one of   | DreamHost SFTP password (fallback when `SFTP_KEY` is unset)                |
+
 ```bash
 gh secret set SFTP_HOST      --body 'iad1-shared-XX-XX.dreamhost.com'
 gh secret set SFTP_USER      --body 'dh_abcd1234'
-gh secret set SFTP_BASE_PATH --body '/home/dh_abcd1234/portal.millrdsdacambridge.uk'
+gh secret set SFTP_LIVE_PATH --body '/home/dh_abcd1234/portal.millrdsdacambridge.uk/public_html'
+gh secret set SFTP_BETA_PATH --body '/home/dh_abcd1234/portal.millrdsdacambridge.uk/public_html_beta'
+gh secret set SFTP_DEV_PATH  --body '/home/dh_abcd1234/portal.millrdsdacambridge.uk/public_html_dev'
 gh secret set SFTP_KEY       < ~/.ssh/webms_intra_deploy
 # optional:
 gh secret set SFTP_PORT      --body '22'
-gh secret set SFTP_PASSWORD  --body '<fallback password>'
+gh secret set SFTP_PASSWORD                       # prompts (avoids password in shell history)
 ```
+
+**Shared-base note.** The shared `core/`, `vendor/`, `sql/` etc. upload to
+`dirname()` of whichever per-branch path applies. When all three paths share
+one parent (the default — recommended for the WebMS-Intra single-site setup),
+all branches' shared code lands in the same place. Point them at different
+parents if you want full isolation.
 
 ### 4. Enable the kill switch
 

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -42,45 +42,165 @@ with `web/`.
 
 ## Deployment Model
 
-WebMS Intra uses a **single-branch deployment model**. Only the `web/` directory
-is synced to the server via FTP.
+WebMS Intra uses a **three-branch SFTP deployment model** modelled on the
+iHymns pipeline. Only `web/` is synced; the active branch decides which
+public web root the upload lands in.
 
-| Environment | Branch / Trigger | What Deploys | URL |
-| ----------- | --------------- | ------------ | --- |
-| **Dev** | Every push to `main` | `web/` → server root | dev subdomain |
-| **Production** | Tagged release (`v*`) | `web/` → server root | main domain |
+| Branch  | Channel    | Public dir on server  | Auto-bump rule           |
+| ------- | ---------- | --------------------- | ------------------------ |
+| `alpha` | alpha/dev  | `public_html_dev/`    | PATCH (always)           |
+| `beta`  | beta       | `public_html_beta/`   | Conventional Commits     |
+| `main`  | production | `public_html/`        | none — tag `v*` manually |
 
-### How It Works
+### Remote layout (shared base)
 
+All three branches share **one** remote base directory on DreamHost. Per
+branch, `web/public_html/` mirrors to a different sibling; everything else
+inside `web/` (`core/`, `vendor/`, `sql/`, `_includes/`, `_functions/`) goes
+to the shared base from every branch — **last push wins for shared code**.
+
+```text
+SFTP_BASE_PATH/
+├── core/                  ← from web/core/         (all branches)
+├── vendor/                ← from web/vendor/       (all branches)
+├── sql/                   ← from web/sql/          (all branches)
+├── _auth_keys/            ← server-managed (excluded from sync)
+├── _libraries/dompdf/     ← fetched at deploy time by tools/download-dompdf.sh
+├── _uploads/              ← server-managed (excluded from sync)
+├── _backups/              ← server-managed (excluded from sync)
+├── public_html/           ← from web/public_html/  (main branch)
+├── public_html_beta/      ← from web/public_html/  (beta branch)
+└── public_html_dev/       ← from web/public_html/  (alpha branch)
 ```
-commit ──► push to main ──► GitHub Actions ──► FTP sync web/ to server
-                                                  (automatic, every push)
 
-git tag v0.3.0 ──► push tag ──► GitHub Actions ──► FTP sync web/ to server
-                                                      (production release)
-```
+### Workflows
 
-Server-managed directories are **excluded** from sync:
-`_auth_keys/`, `_uploads/`, `_backups/`, `_libraries/`
+- `deploy.yml` — push to alpha/beta/main, or manual dispatch. PHP-lint, fetch
+  pinned dompdf, SFTP via lftp (SSH key first, password fallback).
+- `version-bump.yml` — push to alpha or beta. Alpha always bumps PATCH; beta
+  uses Conventional Commits (BREAKING/`!:` → major, `feat(` → minor, else patch).
+- `changelog.yml` — push to alpha/beta/main. Appends per-branch sections to
+  `CHANGELOG.md` from commit messages since the last `v*` tag.
+- `release.yml` — push of any `v*` tag. Creates a GitHub Release from
+  `CHANGELOG.md`; tags containing `-beta` or `-rc` are marked pre-release.
+- `auto-merge-alpha.yml` — PR opened or synchronised against `alpha`. Enables
+  GitHub native auto-merge and dispatches `deploy.yml` after merge.
 
 ### Day-to-Day Workflow
 
-1. Work directly on `main` (or short-lived feature branches merged into `main`)
-2. Push to `main` -- dev site updates automatically
-3. Test on the dev site (restricted to authorised users via Gatekeeper)
-4. When ready for production, tag a release:
+1. Branch off `alpha` for new work.
+2. Open a PR against `alpha` → auto-merge fires once checks pass.
+3. When `alpha` is stable, open a PR from `alpha` → `beta` for wider testing.
+4. When `beta` is stable, open a PR from `beta` → `main` for production.
+5. Tag a release on `main`:
 
 ```bash
-git tag v0.3.0
-git push origin v0.3.0
+git tag -a v0.9.0 -m "Release notes summary"
+git push origin v0.9.0   # fires release.yml
 ```
-
-5. GitHub Actions deploys the tagged code to the server
 
 ### Manual Deploy Override
 
-The workflow also supports manual dispatch via the GitHub Actions UI:
-**Actions > Deploy to DreamHost > Run workflow** -- choose `dev` or `live`.
+`Actions → Deploy via SFTP → Run workflow` accepts an override target
+(`alpha` / `beta` / `main`) that bypasses the branch-based mapping for a
+one-off deploy.
+
+### Commit flags
+
+- `[skip ci]` — skip every workflow on this commit
+- `[deploy all]` — force a full re-sync regardless of change detection
+
+---
+
+## CI/CD Secrets Setup — Step-by-Step
+
+Configure these once when bringing a fresh repo (or a new server) online.
+
+### 1. Generate the SSH deploy keypair (preferred over password)
+
+On your local machine:
+
+```bash
+ssh-keygen -t ed25519 -C "webms-intra-deploy@github" \
+  -f ~/.ssh/webms_intra_deploy -N ''
+```
+
+Produces:
+
+- `~/.ssh/webms_intra_deploy`     — private key (goes into GitHub secret `SFTP_KEY`)
+- `~/.ssh/webms_intra_deploy.pub` — public key (goes onto the DreamHost server)
+
+### 2. Authorise the public key on DreamHost
+
+DreamHost panel → **Users → SFTP Users → [deploy user] → Manage Users**,
+paste the contents of `~/.ssh/webms_intra_deploy.pub` into **Authorized Keys**.
+
+Verify from your laptop:
+
+```bash
+ssh -i ~/.ssh/webms_intra_deploy -p 22 <SFTP_USER>@<SFTP_HOST> 'pwd; ls'
+```
+
+### 3. Set the GitHub repo secrets
+
+```bash
+gh secret set SFTP_HOST      --body 'iad1-shared-XX-XX.dreamhost.com'
+gh secret set SFTP_USER      --body 'dh_abcd1234'
+gh secret set SFTP_BASE_PATH --body '/home/dh_abcd1234/portal.millrdsdacambridge.uk'
+gh secret set SFTP_KEY       < ~/.ssh/webms_intra_deploy
+# optional:
+gh secret set SFTP_PORT      --body '22'
+gh secret set SFTP_PASSWORD  --body '<fallback password>'
+```
+
+### 4. Enable the kill switch
+
+```bash
+gh variable set SFTP_ENABLED --body 'true'
+```
+
+While `SFTP_ENABLED != 'true'`, all deploy runs no-op.
+
+### 5. Repo settings (one-time UI clicks)
+
+1. **Settings → General → Pull Requests → Allow auto-merge** = ON.
+2. **Settings → Branches → Add rule** on `alpha`, `beta`, and `main`:
+   - Disable allow-deletions
+   - Disable allow-force-pushes
+   - (Recommended) Require status check on `main`
+
+### 6. Verify
+
+```bash
+gh workflow run deploy.yml --ref main
+gh run watch
+```
+
+### Rotating the SSH key
+
+1. Generate a new keypair
+2. Add the new public key on DreamHost (don't remove the old yet)
+3. Update `SFTP_KEY` in GitHub
+4. Trigger a manual deploy to confirm
+5. Remove the old public key from DreamHost
+
+---
+
+## dompdf at deploy time
+
+Expense PDF generation depends on dompdf in `_libraries/dompdf/`. The library
+is **not** committed to this repo — `tools/download-dompdf.sh` fetches the
+pinned version at deploy time and the lftp mirror uploads it as part of the
+shared `web/` sync. Update the pinned version by editing `DOMPDF_VERSION` in
+that script.
+
+For local development:
+
+```bash
+bash tools/download-dompdf.sh
+```
+
+The script is idempotent — re-runs skip if the right version is already present.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -140,13 +140,34 @@ php -S localhost:8080 -t public_html
 
 ## Deployment
 
-CI/CD via GitHub Actions syncs the `web/` directory to DreamHost via FTP.
+CI/CD via GitHub Actions syncs `web/` to DreamHost over **SFTP** (SSH key
+preferred, password fallback) on a three-branch model:
 
-- **Push to `main`** deploys automatically to the server
-- **Tagged `v*`** also deploys (production releases)
-- **Manual dispatch** available via GitHub Actions UI
+| Branch  | Channel    | Public dir on server  | Auto-bump rule           |
+| ------- | ---------- | --------------------- | ------------------------ |
+| `alpha` | alpha/dev  | `public_html_dev/`    | PATCH (always)           |
+| `beta`  | beta       | `public_html_beta/`   | Conventional Commits     |
+| `main`  | production | `public_html/`        | none — tag `v*` manually |
 
-Server-managed directories (`_auth_keys/`, `_uploads/`, `_backups/`, `_libraries/`) are excluded from FTP sync.
+Everything else inside `web/` (`core/`, `vendor/`, `sql/`) deploys to the
+shared remote base from every branch.
+
+Workflows in `.github/workflows/`:
+
+- `deploy.yml` — SFTP sync; key-first / password-fallback auth
+- `version-bump.yml` — updates `web/core/App.php` on alpha/beta pushes
+- `changelog.yml` — appends commit-message entries to CHANGELOG.md
+- `release.yml` — creates a GitHub Release on `v*` tag push
+- `auto-merge-alpha.yml` — enables auto-merge on PRs whose base is `alpha`
+
+dompdf is fetched at deploy time by `tools/download-dompdf.sh` (pinned
+version) and uploaded as part of the shared sync. Other server-managed
+directories (`_auth_keys/`, `_uploads/`, `_backups/`) stay on the server and
+are excluded from upload.
+
+Required repo configuration (one-time): see **DEV_NOTES.md → CI/CD Secrets
+Setup** for the step-by-step guide (SSH keypair, GitHub secrets, kill switch,
+branch protection).
 
 ---
 

--- a/tools/download-dompdf.sh
+++ b/tools/download-dompdf.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+# =============================================================================
+# WebMS-Intra — Download pinned dompdf release into web/_libraries/dompdf/
+#
+# Copyright (c) 2026 MWBM Partners Ltd. All rights reserved.
+# Proprietary. Unauthorised copying, modification or distribution prohibited.
+#
+# PURPOSE
+# -------
+# Fetches a pinned dompdf release tarball from GitHub and extracts it into
+# web/_libraries/dompdf/. Used by:
+#   - .github/workflows/deploy.yml (CI; downloads before SFTP upload)
+#   - local devs who need expense PDF rendering
+#
+# This script is idempotent: if the right version is already present,
+# it exits without re-downloading.
+#
+# To upgrade dompdf, change DOMPDF_VERSION below and commit.
+# Release index: https://github.com/dompdf/dompdf/releases
+# =============================================================================
+set -euo pipefail
+
+DOMPDF_VERSION="${DOMPDF_VERSION:-v3.1.5}"
+
+# Resolve absolute path of this script's parent dir, then jump to repo root
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEST_DIR="$REPO_ROOT/web/_libraries/dompdf"
+VERSION_FILE="$DEST_DIR/VERSION.txt"
+
+# -- Skip if already at the right version --
+if [[ -f "$VERSION_FILE" ]] && [[ "$(cat "$VERSION_FILE")" == "$DOMPDF_VERSION" ]]; then
+    echo "dompdf $DOMPDF_VERSION already present at $DEST_DIR — skipping"
+    exit 0
+fi
+
+echo "Fetching dompdf $DOMPDF_VERSION into $DEST_DIR"
+
+# -- Clean any previous version --
+rm -rf "$DEST_DIR"
+mkdir -p "$DEST_DIR"
+
+# -- Fetch + extract the source tarball --
+TARBALL_URL="https://github.com/dompdf/dompdf/archive/refs/tags/${DOMPDF_VERSION}.tar.gz"
+TMP_TARBALL="$(mktemp -t dompdf.XXXXXX.tar.gz)"
+
+trap 'rm -f "$TMP_TARBALL"' EXIT
+
+if ! curl -fsSL --max-time 120 -o "$TMP_TARBALL" "$TARBALL_URL"; then
+    echo "ERROR: failed to download $TARBALL_URL" >&2
+    exit 1
+fi
+
+# Strip the top-level "dompdf-x.y.z/" directory from the tarball as we extract
+tar -xzf "$TMP_TARBALL" --strip-components=1 -C "$DEST_DIR"
+
+# -- Pin marker (used by the idempotency check above) --
+echo "$DOMPDF_VERSION" > "$VERSION_FILE"
+
+# -- Sanity check: the loader file we depend on exists --
+if [[ ! -f "$DEST_DIR/src/Autoloader.php" ]] && [[ ! -f "$DEST_DIR/lib/Autoloader.php" ]]; then
+    echo "WARNING: expected autoloader not found in extracted dompdf — verify the tarball layout for $DOMPDF_VERSION" >&2
+fi
+
+echo "dompdf $DOMPDF_VERSION installed at $DEST_DIR"

--- a/web/core/bootstrap.php
+++ b/web/core/bootstrap.php
@@ -56,10 +56,13 @@ define('PORTAL_APPS',   PORTAL_ROOT . DIRECTORY_SEPARATOR . 'public_html');
 define('PORTAL_VENDOR', PORTAL_ROOT . DIRECTORY_SEPARATOR . 'vendor');
 define('PORTAL_SQL',    PORTAL_ROOT . DIRECTORY_SEPARATOR . 'sql');
 
-// 🌍 Determine runtime environment flag (dev | prod)
+// 🌍 Determine runtime environment flag (dev | beta | prod)
 // Priority: 1) PORTAL_ENV env var  2) directory name detection  3) default 'dev'
-// Primary directories: public_html (prod), public_html_dev (dev)
-// Legacy alpha_html / beta_html checks kept for backwards compatibility
+// Primary directories: public_html (prod), public_html_beta (beta), public_html_dev (dev)
+// Legacy alpha_html / beta_html checks kept for backwards compatibility.
+// IMPORTANT: order matters — public_html_dev / public_html_beta must be tested
+// BEFORE public_html, since str_contains() would otherwise match "public_html"
+// inside the beta/dev directory names and misclassify them as prod.
 // See: https://www.php.net/manual/en/function.getenv.php
 $env = getenv('PORTAL_ENV');
 if ($env === false || $env === '') {
@@ -67,7 +70,7 @@ if ($env === false || $env === '') {
     $docRoot = $_SERVER['DOCUMENT_ROOT'] ?? '';
     if (str_contains($docRoot, 'public_html_dev') === true || str_contains($docRoot, 'alpha_html') === true) {
         $env = 'dev';
-    } elseif (str_contains($docRoot, 'beta_html') === true) {
+    } elseif (str_contains($docRoot, 'public_html_beta') === true || str_contains($docRoot, 'beta_html') === true) {
         $env = 'beta';
     } elseif (str_contains($docRoot, 'public_html') === true) {
         $env = 'prod';


### PR DESCRIPTION
## Summary

Replaces the existing single-branch FTP deploy with a three-branch SFTP pipeline modelled on the iHymns project, and adds automation around versioning, changelogs, and GitHub Releases.

- **Three branches → three web roots** on a shared remote base: `main → public_html/`, `beta → public_html_beta/`, `alpha → public_html_dev/`. Shared `core/`, `vendor/`, `sql/` deploy from every branch.
- **SFTP via lftp** with SSH-key auth (password fallback). New secrets: `SFTP_HOST`, `SFTP_USER`, `SFTP_BASE_PATH`, `SFTP_KEY` and/or `SFTP_PASSWORD`. Replaces `DH_HOST` / `DH_USER` / `DH_PASS`.
- **Auto-versioning** via `version-bump.yml`: alpha = always PATCH, beta = Conventional Commits.
- **Auto-changelog** via `changelog.yml`: per-branch sections appended to `CHANGELOG.md` since the last `v*` tag.
- **Auto-release** via `release.yml`: GitHub Release created from `CHANGELOG.md` on any `v*` tag push.
- **Auto-merge on alpha** via `auto-merge-alpha.yml`: PRs against `alpha` use GitHub native auto-merge once checks pass.
- **dompdf at deploy time** via `tools/download-dompdf.sh` (pinned v3.1.5) — no more manual server upload.
- **Fix:** `web/core/bootstrap.php` env detection now recognises `public_html_beta/` (was `beta_html` only) with the substring-order caveat documented.

`vars.SFTP_ENABLED` is the kill switch — workflows no-op until it is set to `'true'`.

## Files

```
.github/workflows/auto-merge-alpha.yml  (new)
.github/workflows/changelog.yml         (new)
.github/workflows/deploy.yml            (rewritten)
.github/workflows/release.yml           (new)
.github/workflows/version-bump.yml      (new)
tools/download-dompdf.sh                (new, +x)
web/core/bootstrap.php                  (beta channel fix)
CHANGELOG.md / DEV_NOTES.md / README.md (docs)
```

The web-based installation wizard already on `main` at `web/install/` is unchanged — this PR deliberately does not touch it.

## Test plan

Configuration steps (one-time, before any branch push will deploy):

- [ ] **Enable Allow auto-merge** in repo settings (Settings → General → Pull Requests)
- [ ] **Generate an SSH deploy keypair** locally: `ssh-keygen -t ed25519 -C webms-intra-deploy -f ~/.ssh/webms_intra_deploy -N ''`
- [ ] **Add the public key to DreamHost** (panel → SFTP Users → Manage Users → Authorized Keys)
- [ ] **Set repo secrets**: `SFTP_HOST`, `SFTP_USER`, `SFTP_BASE_PATH`, `SFTP_KEY` (paste private key), optional `SFTP_PORT` / `SFTP_PASSWORD`
- [ ] **Set repo variable** `SFTP_ENABLED=true`
- [ ] **Create branches** `beta` and `alpha` (off `main` once this PR merges)
- [ ] **Branch protection** on `main`, `beta`, `alpha`: disable allow-deletions and allow-force-pushes

Smoke tests once the above is in place:

- [ ] Trigger `gh workflow run deploy.yml --ref main` and confirm a green run that touches `public_html/`
- [ ] Push a no-op commit to `alpha` and confirm: version-bump.yml bumps PATCH, changelog.yml appends an entry, deploy.yml lands in `public_html_dev/`
- [ ] Open a PR against `alpha` and confirm auto-merge.yml enables auto-merge
- [ ] Tag `v0.9.0-beta.1` on `beta` and confirm release.yml creates a pre-release

🤖 Generated with [Claude Code](https://claude.com/claude-code)