### PR TITLE
feat(ui): PR 2 — per-site branding flows into portal CSS tokens

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -233,6 +233,70 @@ The script is idempotent — re-runs skip if the right version is already presen
 
 ---
 
+## Per-site branding flow
+
+The portal supports per-site visual branding via `tblSites` columns. Site
+admins can override the brand colour, logo and favicon per-site without
+touching code.
+
+### Data model
+
+`tblSites` columns relevant to branding (see migration `037_site_favicon.sql`):
+
+| Column         | Type         | Purpose                                          |
+| -------------- | ------------ | ------------------------------------------------ |
+| `siteName`     | VARCHAR(255) | Display name used in nav, page titles, footer    |
+| `logoPath`     | VARCHAR(500) | Header logo URL/path (any image format)          |
+| `faviconPath`  | VARCHAR(500) | Browser-tab favicon URL/path; NULL = default     |
+| `primaryColor` | VARCHAR(7)   | `#RRGGBB` hex; default `#5e6ad2` (Linear indigo) |
+| `copyrightOrg` | VARCHAR(255) | Footer copyright holder                          |
+
+### How a value flows from DB to UI
+
+1. `Site::loadCurrentSite()` selects the row into a class-level cache.
+2. `Site::branding('color' | 'logo' | 'favicon' | 'name' | …)` returns the
+   relevant column.
+3. `web/core/templates/header.php` reads `Site::branding('color')`,
+   derives `--portal-primary-rgb` (R,G,B) from the hex, and **inline-
+   styles** the `<html>` element:
+
+   ```html
+   <html data-bs-theme="light"
+         style="--portal-primary: #5e6ad2; --portal-primary-rgb: 94, 106, 210;">
+   ```
+
+4. `web/public_html/assets/css/portal.css` defines the design tokens
+   inside `:root`. Because the `<html>` inline style has higher
+   specificity than `:root`, the per-site primary wins. The derived
+   variants (`--portal-primary-hover`, `--portal-primary-active`,
+   `--portal-primary-subtle`) are auto-derived from the primary via
+   `color-mix()` and shift along with it on any browser that supports
+   color-mix (Chrome 111+, Safari 16.2+, Firefox 113+). On older
+   browsers, the literal indigo hex fallbacks defined in `:root` apply.
+5. `header.php` also renders `<link rel="icon">` from
+   `Site::branding('favicon')`, with `/assets/images/favicon.ico` as the
+   fallback.
+
+### Admin UI
+
+Umbrella admins manage all sites at **`/admin/sites/`**. The "New / Edit
+site" modal has form fields for `siteName`, `siteKey`, `hostPattern`,
+`logoPath`, `faviconPath`, `primaryColor` (color picker), `copyrightOrg`,
+`timezone`, and active status.
+
+The save handler at `web/public_html/admin/sites/save.php` validates the
+primary colour as `#RGB` or `#RRGGBB` and falls back to the indigo default
+on invalid input.
+
+### Defaults for white-label deploys
+
+`tblSites` ships with the global "WebMS Intra" defaults. New sites
+inherit `#5e6ad2` until the admin sets their own brand colour. Logo and
+favicon default to `/assets/images/logo.svg` and
+`/assets/images/favicon.ico` respectively.
+
+---
+
 ## Branch protection & rulesets — gotchas
 
 Two GitHub mechanisms can guard a branch in parallel: classic **branch

