### PR TITLE
feat(ui): PR 1 — design tokens refresh + installer styling

### DIFF
--- a/web/install/index.php
+++ b/web/install/index.php
@@ -441,24 +441,188 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
           integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YcnS/1PTgCq0l0vD8pVNSNZS1p0H084UB" crossorigin="anonymous">
     <style>
-        body { background: #f0f2f5; }
-        .install-card { max-width: 640px; margin: 2rem auto; }
-        .step-badge { width: 2rem; height: 2rem; border-radius: 50%; display: inline-flex;
-                      align-items: center; justify-content: center; font-weight: 600; font-size: .85rem; }
-        .step-active { background: #0d6efd; color: #fff; }
-        .step-done { background: #198754; color: #fff; }
-        .step-pending { background: #dee2e6; color: #6c757d; }
-        .prereq-pass { color: #198754; }
-        .prereq-fail { color: #dc3545; }
+        /* ===== Design tokens (mirrors web/public_html/assets/css/portal.css) =====
+           Installer is standalone — runs before bootstrap.php, so portal.css
+           can't be loaded. Token values are kept in sync manually. */
+        :root {
+            --portal-primary:        #5e6ad2;
+            --portal-primary-rgb:    94, 106, 210;
+            --portal-primary-hover:  #4f5bbf;
+            --portal-primary-subtle: #eef0fb;
+            --portal-success:        #16a34a;
+            --portal-warning:        #d97706;
+            --portal-danger:         #dc2626;
+            --portal-bg:             #f7f8fa;
+            --portal-surface:        #ffffff;
+            --portal-border:         #e5e7eb;
+            --portal-border-strong:  #d1d5db;
+            --portal-text:           #1b2330;
+            --portal-text-muted:     #6b7280;
+            --portal-radius-md:      0.5rem;
+            --portal-radius-lg:      0.75rem;
+            --portal-shadow-md:      0 4px 6px -1px rgba(16,24,40,0.08),
+                                     0 2px 4px -2px rgba(16,24,40,0.06);
+            --portal-shadow-lg:      0 12px 20px -8px rgba(16,24,40,0.12),
+                                     0 4px 8px -4px rgba(16,24,40,0.08);
+        }
+
+        /* ===== Page ===== */
+        body {
+            background: var(--portal-bg);
+            color: var(--portal-text);
+            font-family: system-ui, -apple-system, "Segoe UI", Roboto,
+                         "Helvetica Neue", Arial, sans-serif;
+            min-height: 100vh;
+        }
+
+        /* ===== Header ===== */
+        .install-header h1 {
+            color: var(--portal-text);
+            letter-spacing: -0.01em;
+            font-weight: 600;
+        }
+        .install-header .install-tagline {
+            color: var(--portal-text-muted);
+            margin-top: 0.25rem;
+            font-size: 0.9375rem;
+        }
+
+        /* ===== Card (the main wizard panel) ===== */
+        .install-card {
+            max-width: 640px;
+            margin: 0 auto;
+            background: var(--portal-surface);
+            border: 1px solid var(--portal-border);
+            border-radius: var(--portal-radius-lg);
+            box-shadow: var(--portal-shadow-md);
+        }
+        .install-card .card-body { padding: 2rem; }
+        .install-card h2 {
+            color: var(--portal-text);
+            font-weight: 600;
+            letter-spacing: -0.01em;
+            margin-bottom: 0.75rem;
+        }
+        .install-card h3 {
+            color: var(--portal-text);
+            font-weight: 600;
+            font-size: 0.9375rem;
+            margin-top: 1.5rem;
+            margin-bottom: 0.75rem;
+        }
+
+        /* ===== Step indicator badges =====
+           Markup keeps the existing flex+gap row; only the badges restyle. */
+        .step-badge {
+            width: 2.25rem;
+            height: 2.25rem;
+            border-radius: 50%;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            font-weight: 600;
+            font-size: 0.875rem;
+            transition: background 200ms cubic-bezier(0.4,0,0.2,1),
+                        color 200ms cubic-bezier(0.4,0,0.2,1),
+                        box-shadow 200ms cubic-bezier(0.4,0,0.2,1);
+        }
+        .step-active {
+            background: var(--portal-primary);
+            color: #fff;
+            box-shadow: 0 0 0 4px rgba(var(--portal-primary-rgb), 0.18);
+        }
+        .step-done {
+            background: var(--portal-success);
+            color: #fff;
+        }
+        .step-pending {
+            background: var(--portal-surface);
+            color: var(--portal-text-muted);
+            border: 1px solid var(--portal-border-strong);
+        }
+
+        /* ===== Prerequisites table polish ===== */
+        .install-card .table {
+            margin-bottom: 0;
+            font-size: 0.9375rem;
+        }
+        .install-card .table thead th {
+            color: var(--portal-text-muted);
+            font-weight: 600;
+            font-size: 0.75rem;
+            text-transform: uppercase;
+            letter-spacing: 0.04em;
+            border-bottom: 1px solid var(--portal-border);
+            padding-bottom: 0.5rem;
+        }
+        .install-card .table td {
+            padding: 0.6rem 0.5rem;
+            vertical-align: middle;
+            border-color: var(--portal-border);
+        }
+        .prereq-pass { color: var(--portal-success); font-weight: 500; }
+        .prereq-fail { color: var(--portal-danger);  font-weight: 500; }
+
+        /* ===== Buttons (override Bootstrap primary to match indigo) ===== */
+        .btn-primary {
+            --bs-btn-bg:           var(--portal-primary);
+            --bs-btn-border-color: var(--portal-primary);
+            --bs-btn-hover-bg:           var(--portal-primary-hover);
+            --bs-btn-hover-border-color: var(--portal-primary-hover);
+            --bs-btn-active-bg:           var(--portal-primary-hover);
+            --bs-btn-active-border-color: var(--portal-primary-hover);
+            font-weight: 500;
+            padding-inline: 1.25rem;
+        }
+
+        /* ===== Form inputs ===== */
+        .install-card .form-control,
+        .install-card .form-select {
+            border-color: var(--portal-border-strong);
+            border-radius: var(--portal-radius-md);
+        }
+        .install-card .form-control:focus,
+        .install-card .form-select:focus {
+            border-color: var(--portal-primary);
+            box-shadow: 0 0 0 3px rgba(var(--portal-primary-rgb), 0.18);
+        }
+        .install-card .form-label { font-weight: 500; color: var(--portal-text); }
+
+        /* ===== Alerts ===== */
+        .alert.install-card { box-shadow: none; }
+        .alert-danger {
+            background: #fef2f2;
+            border-color: #fecaca;
+            color: #991b1b;
+        }
+        .alert-success {
+            background: #f0fdf4;
+            border-color: #bbf7d0;
+            color: #166534;
+        }
+
+        /* ===== Footer ===== */
+        .install-footer {
+            text-align: center;
+            color: var(--portal-text-muted);
+            font-size: 0.8125rem;
+            margin-top: 1.5rem;
+        }
+
+        /* ===== Focus indicators (WCAG) ===== */
+        :focus-visible {
+            outline: 3px solid var(--portal-primary);
+            outline-offset: 2px;
+        }
     </style>
 </head>
 <body>
 <div class="container py-4">
 
     <!-- Header -->
-    <div class="text-center mb-4">
+    <div class="install-header text-center mb-4">
         <h1 class="h3 fw-bold">WebMS Intra</h1>
-        <p class="text-muted">Installation Wizard &mdash; v<?php echo INSTALL_VERSION; ?></p>
+        <p class="install-tagline">Installation Wizard &mdash; v<?php echo INSTALL_VERSION; ?></p>
     </div>
 
     <!-- Step indicator -->

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -18,53 +18,106 @@
    ============================================================================ */
 
 :root {
-    /* Brand colours */
-    --portal-primary: #0d6efd;
-    --portal-primary-rgb: 13, 110, 253;
-    --portal-secondary: #6c757d;
-    --portal-accent: #0dcaf0;
-    --portal-success: #198754;
-    --portal-warning: #ffc107;
-    --portal-danger: #dc3545;
+    /* =========================================================================
+     * UI direction (#111 PR 1):
+     *   • Linear-style indigo accent (#5e6ad2)
+     *   • Stripe-inspired layered shadows
+     *   • System font stack for body+headings (no web-font cost yet)
+     *   • Site admins will override --portal-primary etc. per #111 PR 2
+     *     (branding settings) — keep the token names stable.
+     * =====================================================================*/
 
-    /* Surfaces */
-    --portal-bg: #f8f9fa;
-    --portal-surface: #ffffff;
-    --portal-surface-hover: #f0f1f3;
-    --portal-border: #dee2e6;
+    /* ----- Brand colours ----- */
+    --portal-primary:        #5e6ad2;
+    --portal-primary-rgb:    94, 106, 210;
+    --portal-primary-hover:  #4f5bbf;
+    --portal-primary-active: #424da5;
+    --portal-primary-subtle: #eef0fb;       /* tinted bg for callouts / hover */
 
-    /* Text */
-    --portal-text: #212529;
-    --portal-text-muted: #6c757d;
-    --portal-text-on-primary: #ffffff;
+    /* ----- Semantic colours ----- */
+    --portal-secondary: #6b7280;
+    --portal-accent:    #06b6d4;            /* cyan accent for links / info */
+    --portal-success:   #16a34a;
+    --portal-warning:   #d97706;
+    --portal-danger:    #dc2626;
 
-    /* Typography */
-    --portal-font-family: system-ui, -apple-system, "Segoe UI", Roboto, "Helvetica Neue", Arial, sans-serif;
-    --portal-font-mono: SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
-    --portal-font-size-sm: 0.875rem;
-    --portal-font-size-xs: 0.75rem;
+    /* ----- Surfaces ----- */
+    --portal-bg:               #f7f8fa;     /* slightly warmer page bg */
+    --portal-surface:          #ffffff;     /* card / panel base */
+    --portal-surface-elevated: #ffffff;     /* same colour, different shadow depth */
+    --portal-surface-hover:    #f0f2f6;
+    --portal-border:           #e5e7eb;     /* warmer than #dee2e6 */
+    --portal-border-strong:    #d1d5db;
 
-    /* Spacing */
-    --portal-spacing-xs: 0.25rem;
-    --portal-spacing-sm: 0.5rem;
-    --portal-spacing-md: 1rem;
-    --portal-spacing-lg: 1.5rem;
-    --portal-spacing-xl: 2rem;
+    /* ----- Text ----- */
+    --portal-text:             #1b2330;     /* near-black, slight cool tint to pair with indigo */
+    --portal-text-muted:       #6b7280;
+    --portal-text-subtle:      #9ca3af;
+    --portal-text-on-primary:  #ffffff;
+    --portal-link:             var(--portal-primary);
 
-    /* Shadows */
-    --portal-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.08);
-    --portal-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.1);
-    --portal-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.12);
+    /* ----- Typography ----- */
+    --portal-font-family:      system-ui, -apple-system, "Segoe UI", Roboto,
+                               "Helvetica Neue", Arial, sans-serif;
+    --portal-font-mono:        ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+                               Monaco, Consolas, "Liberation Mono", monospace;
 
-    /* Borders */
-    --portal-radius-sm: 0.375rem;
-    --portal-radius-md: 0.5rem;
-    --portal-radius-lg: 0.75rem;
+    --portal-font-size-xs:     0.75rem;     /* 12px */
+    --portal-font-size-sm:     0.875rem;    /* 14px */
+    --portal-font-size-base:   1rem;        /* 16px — default */
+    --portal-font-size-lg:     1.125rem;    /* 18px */
+    --portal-font-size-xl:     1.25rem;     /* 20px */
+    --portal-font-size-2xl:    1.5rem;      /* 24px */
+    --portal-font-size-3xl:    1.875rem;    /* 30px */
+    --portal-font-size-4xl:    2.25rem;     /* 36px */
+
+    --portal-font-weight-regular: 400;
+    --portal-font-weight-medium:  500;
+    --portal-font-weight-bold:    600;      /* modern semi-bold for headings */
+
+    --portal-line-height-tight:   1.25;
+    --portal-line-height-base:    1.5;
+    --portal-line-height-relaxed: 1.7;
+
+    --portal-letter-spacing-tight: -0.01em; /* subtle on large display text */
+
+    /* ----- Spacing scale ----- */
+    --portal-spacing-2xs: 0.125rem;         /* 2px */
+    --portal-spacing-xs:  0.25rem;          /* 4px */
+    --portal-spacing-sm:  0.5rem;           /* 8px */
+    --portal-spacing-md:  1rem;             /* 16px */
+    --portal-spacing-lg:  1.5rem;           /* 24px */
+    --portal-spacing-xl:  2rem;             /* 32px */
+    --portal-spacing-2xl: 3rem;             /* 48px */
+    --portal-spacing-3xl: 4rem;             /* 64px */
+
+    /* ----- Shadows (multi-layer, Stripe-style) ----- */
+    --portal-shadow-xs: 0 1px 2px rgba(16, 24, 40, 0.06);
+    --portal-shadow-sm: 0 1px 3px rgba(16, 24, 40, 0.08),
+                        0 1px 2px rgba(16, 24, 40, 0.05);
+    --portal-shadow-md: 0 4px 6px -1px rgba(16, 24, 40, 0.08),
+                        0 2px 4px -2px rgba(16, 24, 40, 0.06);
+    --portal-shadow-lg: 0 12px 20px -8px rgba(16, 24, 40, 0.12),
+                        0 4px 8px -4px rgba(16, 24, 40, 0.08);
+    --portal-shadow-xl: 0 24px 40px -12px rgba(16, 24, 40, 0.15),
+                        0 8px 16px -6px rgba(16, 24, 40, 0.08);
+    --portal-shadow-focus: 0 0 0 3px rgba(var(--portal-primary-rgb), 0.25);
+
+    /* ----- Borders / radius ----- */
+    --portal-radius-xs:    0.25rem;         /* 4px — tiny chips */
+    --portal-radius-sm:    0.375rem;        /* 6px — buttons */
+    --portal-radius-md:    0.5rem;          /* 8px — inputs, badges */
+    --portal-radius-lg:    0.75rem;         /* 12px — cards */
+    --portal-radius-xl:    1rem;            /* 16px — hero / large panels */
     --portal-radius-round: 50%;
 
-    /* Transitions */
-    --portal-transition-fast: 150ms ease;
-    --portal-transition-normal: 250ms ease;
+    /* ----- Motion ----- */
+    --portal-easing-standard:   cubic-bezier(0.4, 0, 0.2, 1);
+    --portal-easing-emphasised: cubic-bezier(0.16, 1, 0.3, 1);  /* spring-y */
+
+    --portal-transition-fast:   120ms var(--portal-easing-standard);
+    --portal-transition-normal: 200ms var(--portal-easing-standard);
+    --portal-transition-slow:   320ms var(--portal-easing-emphasised);
 }
 
 /* ============================================================================
@@ -72,15 +125,43 @@
    ============================================================================ */
 
 [data-bs-theme="dark"] {
-    --portal-bg: #1a1d21;
-    --portal-surface: #212529;
-    --portal-surface-hover: #2b3035;
-    --portal-border: #495057;
-    --portal-text: #e9ecef;
-    --portal-text-muted: #adb5bd;
-    --portal-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.3);
-    --portal-shadow-md: 0 4px 12px rgba(0, 0, 0, 0.4);
-    --portal-shadow-lg: 0 8px 24px rgba(0, 0, 0, 0.5);
+    /* Primary brightens for dark mode to keep adequate contrast on dark surfaces.
+     * Subtle-bg flips to a deep indigo tint so callouts read as "branded"
+     * rather than just "lighter grey". */
+    --portal-primary:        #7b86e8;
+    --portal-primary-rgb:    123, 134, 232;
+    --portal-primary-hover:  #8f99eb;
+    --portal-primary-active: #a0a9ee;
+    --portal-primary-subtle: #1f2347;
+
+    --portal-accent:  #22d3ee;
+    --portal-success: #4ade80;
+    --portal-warning: #fbbf24;
+    --portal-danger:  #f87171;
+
+    --portal-bg:               #0f1115;     /* near-black with slight indigo cast */
+    --portal-surface:          #161a22;
+    --portal-surface-elevated: #1c212c;
+    --portal-surface-hover:    #232936;
+    --portal-border:           #2c3441;
+    --portal-border-strong:    #3a4252;
+
+    --portal-text:             #e8eaf0;
+    --portal-text-muted:       #9aa3b2;
+    --portal-text-subtle:      #6b7280;
+    --portal-text-on-primary:  #0f1115;     /* dark text on the lighter dark-mode primary */
+    --portal-link:             #9aa5f0;
+
+    --portal-shadow-xs: 0 1px 2px rgba(0, 0, 0, 0.4);
+    --portal-shadow-sm: 0 1px 3px rgba(0, 0, 0, 0.5),
+                        0 1px 2px rgba(0, 0, 0, 0.3);
+    --portal-shadow-md: 0 4px 6px -1px rgba(0, 0, 0, 0.4),
+                        0 2px 4px -2px rgba(0, 0, 0, 0.3);
+    --portal-shadow-lg: 0 12px 20px -8px rgba(0, 0, 0, 0.5),
+                        0 4px 8px -4px rgba(0, 0, 0, 0.4);
+    --portal-shadow-xl: 0 24px 40px -12px rgba(0, 0, 0, 0.6),
+                        0 8px 16px -6px rgba(0, 0, 0, 0.4);
+    --portal-shadow-focus: 0 0 0 3px rgba(var(--portal-primary-rgb), 0.4);
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

First PR of the holistic UI refresh tracked in #111. Establishes the new design language by refining the design tokens in \`portal.css\` and applying the same tokens (inline) to the standalone installer. **No application templates touched in this PR** — that's PRs 2-6.

## What changed visually

- **Brand primary** shifts from generic Bootstrap blue \`#0d6efd\` → Linear-style indigo \`#5e6ad2\` (per the colour pick locked in #111 discussion)
- **Shadows** become layered Stripe-style (multi-shadow rules give cards proper depth instead of flat blur)
- **Typography**: semi-bold (600) headings instead of bold (700) — more modern, less heavy. Type scale expanded (xs/sm/base/lg/xl/2xl/3xl/4xl).
- **Motion**: transitions now use cubic-bezier easings (standard + emphasised) rather than plain \`ease\`
- **Dark mode** updated to a deeper near-black with slight indigo cast; primary brightens for adequate contrast.

The installer specifically gets:
- Polished step indicator (larger badges, indigo halo on active step, success-green on done)
- Refined card with proper layered shadow
- Cleaner prerequisites table (uppercase tracked headers, semi-bold pass/fail)
- Buttons use indigo primary via Bootstrap's CSS custom properties
- Focus rings tinted with primary
- Softer alert palette

## What did NOT change

- 95 references to \`var(--portal-*)\` throughout portal.css still work — all token names kept stable
- Component CSS in portal.css (navbar, cards, data-list etc) untouched — they pick up the new tokens automatically but their structure is unchanged
- All application templates / pages untouched
- All PHP logic untouched

## Files

\`\`\`
web/public_html/assets/css/portal.css   (modified — :root + dark-mode token blocks)
web/install/index.php                    (modified — inline <style> block + small markup)
\`\`\`

## Test plan

This PR's merge ALSO doubles as another verification that auto-deploy fires on \`web/**\` changes (after PR #112 already proved it). Expect:

- [ ] \`PR Security Checks\` runs and passes (no PHP changes, just CSS + minor HTML class change)
- [ ] \`Repo Config Audit\` doesn't run (no \`.github/workflows/\` change)
- [ ] On squash-merge to main: \`Deploy via SFTP\` fires on \`push\` event automatically (no manual dispatch needed)
- [ ] Visit \`https://portal.millrdsdacambridge.uk/install/\` after deploy — installer should now look like the new design language (indigo accent, layered card, polished step indicator)
- [ ] Visit any portal page after deploy — primary colour changes to indigo wherever \`--portal-primary\` is used (logged-in pages, login screen, etc.)

## Sequence

This is **PR 1 of 6** per the plan in #111. After it merges:

- PR 2: Branding settings infrastructure (let admins override \`--portal-primary\` etc. per-site)
- PR 3: Navbar + top chrome polish
- PR 4: Forms + data list polish
- PR 5: Dashboard hero + app cards
- PR 6: Polish pass + dark mode audit

## Out of scope reminders

- No web fonts loaded yet (system stack stays for now — separate decision)
- No logo change (still text wordmark — branding work is PR 2)
- Light markup change limited to one header div getting a CSS class hook

Refs #111