### PR TITLE
fix(ci): repo-config-audit no longer fails on missing admin scope

### DIFF
--- a/.github/workflows/repo-config-audit.yml
+++ b/.github/workflows/repo-config-audit.yml
@@ -34,8 +34,15 @@ on:
 
 permissions:
   contents: read
-  administration: read    # read rulesets + branch protection
   pull-requests: write    # post a comment on PRs when run from one
+  # NOTE: `administration: read` would let GITHUB_TOKEN read rulesets and
+  # branch-protection, but it's NOT a valid `permissions:` key in
+  # workflow files (it's exposed only to GitHub Apps and fine-grained
+  # PATs). To run the FULL audit in CI, set a repo secret
+  # RULESET_AUDIT_TOKEN to a fine-grained PAT with `Administration: Read`
+  # on this repo. Without it, the audit gracefully degrades to a
+  # no-op summary (the local `python3 tools/audit-required-checks.py`
+  # still works for devs, since their `gh` CLI is authenticated as them).
 
 concurrency:
   group: repo-config-audit-${{ github.ref }}
@@ -58,7 +65,10 @@ jobs:
       - name: Run audit
         id: audit
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # Prefer a PAT with Administration:Read when configured; otherwise
+          # fall back to GITHUB_TOKEN, which causes the script to run in
+          # degraded mode (no rulesets / branch-protection visibility).
+          GH_TOKEN: ${{ secrets.RULESET_AUDIT_TOKEN != '' && secrets.RULESET_AUDIT_TOKEN || secrets.GITHUB_TOKEN }}
           GITHUB_REPOSITORY: ${{ github.repository }}
         run: |
           set +e
@@ -66,7 +76,7 @@ jobs:
           EXIT=${PIPESTATUS[0]}
           echo "exit_code=$EXIT" >> "$GITHUB_OUTPUT"
           if [ "$EXIT" -eq 2 ]; then