--- a/web/core/Site.php
+++ b/web/core/Site.php
@@ -113,8 +113,8 @@ class Site
     private static function loadSiteRow(\mysqli $db): void
     {
         $stmt = $db->prepare(
-            'SELECT siteID, siteName, siteKey, hostPattern, logoPath, primaryColor, '
-            . 'copyrightOrg, timezone, isActive '
+            'SELECT siteID, siteName, siteKey, hostPattern, logoPath, faviconPath, '
+            . 'primaryColor, copyrightOrg, timezone, isActive '
             . 'FROM tblSites WHERE siteID = ? LIMIT 1'
         );
         if ($stmt === false) {
@@ -157,7 +157,7 @@ class Site
     /**
      * Get a site-specific branding value.
      *
-     * @param string $key One of: name, logo, color, copyright, timezone, key
+     * @param string $key One of: name, logo, favicon, color, copyright, timezone, key
      *
      * @return string|null Value or null if site not loaded
      */
@@ -173,6 +173,11 @@ class Site
         }
         if ($key === 'logo') {
             return $site['logoPath'];
+        }
+        if ($key === 'favicon') {
+            // faviconPath column may not yet exist on databases that haven't
+            // run migration 037; return null to let the caller fall back.
+            return $site['faviconPath'] ?? null;
         }
         if ($key === 'color') {
             return $site['primaryColor'];
@@ -277,8 +282,8 @@ class Site
     public static function allActive(\mysqli $db): array
     {
         $result = $db->query(
-            'SELECT siteID, siteName, siteKey, hostPattern, logoPath, primaryColor, '
-            . 'copyrightOrg, timezone, isActive, createdAt '
+            'SELECT siteID, siteName, siteKey, hostPattern, logoPath, faviconPath, '
+            . 'primaryColor, copyrightOrg, timezone, isActive, createdAt '
             . 'FROM tblSites WHERE isActive = 1 ORDER BY siteName ASC'
         );
         if ($result === false) {
@@ -297,8 +302,8 @@ class Site
     public static function all(\mysqli $db): array
     {
         $result = $db->query(
-            'SELECT siteID, siteName, siteKey, hostPattern, logoPath, primaryColor, '
-            . 'copyrightOrg, timezone, isActive, createdAt, updatedAt '
+            'SELECT siteID, siteName, siteKey, hostPattern, logoPath, faviconPath, '
+            . 'primaryColor, copyrightOrg, timezone, isActive, createdAt, updatedAt '
             . 'FROM tblSites ORDER BY siteID ASC'
         );
         if ($result === false) {

--- a/web/core/templates/header.php
+++ b/web/core/templates/header.php
@@ -36,9 +36,28 @@ $pageTitle   = $pageTitle   ?? 'Portal';
 $pageSection = $pageSection ?? '';
 $breadcrumbs = $breadcrumbs ?? [];
 
-// 🌐 Site branding — use Site::branding() for multi-site, fallback to settings
+// 🌐 Site branding — use Site::branding() for multi-site, fallback to settings.
+// $siteColor is injected as --portal-primary on the <html> element below so
+// portal.css's design tokens shift to the site's brand colour automatically.
 $siteName    = Site::branding('name') ?? App::settings('site.name') ?? 'Portal';
-$siteColor   = Site::branding('color') ?? '#0d6efd';
+$siteColor   = Site::branding('color') ?? '#5e6ad2';
+$siteFavicon = Site::branding('favicon') ?? '/assets/images/favicon.ico';
+
+// 🎨 Derive --portal-primary-rgb (comma-separated R,G,B) from the hex colour
+// so portal.css's rgba()-based focus rings and shadows tint correctly.
+// Accepts #RGB / #RRGGBB; falls back to the indigo default on bad input.
+$hex = ltrim((string) $siteColor, '#');
+if (strlen($hex) === 3) {
+    $hex = $hex[0] . $hex[0] . $hex[1] . $hex[1] . $hex[2] . $hex[2];
+}
+if (preg_match('/^[0-9a-fA-F]{6}$/', $hex) === 1) {
+    $siteColorRgb = (int) hexdec(substr($hex, 0, 2)) . ', '
+                  . (int) hexdec(substr($hex, 2, 2)) . ', '
+                  . (int) hexdec(substr($hex, 4, 2));
+} else {
+    $siteColor    = '#5e6ad2';
+    $siteColorRgb = '94, 106, 210';
+}
 
 // 🔒 Security headers
 header_remove('X-Powered-By');
@@ -52,7 +71,10 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-i
 // 🎨 Determine initial theme from localStorage (handled by JS, default light)
 ?>
 <!doctype html>
-<html lang="<?php echo htmlspecialchars(I18n::locale(), ENT_QUOTES, 'UTF-8'); ?>" dir="<?php echo I18n::dir(); ?>" data-bs-theme="light">
+<html lang="<?php echo htmlspecialchars(I18n::locale(), ENT_QUOTES, 'UTF-8'); ?>"
+      dir="<?php echo I18n::dir(); ?>"
+      data-bs-theme="light"
+      style="--portal-primary: <?php echo htmlspecialchars($siteColor, ENT_QUOTES, 'UTF-8'); ?>; --portal-primary-rgb: <?php echo htmlspecialchars($siteColorRgb, ENT_QUOTES, 'UTF-8'); ?>;">
 <head>
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
@@ -61,6 +83,7 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-i
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="manifest" href="/manifest.json">
+    <link rel="icon" href="<?php echo htmlspecialchars($siteFavicon, ENT_QUOTES, 'UTF-8'); ?>">
     <link rel="apple-touch-icon" href="/assets/images/icon-192.svg">
     <title><?php echo htmlspecialchars($pageTitle . ' - ' . $siteName, ENT_QUOTES, 'UTF-8'); ?></title>
 

--- a/web/public_html/admin/sites/index.php
+++ b/web/public_html/admin/sites/index.php
@@ -184,8 +184,14 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
                     <div class="col-md-6 mb-3">
                         <label for="formPrimaryColor" class="form-label">Primary Colour</label>
                         <input type="color" class="form-control form-control-color" id="formPrimaryColor"
-                               name="primaryColor" value="#0d6efd">
+                               name="primaryColor" value="#5e6ad2">
                     </div>
+                </div>
+                <div class="mb-3">
+                    <label for="formFaviconPath" class="form-label">Favicon Path</label>
+                    <input type="text" class="form-control" id="formFaviconPath" name="faviconPath" maxlength="500"
+                           placeholder="/assets/images/favicon.ico">
+                    <div class="form-text">URL or path to the favicon. Leave blank to use the default.</div>
                 </div>
                 <div class="mb-3">
                     <label for="formCopyrightOrg" class="form-label">Copyright Organisation</label>
@@ -226,7 +232,8 @@ function resetSiteForm() {
     document.getElementById('formSiteKey').value = '';
     document.getElementById('formHostPattern').value = '';
     document.getElementById('formLogoPath').value = '/assets/images/logo.svg';
-    document.getElementById('formPrimaryColor').value = '#0d6efd';
+    document.getElementById('formFaviconPath').value = '';
+    document.getElementById('formPrimaryColor').value = '#5e6ad2';
     document.getElementById('formCopyrightOrg').value = '';
     document.getElementById('formTimezone').value = 'UTC';
     document.getElementById('formIsActive').checked = true;
@@ -239,7 +246,8 @@ function editSite(site) {
     document.getElementById('formSiteKey').value = site.siteKey || '';
     document.getElementById('formHostPattern').value = site.hostPattern || '';
     document.getElementById('formLogoPath').value = site.logoPath || '/assets/images/logo.svg';
-    document.getElementById('formPrimaryColor').value = site.primaryColor || '#0d6efd';
+    document.getElementById('formFaviconPath').value = site.faviconPath || '';
+    document.getElementById('formPrimaryColor').value = site.primaryColor || '#5e6ad2';
     document.getElementById('formCopyrightOrg').value = site.copyrightOrg || '';
     document.getElementById('formTimezone').value = site.timezone || 'UTC';
     document.getElementById('formIsActive').checked = (String(site.isActive) === '1');

--- a/web/public_html/admin/sites/save.php
+++ b/web/public_html/admin/sites/save.php
@@ -51,10 +51,16 @@ $siteName     = trim($_POST['siteName'] ?? '');
 $siteKey      = trim(strtolower($_POST['siteKey'] ?? ''));
 $hostPattern  = trim($_POST['hostPattern'] ?? '');
 $logoPath     = trim($_POST['logoPath'] ?? '/assets/images/logo.svg');
-$primaryColor = trim($_POST['primaryColor'] ?? '#0d6efd');
+$faviconPath  = trim($_POST['faviconPath'] ?? '');
+$primaryColor = trim($_POST['primaryColor'] ?? '#5e6ad2');
 $copyrightOrg = trim($_POST['copyrightOrg'] ?? '');
 $timezone     = trim($_POST['timezone'] ?? 'UTC');
 $isActive     = isset($_POST['isActive']) ? 1 : 0;
+
+// 🔍 Validate primaryColor as #RGB or #RRGGBB hex; fall back to indigo default
+if (preg_match('/^#(?:[0-9a-fA-F]{3}|[0-9a-fA-F]{6})$/', $primaryColor) !== 1) {
+    $primaryColor = '#5e6ad2';
+}
 
 // 🔍 Validate required fields
 if ($siteName === '' || $siteKey === '') {
@@ -81,7 +87,7 @@ if ($siteID > 0) {
     // ♻️ UPDATE existing site
     $stmt = $db->prepare(
         'UPDATE tblSites SET siteName = ?, siteKey = ?, hostPattern = ?, logoPath = ?, '
-        . 'primaryColor = ?, copyrightOrg = ?, timezone = ?, isActive = ? '
+        . 'faviconPath = ?, primaryColor = ?, copyrightOrg = ?, timezone = ?, isActive = ? '
         . 'WHERE siteID = ?'
     );
     if ($stmt === false) {
@@ -93,10 +99,11 @@ if ($siteID > 0) {
 
     $hostPatternVal = ($hostPattern !== '') ? $hostPattern : null;
     $copyrightVal   = ($copyrightOrg !== '') ? $copyrightOrg : null;
+    $faviconVal     = ($faviconPath !== '') ? $faviconPath : null;
 
     $stmt->bind_param(
-        'sssssssii',
-        $siteName, $siteKey, $hostPatternVal, $logoPath,
+        'ssssssssii',
+        $siteName, $siteKey, $hostPatternVal, $logoPath, $faviconVal,
         $primaryColor, $copyrightVal, $timezone, $isActive, $siteID
     );
 
@@ -112,8 +119,8 @@ if ($siteID > 0) {
 } else {
     // ➕ INSERT new site
     $stmt = $db->prepare(
-        'INSERT INTO tblSites (siteName, siteKey, hostPattern, logoPath, primaryColor, copyrightOrg, timezone, isActive) '
-        . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+        'INSERT INTO tblSites (siteName, siteKey, hostPattern, logoPath, faviconPath, primaryColor, copyrightOrg, timezone, isActive) '
+        . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
     );
     if ($stmt === false) {
         $_SESSION['flash_msg'] = 'Database error: ' . $db->error;
@@ -124,10 +131,11 @@ if ($siteID > 0) {
 
     $hostPatternVal = ($hostPattern !== '') ? $hostPattern : null;
     $copyrightVal   = ($copyrightOrg !== '') ? $copyrightOrg : null;
+    $faviconVal     = ($faviconPath !== '') ? $faviconPath : null;
 
     $stmt->bind_param(
-        'sssssssi',
-        $siteName, $siteKey, $hostPatternVal, $logoPath,
+        'ssssssssi',
+        $siteName, $siteKey, $hostPatternVal, $logoPath, $faviconVal,
         $primaryColor, $copyrightVal, $timezone, $isActive
     );
 

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -27,7 +27,16 @@
      *     (branding settings) — keep the token names stable.
      * =====================================================================*/
 
-    /* ----- Brand colours ----- */
+    /* ----- Brand colours -----
+     * --portal-primary and --portal-primary-rgb are overridable per-site
+     * via inline style on the <html> element (set in header.php from
+     * tblSites.primaryColor). The hover/active/subtle variants below are
+     * DERIVED from --portal-primary using color-mix() so they shift
+     * automatically with the per-site primary.
+     *
+     * Fallback hex values are kept for browsers that don't support
+     * color-mix() (Chrome <111, Safari <16.2, Firefox <113). On those
+     * browsers all three derived tokens use the indigo default. */
     --portal-primary:        #5e6ad2;
     --portal-primary-rgb:    94, 106, 210;
     --portal-primary-hover:  #4f5bbf;
@@ -118,6 +127,26 @@
     --portal-transition-fast:   120ms var(--portal-easing-standard);
     --portal-transition-normal: 200ms var(--portal-easing-standard);
     --portal-transition-slow:   320ms var(--portal-easing-emphasised);
+}
+
+/* ----------------------------------------------------------------------------
+ * Derive primary-hover / primary-active / primary-subtle from --portal-primary
+ * so per-site overrides (header.php injects --portal-primary on <html>) shift
+ * the whole indigo family automatically. Wrapped in @supports because
+ * color-mix() lands in Chrome 111 / Safari 16.2 / Firefox 113. Browsers that
+ * don't support it fall back to the literal hex values defined inside :root.
+ * --------------------------------------------------------------------------*/
+@supports (color: color-mix(in srgb, red, blue)) {
+    :root {
+        --portal-primary-hover:  color-mix(in srgb, var(--portal-primary), black 12%);
+        --portal-primary-active: color-mix(in srgb, var(--portal-primary), black 24%);
+        --portal-primary-subtle: color-mix(in srgb, var(--portal-primary), white 92%);
+    }
+    [data-bs-theme="dark"] {
+        --portal-primary-hover:  color-mix(in srgb, var(--portal-primary), white 12%);
+        --portal-primary-active: color-mix(in srgb, var(--portal-primary), white 24%);
+        --portal-primary-subtle: color-mix(in srgb, var(--portal-primary), black 80%);
+    }
 }
 
 /* ============================================================================

--- a/web/sql/037_site_favicon.sql
+++ b/web/sql/037_site_favicon.sql
@@ -1,0 +1,32 @@
+-- =============================================================================
+-- 037 — Add faviconPath column to tblSites
+-- =============================================================================
+-- Part of the UI refresh PR 2 (#111). Site admins can now set a per-site
+-- favicon URL; header.php picks it up via Site::branding('favicon') and
+-- renders <link rel="icon"> with it. Falls back to the SVG default when null.
+--
+-- Idempotent: uses INFORMATION_SCHEMA to check before ALTER.
+-- =============================================================================
+
+SET @col_exists := (
+    SELECT COUNT(*)
+    FROM INFORMATION_SCHEMA.COLUMNS
+    WHERE TABLE_SCHEMA = DATABASE()
+      AND TABLE_NAME = 'tblSites'
+      AND COLUMN_NAME = 'faviconPath'
+);
+
+SET @stmt := IF(
+    @col_exists = 0,
+    'ALTER TABLE `tblSites`
+        ADD COLUMN `faviconPath` VARCHAR(500)
+        COLLATE utf8mb4_general_ci
+        DEFAULT NULL
+        COMMENT ''Path or URL to per-site favicon; NULL falls back to /assets/images/favicon.ico''
+        AFTER `logoPath`',
+    'SELECT ''column faviconPath already exists; skipping'' AS info'
+);
+
+PREPARE addCol FROM @stmt;
+EXECUTE addCol;
+DEALLOCATE PREPARE addCol;

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -55,8 +55,10 @@ CREATE TABLE IF NOT EXISTS `tblSites` (
                     COMMENT 'Hostname for subdomain detection',
     `logoPath`      VARCHAR(500) COLLATE utf8mb4_general_ci DEFAULT '/assets/images/logo.svg'
                     COMMENT 'Path to site-specific logo image',
-    `primaryColor`  VARCHAR(7)   COLLATE utf8mb4_general_ci DEFAULT '#0d6efd'
-                    COMMENT 'Hex colour for site branding',
+    `faviconPath`   VARCHAR(500) COLLATE utf8mb4_general_ci DEFAULT NULL
+                    COMMENT 'Path or URL to per-site favicon; NULL falls back to default',
+    `primaryColor`  VARCHAR(7)   COLLATE utf8mb4_general_ci DEFAULT '#5e6ad2'
+                    COMMENT 'Hex colour for site branding (default: Linear-style indigo)',
     `copyrightOrg`  VARCHAR(255) COLLATE utf8mb4_general_ci DEFAULT NULL
                     COMMENT 'Copyright holder name for footer',
     `timezone`      VARCHAR(50)  COLLATE utf8mb4_general_ci DEFAULT 'UTC'
@@ -1826,4 +1828,7 @@ INSERT INTO `tblMigrations` (`filename`) VALUES ('035_api_expansion.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblMigrations` (`filename`) VALUES ('036_tasks_reminders.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('037_site_favicon.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;


### PR DESCRIPTION
## Summary

PR 2 of the UI refresh tracked in #111. **Closes the loop on per-site branding** — admin-set colours and favicons now actually propagate to portal.css's design tokens at render time.

## What was already there vs. what was missing

Discovered during PR 2 design that most of the multi-site branding infrastructure was already in place:

| Component | Status before this PR |
|---|---|
| \`tblSites\` columns (logoPath, primaryColor, copyrightOrg, timezone) | ✅ existed |
| \`Site::branding('name' / 'logo' / 'color' / …)\` | ✅ existed |
| Admin UI at \`/admin/sites/\` for editing | ✅ existed (issue #45) |
| \`<meta name=\"theme-color\">\` per site | ✅ existed |
| **Per-site color flowing into portal.css tokens** | ❌ **missing — this PR adds it** |
| Favicon support | ❌ missing — this PR adds it |
| <link rel=\"icon\"> in header | ❌ missing — this PR adds it |

## Files

\`\`\`
web/sql/037_site_favicon.sql           (new — ALTER TABLE)
web/sql/full_schema.sql                (faviconPath col + migration row + default indigo)
web/core/Site.php                      ('favicon' case + faviconPath in SELECTs)
web/core/templates/header.php          (compute RGB, inline-style <html>, <link rel=icon>)
web/public_html/assets/css/portal.css  (color-mix derivation in @supports)
web/public_html/admin/sites/index.php  (favicon field + edit JS)
web/public_html/admin/sites/save.php   (faviconPath save + primaryColor validation)
DEV_NOTES.md                            (new "Per-site branding flow" section)
\`\`\`

## How it works end-to-end

1. Umbrella admin edits a site at \`/admin/sites/\`, sets primaryColor to e.g. \`#6d28d9\` (deep violet)
2. save.php validates and writes to \`tblSites.primaryColor\`
3. On the next request, \`Site::branding('color')\` returns \`#6d28d9\`
4. header.php computes the RGB tuple in PHP (\`109, 40, 217\`)
5. \`<html>\` element gets inline-styled: \`style=\"--portal-primary: #6d28d9; --portal-primary-rgb: 109, 40, 217;\"\`
6. portal.css's \`color-mix()\` derivation block recalculates \`--portal-primary-hover\` (12 % darker), \`--portal-primary-active\` (24 % darker), \`--portal-primary-subtle\` (92 % lighter for callout backgrounds)
7. Every component using \`var(--portal-primary)\` etc. — buttons, focus rings, badges, navbar accents — shifts to violet automatically

Same flow for favicon: admin sets path → \`Site::branding('favicon')\` → header.php renders \`<link rel=\"icon\">\`.

## Defaults updated

- \`tblSites.primaryColor\` default: \`#0d6efd\` → \`#5e6ad2\` (matches the new indigo design tokens from PR #114)
- \`tblSites.faviconPath\` default: NULL → header.php falls back to \`/assets/images/favicon.ico\`

## What's NOT in this PR (handled by PR 2.5, coming next)

Per your follow-up message, **theme modes** are scoped separately:

- System-auto theme detection (\`prefers-color-scheme\`)
- Colour-blind safe palette + toggle
- Theme/CB parity in the standalone installer

Splitting keeps each PR focused and reviewable. PR 2.5 will land immediately after this one.

## Test plan

- [ ] Auto-deploy fires on merge (touches \`web/**\`)
- [ ] Run migration 037 via \`/admin/migrations\` to add the faviconPath column
- [ ] Edit any site at \`/admin/sites/\` — set primaryColor to a noticeably different colour (e.g. \`#dc2626\` red) — save
- [ ] Reload the portal — buttons / focus rings / navbar accents shift to the new colour without any code change
- [ ] Set a custom faviconPath — browser tab icon updates
- [ ] Clear primaryColor in DB (set to NULL via SQL) — falls back to the indigo default
- [ ] No regressions on browsers without color-mix() (e.g. older Safari) — hex fallbacks kick in

Refs #111