### PR TITLE
feat(ui): PR 3 — navbar + top chrome polish

### DIFF
--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -265,29 +265,134 @@ textarea:focus-visible,
    5. Navbar Enhancements
    ============================================================================ */
 
+/* ----- Navbar shell ----- */
 .portal-navbar {
-    box-shadow: var(--portal-shadow-sm);
+    background-color: var(--portal-surface) !important; /* override Bootstrap's bg-body-tertiary */
     border-bottom: 1px solid var(--portal-border);
+    box-shadow: var(--portal-shadow-xs);
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+    /* Sticky-friendly backdrop for when pages opt into position: sticky later */
+    -webkit-backdrop-filter: saturate(180%) blur(8px);
+    backdrop-filter: saturate(180%) blur(8px);
 }
 
+/* ----- Brand (logo + wordmark) ----- */
 .portal-navbar .navbar-brand {
     font-weight: 600;
-    letter-spacing: -0.025em;
+    letter-spacing: -0.015em;
+    color: var(--portal-text);
+    transition: opacity var(--portal-transition-fast);
 }
-
-.portal-navbar .nav-link {
-    transition: color var(--portal-transition-fast),
-                background-color var(--portal-transition-fast);
+.portal-navbar .navbar-brand:hover { opacity: 0.85; }
+.portal-navbar .navbar-brand img {
     border-radius: var(--portal-radius-sm);
-    padding: 0.4rem 0.75rem;
 }
 
+/* ----- Primary nav links ----- */
+.portal-navbar .nav-link {
+    color: var(--portal-text-muted);
+    font-weight: 500;
+    border-radius: var(--portal-radius-sm);
+    padding: 0.4375rem 0.75rem;
+    transition: color           var(--portal-transition-fast),
+                background-color var(--portal-transition-fast);
+}
 .portal-navbar .nav-link:hover {
+    color: var(--portal-text);
     background-color: var(--portal-surface-hover);
 }
-
 .portal-navbar .nav-link.active {
+    color: var(--portal-primary);
+    background-color: var(--portal-primary-subtle);
     font-weight: 600;
+}
+
+/* ----- Avatar dropdown trigger ----- */
+.portal-navbar .dropdown-toggle {
+    color: var(--portal-text);
+    padding: 0.25rem 0.5rem;
+    border-radius: var(--portal-radius-sm);
+    transition: background-color var(--portal-transition-fast);
+}
+.portal-navbar .dropdown-toggle:hover {
+    background-color: var(--portal-surface-hover);
+}
+.portal-navbar .dropdown-toggle::after {
+    color: var(--portal-text-muted);
+    margin-left: 0.375rem;
+}
+
+/* Tighten the avatar treatment when it lives inside the navbar */
+.portal-navbar .portal-avatar {
+    transition: box-shadow var(--portal-transition-fast),
+                border-color var(--portal-transition-fast);
+}
+.portal-navbar .dropdown-toggle:hover .portal-avatar,
+.portal-navbar .dropdown-toggle[aria-expanded="true"] .portal-avatar {
+    border-color: var(--portal-primary);
+    box-shadow: 0 0 0 2px rgba(var(--portal-primary-rgb), 0.18);
+}
+
+/* ----- Dropdown menus (user + multi-site switcher) ----- */
+.portal-navbar .dropdown-menu {
+    background-color: var(--portal-surface);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-md);
+    box-shadow: var(--portal-shadow-lg);
+    padding: 0.375rem;
+    min-width: 12rem;
+    font-size: var(--portal-font-size-sm);
+}
+.portal-navbar .dropdown-item {
+    color: var(--portal-text);
+    padding: 0.5rem 0.6875rem;
+    border-radius: var(--portal-radius-sm);
+    transition: background-color var(--portal-transition-fast),
+                color            var(--portal-transition-fast);
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+}
+.portal-navbar .dropdown-item i,
+.portal-navbar .dropdown-item .fa-solid,
+.portal-navbar .dropdown-item .fa-regular {
+    width: 1rem;                /* fixed-width so labels line up */
+    text-align: center;
+    color: var(--portal-text-muted);
+    transition: color var(--portal-transition-fast);
+}
+.portal-navbar .dropdown-item:hover,
+.portal-navbar .dropdown-item:focus {
+    background-color: var(--portal-primary-subtle);
+    color: var(--portal-primary);
+}
+.portal-navbar .dropdown-item:hover i,
+.portal-navbar .dropdown-item:focus i {
+    color: var(--portal-primary);
+}
+.portal-navbar .dropdown-item.active {
+    background-color: var(--portal-primary);
+    color: var(--portal-text-on-primary);
+}
+.portal-navbar .dropdown-item.active i { color: var(--portal-text-on-primary); }
+.portal-navbar .dropdown-item-text {
+    padding: 0.5rem 0.6875rem;
+    color: var(--portal-text-muted);
+}
+.portal-navbar .dropdown-divider {
+    border-color: var(--portal-border);
+    margin: 0.375rem 0;
+}
+
+/* ----- Mobile menu collapse ----- */
+@media (max-width: 991.98px) {
+    .portal-navbar .navbar-collapse {
+        margin-top: 0.625rem;
+        padding-top: 0.5rem;
+        border-top: 1px solid var(--portal-border);
+    }
+    .portal-navbar .navbar-nav .nav-link { padding-block: 0.625rem; }
 }
 
 /* ============================================================================


### PR DESCRIPTION
## Summary

PR 3 of the UI refresh (#111). **CSS-only** polish for the navbar and its dropdowns. No markup changes — all existing class hooks (`.portal-navbar`, `.nav-link`, `.dropdown-menu`, `.dropdown-item`, `.portal-avatar`) just get a richer ruleset.

## Files

```text
web/public_html/assets/css/portal.css   (119 lines added, 7 removed)
```

## What you'll see

### Navbar shell
- Background explicitly uses `--portal-surface` (overrides Bootstrap's `bg-body-tertiary`)
- Backdrop-filter saturate+blur for translucent feel (forward-compatible with sticky nav if added later)
- Refined softer shadow (`--portal-shadow-xs`)
- Slightly more vertical padding for better visual weight

### Brand (logo + wordmark)
- Tighter but not crushing letter-spacing
- Subtle opacity fade on hover
- Logo gets 6px radius so it pairs with rounded UI

### Primary nav links
**Biggest visible change:** the active state is now genuinely distinctive — was just `font-weight: 600`, now it's `--portal-primary` text colour on a `--portal-primary-subtle` background. The active section becomes obvious at a glance.

Hover: subtle muted-to-strong text shift + light bg.

### User avatar dropdown trigger
- Subtle hover background on the whole trigger area
- **Avatar gets a primary-tinted ring** on hover and when the dropdown is open — uses `--portal-primary-rgb` so it shifts with the per-site brand colour
- Caret refined to muted colour

### Dropdown menu (user + multi-site switcher)
- Layered Stripe-style shadow (was Bootstrap default)
- 8px radius matches inputs/badges
- Items: 8px padding, 6px radius
- **Hover/focus on item:** primary-subtle bg + primary text colour
- Item icons have a fixed 1rem width so labels line up regardless of icon
- 14px font (more refined for a tight dropdown menu)

### Mobile
- Collapsed nav gets a top border + padding so it visually separates from the navbar shell on phones
- Nav links use ~10px vertical padding for proper tap targets

## Test plan

- [ ] Auto-deploy fires on merge (touches `web/**`)
- [ ] Navigate the portal — the active section is now visibly highlighted (indigo bg + text), not just bold
- [ ] Hover items in the user dropdown — they tint with the primary subtle bg + primary text
- [ ] Open the user dropdown — avatar gains a primary ring while expanded
- [ ] Switch theme: light → dark — every effect above stays readable (uses tokens, not literals)
- [ ] Switch CB mode on/off — primary stays the site's primary; nothing in this PR is a semantic colour
- [ ] If you have multiple sites configured: open the multi-site switcher dropdown — same polished item styling
- [ ] Mobile (narrow viewport): toggle the hamburger — collapsed menu has a clean separator above it; tap targets feel right

## Sequence

PR 3 of #111. Coming next:

- **PR 4** — Forms + portal-data-list / portal-data-row polish across the app
- **PR 5** — Dashboard hero + app card grid
- **PR 6** — Final polish pass + dark-mode component audit

Refs #111