### PR TITLE
fix(ci): changelog.yml — skip main branch (ruleset blocks bot push)

### DIFF
--- a/.github/workflows/changelog.yml
+++ b/.github/workflows/changelog.yml
@@ -7,13 +7,18 @@
 # PURPOSE
 # -------
 # Generates / updates CHANGELOG.md from commit messages since the last v* tag
-# on push to alpha, beta, or main. Commits the result with [skip ci] so the
-# update itself does not retrigger the workflow.
+# on push to alpha or beta. Commits the result with [skip ci] so the update
+# itself does not retrigger the workflow.
 #
 # Excludes meta commits (CI bot bumps, [skip ci], changelog updates) from
 # the generated section. Per-branch sections use the heading format:
 #   ## [VERSION] - YYYY-MM-DD (branch)
-# so alpha/beta/main entries for the same version can coexist.
+# so alpha/beta entries for the same version can coexist.
+#
+# IMPORTANT: this workflow does NOT run on `main`. The ruleset on main
+# requires a PR — the bot's direct push would be rejected with GH013.
+# Changelog entries created on alpha/beta propagate to main via the
+# normal beta → main merge, so a main-side bot push isn't necessary.
 # =============================================================================
 
 name: Changelog
@@ -23,7 +28,13 @@ on:
     branches:
       - alpha
       - beta
-      - main
+      # NOTE: `main` is deliberately NOT in this list. The ruleset on
+      # main requires changes to come via PR — so the `chore: update
+      # changelog [skip ci]` push from this workflow gets rejected with
+      # GH013. Changelog entries are generated during alpha/beta
+      # development; they propagate naturally to main when you merge
+      # beta → main (the merged PR carries the CHANGELOG.md updates
+      # with it). No bot push to main is needed.
     paths:
       - 'web/**'
 

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -79,8 +79,10 @@ SFTP_BASE_PATH/
   pinned dompdf, SFTP via lftp (SSH key first, password fallback).
 - `version-bump.yml` — push to alpha or beta. Alpha always bumps PATCH; beta
   uses Conventional Commits (BREAKING/`!:` → major, `feat(` → minor, else patch).
-- `changelog.yml` — push to alpha/beta/main. Appends per-branch sections to
-  `CHANGELOG.md` from commit messages since the last `v*` tag.
+- `changelog.yml` — push to alpha or beta only (NOT main — the ruleset
+  on main blocks the bot's direct push). Appends per-branch sections to
+  `CHANGELOG.md` from commit messages since the last `v*` tag. Entries
+  propagate to main via the normal beta → main merge.
 - `release.yml` — push of any `v*` tag. Creates a GitHub Release from
   `CHANGELOG.md`; tags containing `-beta` or `-rc` are marked pre-release.
 - `auto-merge-alpha.yml` — PR opened or synchronised against `alpha`. Enables


### PR DESCRIPTION
## Context

PR #112 (the auto-deploy verification) merged successfully and the deploy fired automatically. Pipeline verified end-to-end. ✅

But the same merge surfaced a second issue: the **Changelog workflow failed** with \`GH013: Repository rule violations\`. The bot tried to commit \`chore: update changelog [skip ci]\` directly to main, and the \"Protect main branch\" ruleset rejected it (correctly — that rule requires PRs).

## Fix

Scope the changelog workflow to alpha + beta only. Diff:

\`\`\`diff
   push:
     branches:
       - alpha
       - beta
-      - main
\`\`\`

## Reasoning

- Changelog entries are generated during **development** (alpha/beta), not on the production branch
- Those \`CHANGELOG.md\` updates propagate to main as part of the normal beta → main PR merge — they ride along inside the squash commit
- main never needs its own bot-pushed changelog entry
- Ruleset stays strict, no bypass-actor required

Same pattern iHymns uses: production is downstream of where automation runs.

## Files

\`\`\`
.github/workflows/changelog.yml   (modified — drop main, add explanatory comment)
DEV_NOTES.md                      (modified — workflow list entry)
\`\`\`

## Test plan

- [ ] Merge this PR (won't trigger changelog.yml because no \`web/**\` change AND main is no longer in the trigger list)
- [ ] The Repo Config Audit + Deploy via SFTP runs may still fire on the merge if their path filters match — neither should fail
- [ ] Next time a real \`web/**\` change merges into alpha or beta, changelog.yml runs there as expected
- [ ] Future PRs to main no longer leave a red Changelog run in the Actions tab

Refs #111