### PR TITLE
feat(ui): PR 2.5 — system-auto theme + colour-blind safe palette + installer parity

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -233,6 +233,81 @@ The script is idempotent — re-runs skip if the right version is already presen
 
 ---
 
+## Theme modes + colour-blind palette
+
+The portal and the standalone installer support three theme modes and an
+opt-in colour-blind safe palette. Both are user-level preferences stored in
+`localStorage` (per-device, per-browser).
+
+### Theme modes
+
+- **Light** — light surfaces, dark text (the design's default visual)
+- **Dark** — dark surfaces, light text (`[data-bs-theme="dark"]` overrides)
+- **Auto** — follows the OS `prefers-color-scheme` and live-updates if the
+  system flips
+
+Click the half-stroke circle icon in the navbar to cycle through the modes.
+The icon updates to indicate the active preference (sun = light, moon =
+dark, half-stroke = auto). Persisted as `localStorage.portal-theme` =
+`light` / `dark` / `auto`. Missing key defaults to `auto`.
+
+The same control exists in the standalone installer at `/install/` (top-
+right of the page). Its tokens mirror `portal.css` and are kept in sync
+manually.
+
+### Colour-blind safe palette
+
+Opt-in toggle (`localStorage.portal-cb` = `on` / unset). When enabled,
+the eye icon in the navbar shows as active and the semantic colours
+(success, danger, warning, accent) shift to a palette from Wong (Nature
+Methods, 2011) that's distinguishable for deutan + protan colour
+blindness (~95 % of CB cases):
+
+- `--portal-success`: default `#16a34a` (green) → CB `#009e73` (bluish-green); dark CB `#5dd1a8`
+- `--portal-danger`: default `#dc2626` (red) → CB `#d55e00` (vermillion); dark CB `#ff8a4d`
+- `--portal-warning`: default `#d97706` (amber) → CB `#e69f00` (orange); dark CB `#ffc04d`
+- `--portal-accent`: default `#06b6d4` (cyan) → CB `#56b4e9` (sky blue); dark CB `#7fc6f0`
+
+Primary stays untouched — it's the site's identity colour and is
+user/site-set.
+
+**Accessibility note:** CB-safe tokens reduce the risk of mis-reading
+status colours, but **colour alone should never be the only signal**.
+Components that convey state (badges, alerts, validation messages)
+should also use icons or text labels. The PR template's security
+checklist already mentions this for new UI work.
+
+### Flow
+
+```text
+localStorage  ──FOUC script──▶  <html data-bs-theme="..." data-portal-cb="...">
+                                       │
+                                       ▼
+                              portal.css token overrides
+                                       │
+                                       ▼
+                              all components inherit
+```
+
+The FOUC script runs synchronously in `<head>` before first paint, so
+the chosen theme + CB mode are applied with no flash. portal.js (and
+the installer's inline JS) then wire up the toggle buttons and listen
+for `prefers-color-scheme` changes when in `auto` mode.
+
+### Where to find the code
+
+- `web/public_html/assets/css/portal.css` — token blocks for light,
+  dark, CB-safe (and dark + CB-safe combined)
+- `web/core/templates/header.php` — inline FOUC script reading
+  localStorage and applying the attrs
+- `web/core/templates/nav.php` — theme + CB toggle buttons
+- `web/public_html/assets/js/portal.js` — `initThemeToggle()` (cycles
+  light → dark → auto), `initCbToggle()` (on/off)
+- `web/install/index.php` — installer mirrors all of the above inline
+  (it's standalone, can't load portal.css/portal.js)
+
+---
+
 ## Branch protection & rulesets — gotchas
 
 Two GitHub mechanisms can guard a branch in parallel: classic **branch

--- a/web/core/templates/header.php
+++ b/web/core/templates/header.php
@@ -71,12 +71,22 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-i
 
     <?php echo Asset::portalCss(); ?>
 
-    <!-- 🌙 Prevent FOUC: apply saved theme before first paint -->
+    <!-- 🌙 Prevent FOUC: apply saved theme + accessibility prefs before paint -->
     <script>
     (function(){
+        var html = document.documentElement;
+        // Theme: 'light' / 'dark' / 'auto' (or null/missing = 'auto' default).
         var t = localStorage.getItem('portal-theme');
-        if (t === 'dark' || t === 'light') {
-            document.documentElement.setAttribute('data-bs-theme', t);
+        if (t === 'auto' || t === null) {
+            var prefersDark = window.matchMedia
+                && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            html.setAttribute('data-bs-theme', prefersDark ? 'dark' : 'light');
+        } else if (t === 'dark' || t === 'light') {
+            html.setAttribute('data-bs-theme', t);
+        }
+        // Colour-blind safe palette (toggleable, opt-in)
+        if (localStorage.getItem('portal-cb') === 'on') {
+            html.setAttribute('data-portal-cb', 'on');
         }
     })();
     </script>

--- a/web/core/templates/nav.php
+++ b/web/core/templates/nav.php
@@ -194,9 +194,14 @@ if ($isLoggedIn === true && Site::isMultisiteEnabled() === true && $navUser !== 
                 </div>
                 <?php endif; ?>
 
-                <!-- 🌙 Dark mode toggle -->
+                <!-- 🌙 Theme toggle (cycles light → dark → auto) -->
                 <button type="button" class="portal-theme-toggle" aria-label="<?php echo htmlspecialchars(t('nav.toggle_dark_mode'), ENT_QUOTES, 'UTF-8'); ?>">
-                    <i class="fa-solid fa-moon"></i>
+                    <i class="fa-solid fa-circle-half-stroke"></i>
+                </button>
+
+                <!-- 🎨 Colour-blind safe palette toggle -->
+                <button type="button" class="portal-cb-toggle" aria-label="Toggle colour-blind safe palette" aria-pressed="false">
+                    <i class="fa-solid fa-eye-low-vision"></i>
                 </button>
 
                 <!-- 👤 User dropdown -->
@@ -247,7 +252,12 @@ if ($isLoggedIn === true && Site::isMultisiteEnabled() === true && $navUser !== 
                 </li>
                 <li class="nav-item">
                     <button type="button" class="portal-theme-toggle" aria-label="<?php echo htmlspecialchars(t('nav.toggle_dark_mode'), ENT_QUOTES, 'UTF-8'); ?>">
-                        <i class="fa-solid fa-moon"></i>
+                        <i class="fa-solid fa-circle-half-stroke"></i>
+                    </button>
+                </li>
+                <li class="nav-item">
+                    <button type="button" class="portal-cb-toggle" aria-label="Toggle colour-blind safe palette" aria-pressed="false">
+                        <i class="fa-solid fa-eye-low-vision"></i>
                     </button>
                 </li>
             </ul>

--- a/web/install/index.php
+++ b/web/install/index.php
@@ -475,6 +475,84 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
         }
 
         /* =====================================================================
+         * Dark mode — mirrors portal.css's [data-bs-theme="dark"] block
+         * (applied to <html> by the FOUC script below).
+         * =================================================================*/
+        [data-bs-theme="dark"] {
+            --portal-primary:        #7b86e8;
+            --portal-primary-rgb:    123, 134, 232;
+            --portal-primary-hover:  #8f99eb;
+            --portal-primary-subtle: #1f2347;
+            --portal-success:        #4ade80;
+            --portal-warning:        #fbbf24;
+            --portal-danger:         #f87171;
+            --portal-bg:             #0f1115;
+            --portal-surface:        #161a22;
+            --portal-border:         #2c3441;
+            --portal-border-strong:  #3a4252;
+            --portal-text:           #e8eaf0;
+            --portal-text-muted:     #9aa3b2;
+            --portal-text-subtle:    #6b7280;
+            --portal-shadow-md:      0 4px 6px -1px rgba(0,0,0,0.4),
+                                     0 2px 4px -2px rgba(0,0,0,0.3);
+            --portal-shadow-lg:      0 12px 20px -8px rgba(0,0,0,0.5),
+                                     0 4px 8px -4px rgba(0,0,0,0.4);
+        }
+
+        /* =====================================================================
+         * Colour-blind safe palette — opt-in via [data-portal-cb="on"].
+         * Mirrors portal.css; Wong-based palette distinguishable for
+         * deutan + protan colour blindness (~95% of CB cases).
+         * =================================================================*/
+        [data-portal-cb="on"] {
+            --portal-success: #009e73;
+            --portal-danger:  #d55e00;
+            --portal-warning: #e69f00;
+        }
+        [data-portal-cb="on"][data-bs-theme="dark"] {
+            --portal-success: #5dd1a8;
+            --portal-danger:  #ff8a4d;
+            --portal-warning: #ffc04d;
+        }
+
+        /* =====================================================================
+         * Theme / accessibility toggle buttons in the installer header
+         * =================================================================*/
+        .install-toggles {
+            position: absolute;
+            top: 1rem;
+            right: 1rem;
+            display: flex;
+            gap: 0.375rem;
+        }
+        .install-toggle {
+            background: var(--portal-surface);
+            border: 1px solid var(--portal-border);
+            color: var(--portal-text-muted);
+            border-radius: var(--portal-radius-md);
+            width: 2.25rem;
+            height: 2.25rem;
+            display: inline-flex;
+            align-items: center;
+            justify-content: center;
+            cursor: pointer;
+            font-size: 1rem;
+            transition: background 120ms var(--portal-easing),
+                        color      120ms var(--portal-easing),
+                        border-color 120ms var(--portal-easing);
+        }
+        .install-toggle:hover {
+            background: var(--portal-bg);
+            color: var(--portal-text);
+            border-color: var(--portal-border-strong);
+        }
+        .install-toggle[aria-pressed="true"] {
+            color: var(--portal-primary);
+            background: var(--portal-primary-subtle);
+            border-color: var(--portal-primary);
+        }
+
+        /* =====================================================================
          * Page shell
          * =================================================================*/
         html, body { height: 100%; }
@@ -820,9 +898,52 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
             outline-offset: 2px;
         }
     </style>
+
+    <!-- 🌙 Prevent FOUC: apply saved theme + CB prefs before first paint -->
+    <script>
+    (function(){
+        var html = document.documentElement;
+        var t = localStorage.getItem('portal-theme');
+        if (t === 'auto' || t === null) {
+            var prefersDark = window.matchMedia
+                && window.matchMedia('(prefers-color-scheme: dark)').matches;
+            html.setAttribute('data-bs-theme', prefersDark ? 'dark' : 'light');
+        } else if (t === 'dark' || t === 'light') {
+            html.setAttribute('data-bs-theme', t);
+        }
+        if (localStorage.getItem('portal-cb') === 'on') {
+            html.setAttribute('data-portal-cb', 'on');
+        }
+    })();
+    </script>
 </head>
 <body>
-<div class="install-shell">
+<div class="install-shell" style="position: relative;">
+
+    <!-- 🌙 / 🎨 Theme + accessibility toggles
+         Inline SVG icons so the installer doesn't need Font Awesome loaded. -->
+    <div class="install-toggles">
+        <button type="button" class="install-toggle" id="installThemeToggle"
+                title="Theme: auto (system) — click for light"
+                aria-label="Toggle theme">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <circle cx="12" cy="12" r="9"/>
+                <path d="M12 3v18" />
+                <path d="M12 3a9 9 0 0 1 0 18 9 9 0 0 1 0-18z" fill="currentColor" opacity="0.3"/>
+            </svg>
+        </button>
+        <button type="button" class="install-toggle" id="installCbToggle"
+                title="Colour-blind safe palette: off — click to turn on"
+                aria-label="Toggle colour-blind safe palette"
+                aria-pressed="false">
+            <svg width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+                 stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true">
+                <path d="M2 12s3.5-7 10-7 10 7 10 7-3.5 7-10 7S2 12 2 12z"/>
+                <circle cx="12" cy="12" r="3"/>
+            </svg>
+        </button>
+    </div>
 
     <!-- Header -->
     <div class="install-header">
@@ -1069,5 +1190,78 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
     </div>
 
 </div>
+
+<script>
+// Theme + CB toggle wiring for the installer (standalone — doesn't load portal.js)
+(function(){
+    var html = document.documentElement;
+    var themeBtn = document.getElementById('installThemeToggle');
+    var cbBtn    = document.getElementById('installCbToggle');
+    var mql      = window.matchMedia ? window.matchMedia('(prefers-color-scheme: dark)') : null;
+
+    function savedTheme() {
+        var v = localStorage.getItem('portal-theme');
+        return (v === 'light' || v === 'dark' || v === 'auto') ? v : 'auto';
+    }
+    function applyTheme(pref) {
+        if (pref === 'auto') {
+            html.setAttribute('data-bs-theme', (mql && mql.matches) ? 'dark' : 'light');
+        } else {
+            html.setAttribute('data-bs-theme', pref);
+        }
+        updateThemeBtn(pref);
+    }
+    function updateThemeBtn(pref) {
+        if (!themeBtn) return;
+        var titles = {
+            light: 'Theme: light — click for dark',
+            dark:  'Theme: dark — click for auto',
+            auto:  'Theme: auto (system) — click for light'
+        };
+        themeBtn.setAttribute('title', titles[pref] || titles.auto);
+    }
+    function savedCb() { return localStorage.getItem('portal-cb') === 'on'; }
+    function applyCb(on) {
+        if (on) {
+            html.setAttribute('data-portal-cb', 'on');
+        } else {
+            html.removeAttribute('data-portal-cb');
+        }
+        if (cbBtn) {
+            cbBtn.setAttribute('aria-pressed', on ? 'true' : 'false');
+            cbBtn.setAttribute('title', on
+                ? 'Colour-blind safe palette: on — click to turn off'
+                : 'Colour-blind safe palette: off — click to turn on');
+        }
+    }
+
+    if (themeBtn) {
+        themeBtn.addEventListener('click', function(){
+            var cur = savedTheme();
+            var next = (cur === 'light') ? 'dark' : (cur === 'dark' ? 'auto' : 'light');
+            localStorage.setItem('portal-theme', next);
+            applyTheme(next);
+        });
+    }
+    if (cbBtn) {
+        cbBtn.addEventListener('click', function(){
+            var next = !savedCb();
+            if (next) { localStorage.setItem('portal-cb', 'on'); }
+            else      { localStorage.removeItem('portal-cb'); }
+            applyCb(next);
+        });
+    }
+    if (mql && typeof mql.addEventListener === 'function') {
+        mql.addEventListener('change', function(){
+            if (savedTheme() === 'auto') applyTheme('auto');
+        });
+    }
+
+    // Initial state — FOUC script already applied the data-* attrs; just sync the icons/titles.
+    updateThemeBtn(savedTheme());
+    applyCb(savedCb());
+})();
+</script>
+
 </body>
 </html>

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -165,6 +165,34 @@
 }
 
 /* ============================================================================
+   2.5 Colour-blind safe palette (data-portal-cb="on")
+
+   Overrides only the SEMANTIC colours (success / danger / warning / accent /
+   info) when the user opts in. Primary stays under per-site / user control
+   because the primary is meant to be the site's identity colour.
+
+   Palette is based on Wong (Nature Methods, 2011) — distinguishable for
+   the most common forms of colour blindness (deutan + protan, ~95% of
+   cases). The general rule the palette honours: avoid red/green as the
+   only differentiator. Components should also pair colour with icons or
+   text labels (handled at the component level, not the token level).
+   ============================================================================ */
+
+[data-portal-cb="on"] {
+    --portal-success: #009e73;     /* bluish-green — CB-safe */
+    --portal-danger:  #d55e00;     /* vermillion — CB-safe */
+    --portal-warning: #e69f00;     /* orange — CB-safe */
+    --portal-accent:  #56b4e9;     /* sky blue — CB-safe */
+}
+
+[data-portal-cb="on"][data-bs-theme="dark"] {
+    --portal-success: #5dd1a8;     /* lighter bluish-green for dark surfaces */
+    --portal-danger:  #ff8a4d;     /* lighter vermillion */
+    --portal-warning: #ffc04d;     /* lighter orange */
+    --portal-accent:  #7fc6f0;     /* lighter sky blue */
+}
+
+/* ============================================================================
    3. Base / Reset
    ============================================================================ */
 
@@ -544,7 +572,8 @@ textarea:focus-visible,
    14. Dark Mode Toggle Button
    ============================================================================ */
 
-.portal-theme-toggle {
+.portal-theme-toggle,
+.portal-cb-toggle {
     background: none;
     border: none;
     padding: var(--portal-spacing-sm);
@@ -556,8 +585,15 @@ textarea:focus-visible,
     transition: background-color var(--portal-transition-fast);
 }
 
-.portal-theme-toggle:hover {
+.portal-theme-toggle:hover,
+.portal-cb-toggle:hover {
     background-color: var(--portal-surface-hover);
+}
+
+/* Visual cue when CB-safe palette is active */
+.portal-cb-toggle[aria-pressed="true"] {
+    color: var(--portal-primary);
+    background-color: var(--portal-primary-subtle);
 }
 
 /* ============================================================================

--- a/web/public_html/assets/js/portal.js
+++ b/web/public_html/assets/js/portal.js
@@ -26,58 +26,137 @@
     'use strict';
 
     /**
-     * Initialise the dark mode toggle button(s).
-     * Reads the saved preference from localStorage and applies it to the
-     * document's data-bs-theme attribute. Clicking the toggle button swaps
-     * the theme and persists the choice.
+     * Initialise the theme toggle button(s).
+     *
+     * Three-state cycle: light → dark → auto → light. The actual data-bs-theme
+     * value applied to <html> is always 'light' or 'dark' — when the saved
+     * preference is 'auto' the script resolves via prefers-color-scheme and
+     * listens for system theme changes.
+     *
+     * The FOUC script in header.php applies the initial value before this
+     * runs; this function attaches click handlers and updates the icon state.
      */
     function initThemeToggle() {
         var html = document.documentElement;
-        var savedTheme = localStorage.getItem('portal-theme');
+        var mediaQuery = window.matchMedia
+            ? window.matchMedia('(prefers-color-scheme: dark)')
+            : null;
 
-        // Apply saved theme preference on load
-        if (savedTheme === 'dark' || savedTheme === 'light') {
-            html.setAttribute('data-bs-theme', savedTheme);
+        function savedPreference() {
+            var v = localStorage.getItem('portal-theme');
+            return (v === 'light' || v === 'dark' || v === 'auto') ? v : 'auto';
+        }
+        function applyAuto() {
+            var prefersDark = mediaQuery && mediaQuery.matches;
+            html.setAttribute('data-bs-theme', prefersDark ? 'dark' : 'light');
         }
 
-        // Bind click handlers to all toggle buttons
+        // When in 'auto' mode, keep the resolved theme in sync with system pref.
+        if (mediaQuery && typeof mediaQuery.addEventListener === 'function') {
+            mediaQuery.addEventListener('change', function () {
+                if (savedPreference() === 'auto') {
+                    applyAuto();
+                    updateToggleIcons(savedPreference());
+                }
+            });
+        }
+
         var toggleButtons = document.querySelectorAll('.portal-theme-toggle');
         for (var i = 0; i < toggleButtons.length; i++) {
             toggleButtons[i].addEventListener('click', function () {
-                var current = html.getAttribute('data-bs-theme') || 'light';
-                var next = (current === 'dark') ? 'light' : 'dark';
+                var current = savedPreference();
+                var next = (current === 'light')
+                    ? 'dark'
+                    : (current === 'dark' ? 'auto' : 'light');
 
-                html.setAttribute('data-bs-theme', next);
                 localStorage.setItem('portal-theme', next);
-
-                // Update toggle button icons
+                if (next === 'auto') {
+                    applyAuto();
+                } else {
+                    html.setAttribute('data-bs-theme', next);
+                }
                 updateToggleIcons(next);
             });
         }
 
-        // Set initial icon state
-        var currentTheme = html.getAttribute('data-bs-theme') || 'light';
-        updateToggleIcons(currentTheme);
+        // Set initial icon state to reflect the saved preference (not resolved)
+        updateToggleIcons(savedPreference());
     }
 
     /**
-     * Update all theme toggle button icons to reflect the current theme.
-     *
-     * @param {string} theme - Current theme ("light" or "dark")
+     * Initialise the colour-blind-safe palette toggle button(s).
+     * Two states (on / off). Persists in localStorage as 'portal-cb'.
+     * The FOUC script in header.php applies the attribute before paint.
      */
-    function updateToggleIcons(theme) {
+    function initCbToggle() {
+        var html = document.documentElement;
+        function savedCb() {
+            return localStorage.getItem('portal-cb') === 'on';
+        }
+        function apply(on) {
+            if (on) {
+                html.setAttribute('data-portal-cb', 'on');
+            } else {
+                html.removeAttribute('data-portal-cb');
+            }
+        }
+
+        var buttons = document.querySelectorAll('.portal-cb-toggle');
+        for (var i = 0; i < buttons.length; i++) {
+            buttons[i].addEventListener('click', function () {
+                var next = !savedCb();
+                if (next) {
+                    localStorage.setItem('portal-cb', 'on');
+                } else {
+                    localStorage.removeItem('portal-cb');
+                }
+                apply(next);
+                updateCbIcons(next);
+            });
+        }
+        updateCbIcons(savedCb());
+    }
+
+    /**
+     * Update theme toggle icons + aria labels to reflect the saved preference.
+     * Saved preference is one of: 'light', 'dark', 'auto'.
+     *
+     * @param {string} preference - Saved theme preference (not the resolved value)
+     */
+    function updateToggleIcons(preference) {
         var toggleButtons = document.querySelectorAll('.portal-theme-toggle');
         for (var i = 0; i < toggleButtons.length; i++) {
             var icon = toggleButtons[i].querySelector('i');
             if (icon) {
-                if (theme === 'dark') {
-                    icon.className = 'fa-solid fa-sun';
-                    toggleButtons[i].setAttribute('title', 'Switch to light mode');
-                } else {
+                if (preference === 'dark') {
                     icon.className = 'fa-solid fa-moon';
-                    toggleButtons[i].setAttribute('title', 'Switch to dark mode');
+                    toggleButtons[i].setAttribute('title', 'Theme: dark — click for auto');
+                } else if (preference === 'auto') {
+                    icon.className = 'fa-solid fa-circle-half-stroke';
+                    toggleButtons[i].setAttribute('title', 'Theme: auto (system) — click for light');
+                } else {
+                    icon.className = 'fa-solid fa-sun';
+                    toggleButtons[i].setAttribute('title', 'Theme: light — click for dark');
                 }
             }
+        }
+    }
+
+    /**
+     * Update CB toggle icons + aria labels to reflect the current state.
+     *
+     * @param {boolean} on - Whether CB-safe mode is enabled
+     */
+    function updateCbIcons(on) {
+        var buttons = document.querySelectorAll('.portal-cb-toggle');
+        for (var i = 0; i < buttons.length; i++) {
+            buttons[i].setAttribute('aria-pressed', on ? 'true' : 'false');
+            buttons[i].setAttribute(
+                'title',
+                on
+                    ? 'Colour-blind safe palette: on — click to turn off'
+                    : 'Colour-blind safe palette: off — click to turn on'
+            );
         }
     }
 
@@ -276,10 +355,12 @@
     if (document.readyState === 'loading') {
         document.addEventListener('DOMContentLoaded', function () {
             initThemeToggle();
+            initCbToggle();
             initDropzones();
         });
     } else {
         initThemeToggle();
+        initCbToggle();
         initDropzones();
     }
 


### PR DESCRIPTION
## Summary

Per your request: ensure light + dark + system-auto theme modes AND a colour-blind safe palette are supported across BOTH the main UI and the standalone installer.

## What was already there vs. what this PR adds

| Feature | Status before | This PR |
|---|---|---|
| Light theme | ✅ exists | — |
| Dark theme (manual toggle) | ✅ exists (portal.css + portal.js) | — |
| **Auto mode** (follows OS) | ❌ missing | **adds 3-state cycle: light → dark → auto** |
| **Colour-blind safe palette** | ❌ missing | **opt-in via `data-portal-cb="on"`, Wong-based palette for deutan+protan (~95% of CB cases)** |
| **Installer parity** | ❌ standalone, no theme support | **mirrors all of the above inline** |

## How it works

### Theme cycle (3 states)

Click the half-stroke circle icon in the navbar to cycle:

```text
light  →  dark  →  auto  →  light  →  …
```

In `auto` mode the FOUC script reads `prefers-color-scheme` and portal.js subscribes to OS theme changes — so if you flip your OS dark/light, the portal follows live without a refresh.

Persisted as `localStorage.portal-theme` = `light` / `dark` / `auto`. Missing key defaults to `auto`.

### Colour-blind safe palette

Click the eye icon next to the theme toggle. Toggle is on/off.

When **on**, only the SEMANTIC tokens swap (not the primary — that's the site's identity colour):

- `--portal-success`: green → bluish-green (`#009e73`)
- `--portal-danger`:  red → vermillion (`#d55e00`)
- `--portal-warning`: amber → orange (`#e69f00`)
- `--portal-accent`:  cyan → sky-blue (`#56b4e9`)

Palette is from Wong (Nature Methods, 2011), widely cited as deutan + protan safe. Dark-mode variants are brightened equivalents.

**Important accessibility caveat:** the CB palette reduces colour confusion but **doesn't replace** non-colour cues. Components that convey state (badges, alerts, validation) should also use icons or text labels — that's a component-level concern (covered by the security checklist on the PR template).

### Installer parity

`/install/` mirrors all of the above. Top-right of the installer header has the same two toggle buttons (using inline SVG icons since the installer doesn't load Font Awesome). FOUC script, dark-mode tokens, and CB-safe tokens are all inlined in the `<style>` and `<script>` blocks since the installer runs standalone before `bootstrap.php`.

## Files

```text
web/public_html/assets/css/portal.css   (+CB-safe blocks, .portal-cb-toggle styling)
web/public_html/assets/js/portal.js     (3-state cycle, initCbToggle, listener)
web/core/templates/header.php           (FOUC script — auto + CB)
web/core/templates/nav.php              (CB toggle button, theme toggle icon updated)
web/install/index.php                   (dark + CB token blocks, FOUC script, toggles, JS)
DEV_NOTES.md                            (new "Theme modes + colour-blind palette" section)
```

## Test plan

After merge + auto-deploy:

- [ ] Visit a portal page. Default state should be auto-mode (follow system).
- [ ] Click the half-stroke icon → cycles to light. Click again → dark. Click again → auto. Click again → light.
- [ ] In auto mode, flip your OS dark/light setting — portal updates without refresh.
- [ ] Click the eye icon → tints active (indigo bg). Reload the page — CB palette persists.
- [ ] Click eye icon again → CB palette off, button untints.
- [ ] Visit `/install/?step=2` — both toggles in top-right. Same behaviour. Card + form + buttons should remain polished in both themes + with/without CB.
- [ ] Open in a browser that doesn't support `color-mix()` (e.g. Safari <16.2) — primary token still works via the hex fallbacks in `:root` (this is PR #116 territory; mentioning in case CB-safe colours look subtly different on old browsers).
- [ ] LocalStorage values: `portal-theme` and `portal-cb` set/removed correctly.

## Sequence

PR 2.5 follows PR 2 (#116). Either can merge first; they touch overlapping files but the changes don't conflict semantically (PR 2 adds `@supports color-mix` block + PR 2.5 adds the CB block; PR 2's header.php inline-style change doesn't conflict with PR 2.5's FOUC script update).

If PR 2 merges first, this PR may need a trivial rebase.

Refs #111