-            echo "::error::Audit could not query GitHub API — check workflow has admin:read permission."
+            echo "::error::Audit hit an unexpected error talking to GitHub. Check tools/audit-required-checks.py."
             exit 2
           fi
           exit $EXIT

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -286,7 +286,32 @@ Run the audit locally:
 python3 tools/audit-required-checks.py
 ```
 
-Exits 0 on clean, 1 on orphans, 2 on API failure.
+Exits 0 on clean (or degraded mode), 1 on orphans, 2 on unexpected error.
+
+### Optional: enabling the full audit in CI
+
+The default `GITHUB_TOKEN` in workflow runs **cannot read rulesets or
+branch protection** — the GitHub Actions permissions model has no
+`administration: read` key. Without that, the CI audit runs in
+**degraded mode** (it can still emit a useful summary based on
+workflow-file inspection, but can't catch orphans).
+
+To unlock the full CI audit, create a **fine-grained personal access
+token** scoped to this repo with **Administration: Read** permission,
+then store it as a repo secret named `RULESET_AUDIT_TOKEN`:
+
+1. GitHub → your account → Settings → Developer settings → Personal
+   access tokens → Fine-grained tokens → Generate new token
+2. Repository access: select **only** `WebMS-Intra` (least privilege)
+3. Repository permissions: **Administration: Read** (rest stay None)
+4. Generate and copy the token
+5. In the repo: Settings → Secrets and variables → Actions →
+   New repository secret → name `RULESET_AUDIT_TOKEN`, value =
+   the PAT
+
+The workflow auto-detects the secret and uses it when present; absent
+secret = degraded mode, no failure. Local `gh` runs are unaffected
+since you're already authenticated as an admin.
 
 ### Branch protection + rulesets are additive
 

--- a/tools/audit-required-checks.py
+++ b/tools/audit-required-checks.py
@@ -22,12 +22,21 @@ Run in CI:
 
 Exit codes:
     0  no orphans, repo config is consistent
+       (also returned in "degraded" mode when GitHub returns 403/404 for
+        rulesets/branch-protection because the caller lacks admin scope —
+        a warning is printed but the run still passes so CI doesn't fail
+        purely on a permission gap)
     1  one or more orphans found (printed to stdout)
-    2  failed to query GitHub (auth / permission issue)
+    2  unexpected error talking to GitHub (network / json parse / other)
 
-Requires:
-    - `gh` CLI authenticated with admin:read scope on the target repo
-      (rulesets API requires admin; branch-protection requires repo)
+Auth:
+    The `gh` CLI must be authenticated. For full audit (rulesets +
+    branch protection), the calling token needs Administration:Read on
+    the target repo:
+      - Locally: `gh auth login` as you (you're admin) → works
+      - In CI: set repo secret RULESET_AUDIT_TOKEN to a fine-grained PAT
+        with Administration:Read scope and pass it as GH_TOKEN. The
+        default GITHUB_TOKEN does NOT have admin scope.
 """
 
 from __future__ import annotations
@@ -41,8 +50,16 @@ import sys
 from typing import Iterable
 
 
+class GhPermissionError(Exception):
+    """Raised when gh api returns a 403/404 — caller likely lacks admin scope."""
+
+
 def gh(args: list[str]) -> dict | list:
-    """Invoke `gh api` with the given arg list and parse JSON output."""
+    """Invoke `gh api` with the given arg list and parse JSON output.
+
+    Raises GhPermissionError for 403/404 (likely missing admin scope) so the
+    caller can degrade gracefully. SystemExit(2) for any other failure.
+    """
     res = subprocess.run(
         ["gh", "api"] + args,
         capture_output=True,
@@ -50,6 +67,11 @@ def gh(args: list[str]) -> dict | list:
         check=False,
     )
     if res.returncode != 0:
+        # gh prints HTTP status hints to stderr; 403 / 404 / "Resource not
+        # accessible by integration" all mean we lack the scope to query.
+        err = (res.stderr or "").lower()
+        if any(s in err for s in ("403", "404", "resource not accessible", "must have admin", "not found")):
+            raise GhPermissionError(res.stderr.strip())
         sys.stderr.write(f"gh api {args} failed: {res.stderr}\n")
         sys.exit(2)
     if not res.stdout.strip():
@@ -57,14 +79,31 @@ def gh(args: list[str]) -> dict | list:
     return json.loads(res.stdout)
 
 
-def collect_required_checks(repo: str) -> dict[str, list[str]]:
-    """Return {check_name: [source, ...]} aggregated across rulesets + branch protection."""
-    required: dict[str, list[str]] = {}
+def collect_required_checks(repo: str) -> tuple[dict[str, list[str]], list[str]]:
+    """Aggregate required checks across rulesets + branch protection.
 
-    rulesets = gh([f"repos/{repo}/rulesets"])
+    Returns (required, degradations) where:
+      required     — {check_name: [source, ...]}
+      degradations — list of human-readable strings for sources we could
+                     not query due to missing scope; empty if all good
+    """
+    required: dict[str, list[str]] = {}
+    degradations: list[str] = []
+
+    # --- Rulesets ---
+    try:
+        rulesets = gh([f"repos/{repo}/rulesets"])
+    except GhPermissionError as e:
+        degradations.append(f"rulesets API not accessible (need Administration:Read): {e}")
+        rulesets = []
+
     if isinstance(rulesets, list):
         for rs in rulesets:
-            detail = gh([f"repos/{repo}/rulesets/{rs['id']}"])
+            try:
+                detail = gh([f"repos/{repo}/rulesets/{rs['id']}"])
+            except GhPermissionError as e:
+                degradations.append(f"ruleset {rs.get('id')} detail not accessible: {e}")
+                continue
             for rule in detail.get("rules", []) or []:
                 if rule.get("type") != "required_status_checks":
                     continue
@@ -74,10 +113,15 @@ def collect_required_checks(repo: str) -> dict[str, list[str]]:
                     if ctx:
                         required.setdefault(ctx, []).append(f"ruleset:{detail['name']}")
 
+    # --- Branch protection ---
     for branch in ("main", "beta", "alpha"):
         try:
             prot = gh([f"repos/{repo}/branches/{branch}/protection"])
-        except SystemExit:
+        except GhPermissionError as e:
+            degradations.append(f"branch-protection on {branch} not accessible: {e}")
+            continue
+        # 404 from a branch with no protection rule = empty dict
+        if not isinstance(prot, dict):
             continue
         rsc = prot.get("required_status_checks")
         if not rsc:
@@ -89,7 +133,7 @@ def collect_required_checks(repo: str) -> dict[str, list[str]]:
             if ctx:
                 required.setdefault(ctx, []).append(f"branch-protection:{branch}")
 
-    return required
+    return required, degradations
 
 
 def collect_emitted_checks(workflows_dir: str = ".github/workflows") -> dict[str, str]:
@@ -152,8 +196,17 @@ def main(argv: Iterable[str] | None = None) -> int:
     print(f"Workflows dir: {args.workflows_dir}")
     print()
 
-    required = collect_required_checks(args.repo)
+    required, degradations = collect_required_checks(args.repo)
     emitted = collect_emitted_checks(args.workflows_dir)
+
+    if degradations:
+        print("WARNING — running in DEGRADED mode (some rule sources not accessible):")
+        for d in degradations:
+            print(f"  ! {d}")
+        print(
+            "  ! To unlock full audit in CI, store a fine-grained PAT with\n"
+            "    Administration:Read on this repo as secret RULESET_AUDIT_TOKEN.\n"
+        )
 
     print(f"Required check names ({len(required)}):")
     for name, sources in sorted(required.items()):
@@ -181,6 +234,11 @@ def main(argv: Iterable[str] | None = None) -> int:
         print("workflow's job `name:` (with NO 'workflow / job' prefix), or")
         print("remove the requirement, or build a workflow that emits the name.")
         return 1
+
+    if degradations and not required:
+        # Couldn't read anything — useless to claim success
+        print("SKIPPED — no rule sources were readable. See warnings above.")
+        return 0
 
     print("OK — every required check matches a workflow job name.")
     if unused:


### PR DESCRIPTION
## Summary

The \`repo-config-audit.yml\` workflow merged in #109 was failing on every push (you can see three consecutive red Xs in the Actions tab). Two root causes, both fixed here:

### 1. Invalid \`permissions:\` key (the actual reason for the workflow file errors)

The workflow declared:

\`\`\`yaml
permissions:
  administration: read    # ← not a valid workflow permissions key
\`\`\`

\`administration\` exists as a permission scope for **GitHub Apps** and **fine-grained PATs**, but it is **not** a valid \`permissions:\` key in a workflow YAML. GitHub rejected the workflow with \"workflow file issue\" before any job ran. Removed.

### 2. \`GITHUB_TOKEN\` cannot read rulesets / branch-protection anyway

Even if the YAML had been valid, the default \`GITHUB_TOKEN\` available in workflows has no admin scope. The rulesets and branch-protection APIs both require \`Administration: Read\`. Without a separate token, the audit could not actually do its job in CI.

This PR adds an optional \`RULESET_AUDIT_TOKEN\` repo secret (fine-grained PAT scoped to this repo with \`Administration: Read\` only):

- **Secret set:** full audit runs in CI, catches orphaned required checks
- **Secret unset:** audit runs in **degraded mode** — prints a clear warning, lists what it couldn't check, exits 0 so CI doesn't fail purely on a permission gap

Either way, local runs (\`python3 tools/audit-required-checks.py\` via your \`gh\` CLI) are unaffected — you're already authenticated as an admin.

## Files

\`\`\`
.github/workflows/repo-config-audit.yml   (modified — permissions + GH_TOKEN selection)
tools/audit-required-checks.py            (modified — graceful 403/404 handling)
DEV_NOTES.md                              (new \"Enabling the full audit in CI\" subsection)
\`\`\`

## Test plan

- [ ] Workflow loads (i.e. no \"workflow file issue\" red X) after this merges
- [ ] Without \`RULESET_AUDIT_TOKEN\` set: workflow runs, prints WARNING about degraded mode, exits success
- [ ] Verify locally: \`python3 tools/audit-required-checks.py\` → 0 with clean output
- [ ] Optional: create \`RULESET_AUDIT_TOKEN\` per DEV_NOTES instructions, re-run the workflow, confirm full audit fires

## Setting up \`RULESET_AUDIT_TOKEN\` (optional but recommended)

UI flow: GitHub → your account → Settings → Developer settings → Personal access tokens → Fine-grained tokens → Generate new token. Scope to **only** \`WebMS-Intra\`, grant **Administration: Read** (rest stay None), generate, copy. Then in this repo: Settings → Secrets and variables → Actions → New repository secret → name \`RULESET_AUDIT_TOKEN\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)