### PR TITLE
feat(ui): PR 5 — dashboard hero + polished stat widgets + app card grid

### DIFF
--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -1230,3 +1230,132 @@ body.d-flex.vh-100 > .card h1 {
     background-color: rgba(6, 182, 212, 0.12);  /* derived from --portal-accent */
     color: #155e75;
 }
+
+/* ============================================================================
+   PR 5 — Dashboard hero + stat widgets + app card grid
+
+   The dashboard becomes the actual landing experience: a greeting hero at
+   the top, polished stat widgets below, then the app card grid as the main
+   call-to-action region.
+
+   Scoped via .portal-dashboard-hero + .app-card. The stat widgets pick up
+   polish via the global .card.border-* override used by the existing
+   markup (dashboard/index.php uses Bootstrap's border-color utility, e.g.
+   <div class="card border-primary">).
+   ============================================================================ */
+
+/* ----- Hero ----- */
+.portal-dashboard-hero {
+    padding: 0;
+}
+.portal-dashboard-hero-eyebrow {
+    margin: 0;
+    text-transform: uppercase;
+    letter-spacing: 0.08em;
+    font-size: var(--portal-font-size-xs);
+    font-weight: var(--portal-font-weight-medium);
+    color: var(--portal-text-muted);
+}
+.portal-dashboard-hero-title {
+    margin: 0.375rem 0 0.25rem;
+    font-size: var(--portal-font-size-3xl);
+    font-weight: var(--portal-font-weight-bold);
+    line-height: 1.2;
+    letter-spacing: var(--portal-letter-spacing-tight);
+    color: var(--portal-text);
+}
+.portal-dashboard-hero-subtitle {
+    margin: 0;
+    font-size: var(--portal-font-size-lg);
+    color: var(--portal-text-muted);
+    line-height: 1.5;
+}
+@media (max-width: 575.98px) {
+    .portal-dashboard-hero-title { font-size: var(--portal-font-size-2xl); }
+    .portal-dashboard-hero-subtitle { font-size: var(--portal-font-size-base); }
+}
+
+/* ----- Stat widgets (Bootstrap .card.border-* markup in dashboard) -----
+   The dashboard uses `border-primary | border-success | border-warning |
+   border-info` Bootstrap utilities for the stat-widget cards. Override the
+   semantic Bootstrap utility colours with the design tokens so the widgets
+   match the rest of the portal AND shift correctly under CB-safe mode. */
+.card.border-primary { border-color: var(--portal-primary) !important; }
+.card.border-success { border-color: var(--portal-success) !important; }
+.card.border-warning { border-color: var(--portal-warning) !important; }
+.card.border-info    { border-color: var(--portal-accent)  !important; }
+.card.border-danger  { border-color: var(--portal-danger)  !important; }
+
+.text-primary, .text-bg-primary { color: var(--portal-primary) !important; }
+.text-success { color: var(--portal-success) !important; }
+.text-warning { color: var(--portal-warning) !important; }
+.text-info    { color: var(--portal-accent)  !important; }
+.text-danger  { color: var(--portal-danger)  !important; }
+
+/* Stat widget row (the .row.g-3 immediately following the hero — anchor on
+   the markup pattern without requiring a new class). */
+.portal-dashboard-hero + .row .card {
+    border-width: 1px;
+    border-left-width: 4px;
+    border-radius: var(--portal-radius-md);
+    transition: transform var(--portal-transition-fast),
+                box-shadow var(--portal-transition-fast);
+}
+.portal-dashboard-hero + .row a:hover .card,
+.portal-dashboard-hero + .row a:focus .card {
+    transform: translateY(-2px);
+    box-shadow: var(--portal-shadow-md);
+}
+.portal-dashboard-hero + .row .card .h4 {
+    font-size: var(--portal-font-size-2xl);
+    font-weight: var(--portal-font-weight-bold);
+    color: var(--portal-text);
+    line-height: 1;
+    margin: 0 0 0.125rem;
+}
+.portal-dashboard-hero + .row .card small {
+    color: var(--portal-text-muted);
+    font-size: var(--portal-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    font-weight: var(--portal-font-weight-medium);
+}
+
+/* ----- App card grid (the existing .app-card class used in dashboard) -----
+   Replaces the trailing inline <style> block previously in dashboard/index.php
+   with proper tokens + a richer hover treatment. */
+.app-card {
+    border: 1px solid var(--portal-border) !important;
+    border-radius: var(--portal-radius-lg);
+    background-color: var(--portal-surface);
+    box-shadow: var(--portal-shadow-xs);
+    transition: transform var(--portal-transition-fast),
+                box-shadow var(--portal-transition-fast),
+                border-color var(--portal-transition-fast);
+    overflow: hidden;
+}
+.app-card .card-body {
+    padding: 1.5rem 1rem;
+}
+.app-card .card-title {
+    color: var(--portal-text);
+    font-weight: var(--portal-font-weight-bold);
+    font-size: var(--portal-font-size-base);
+    letter-spacing: var(--portal-letter-spacing-tight);
+}
+/* The link wrapping an app card */
+a:hover > .app-card,
+a:focus > .app-card {
+    transform: translateY(-3px);
+    box-shadow: var(--portal-shadow-md);
+    border-color: var(--portal-primary) !important;
+}
+/* The brand-coloured border-top sits at top of each .app-card via inline
+   style on the markup (border-top:4px solid <color>). We've now widened
+   border to 1px elsewhere, so refine the inline-styled top to read as a
+   deliberate accent rather than a slab. */
+.app-card[style*="border-top"] {
+    /* inline border-top wins; just ensure radius doesn't crop it */
+    border-top-left-radius: var(--portal-radius-lg);
+    border-top-right-radius: var(--portal-radius-lg);
+}

--- a/web/public_html/dashboard/index.php
+++ b/web/public_html/dashboard/index.php
@@ -179,9 +179,39 @@ if ($pnStmt !== false) {
     $pnStmt->close();
 }
 
+// 🌅 Build greeting for the hero. UK-style "Good morning/afternoon/evening".
+$hour = (int) date('G');
+if ($hour < 12) {
+    $greeting = 'Good morning';
+} elseif ($hour < 17) {
+    $greeting = 'Good afternoon';
+} elseif ($hour < 22) {
+    $greeting = 'Good evening';
+} else {
+    $greeting = 'Hello';
+}
+$userFirstName = $_SESSION['user_name'] ?? 'there';
+// First word of the full name — friendlier than "Lance Manasse" in a greeting
+$userFirstName = preg_split('/\s+/', trim($userFirstName), 2)[0] ?? 'there';
+$heroSiteName  = Site::branding('name') ?? ($SETTINGS['site']['name'] ?? 'Portal');
+$todayDate     = date('l, j F Y');
+
 // 📄 Include shared header template (DOCTYPE, <head>, navbar, breadcrumbs)
 require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
 ?>
+
+<!-- 🌅 Dashboard Hero -->
+<section class="portal-dashboard-hero mb-4">
+    <p class="portal-dashboard-hero-eyebrow">
+        <?php echo htmlspecialchars($todayDate, ENT_QUOTES, 'UTF-8'); ?>
+    </p>
+    <h1 class="portal-dashboard-hero-title">
+        <?php echo htmlspecialchars($greeting . ', ' . $userFirstName, ENT_QUOTES, 'UTF-8'); ?>
+    </h1>
+    <p class="portal-dashboard-hero-subtitle">
+        Welcome to <?php echo htmlspecialchars($heroSiteName, ENT_QUOTES, 'UTF-8'); ?>.
+    </p>
+</section>
 
 <!-- 📊 Stat Widgets -->
 <?php if (count($widgets) > 0): ?>
@@ -246,11 +276,6 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
         </div>
     <?php endforeach; ?>
 </div>
-
-<style>
-    .app-card { transition: transform .1s; }
-    .app-card:hover { transform: translateY(-4px); }
-</style>
 
 <?php
 // 📄 Include shared footer template (close container, footer bar, JS, debug panel)


### PR DESCRIPTION
## Summary

PR 5 of the UI refresh (#111). Turns the dashboard into the actual landing experience — a greeting hero at the top, polished stat widgets, and a refined app-card grid.

## Files

```text
web/public_html/dashboard/index.php   (+27 -3 — hero markup, inline <style> removed)
web/public_html/assets/css/portal.css (+129 lines — hero/widget/app-card polish)
```

## What you'll see

### 🌅 New hero greeting (top of dashboard)

```text
TUESDAY, 22 MAY 2026                    ← eyebrow (uppercase, tracked, muted)

Good afternoon, Lance                    ← display-size, semi-bold, tight tracking

Welcome to Mill Rd SDA Cambridge.        ← subtitle, large, muted
```

- Greeting: time-of-day aware (morning/afternoon/evening/late-night fallback)
- First-name only (friendlier than "Lance Manasse")
- Site name from `Site::branding('name')` — so each site sees its own
- Date in UK long format
- Responsive: drops from 30px → 24px on phones

### 📊 Stat widgets (Pending claims / Events / Active users / 24h activity)

The dashboard's existing widget cards use `border-primary` / `border-success` / `border-warning` / `border-info` Bootstrap utilities. This PR:

- **Maps those utilities to the design tokens** — so the colours match the rest of the portal AND shift correctly in CB-safe mode (no hard-coded Bootstrap blue/green/yellow anywhere)
- **4px brand-coloured left border** + 1px regular border on the other sides — gives each widget a clean accent without dominating the row
- **Hover lift**: -2px translate + layered shadow when the link is hovered/focused
- Stat number uses 24px bold; label is uppercase tracked muted

### 🎴 App card grid

The existing `.app-card` class previously had a 4-line inline `<style>` block. Now properly styled:

- Token-driven surface + border + large 12px radius
- Subtle base shadow
- **Hover: -3px translate, layered shadow, primary-coloured border** (was just a 4px transform)
- Card title gets bold + tight letter-spacing
- Per-app brand accent via inline `border-top:4px` still works — the radius harmonises with it

## Test plan

After merge + auto-deploy:

- [ ] Visit `/` (dashboard) — hero greeting appears at top
- [ ] Time-of-day check: morning/afternoon/evening greeting matches your local hour
- [ ] Stat widgets: subtle left-border accent in brand colour, lift on hover
- [ ] App cards: lift + primary border accent on hover
- [ ] Dark mode: everything still reads cleanly (tokens, not hard-coded colours)
- [ ] CB-safe on: stat widget colours shift to the CB palette (the `text-success` widgets go from green → teal etc.)
- [ ] Mobile (narrow viewport): hero title drops in size; widgets stack 2-up; app cards stack
- [ ] Per-site brand: change a site's `primaryColor` to red — app card hover accent + primary stat widget shift to red

## Sequence

PR 5 of 6. **One PR left:**

- **PR 6** — Final polish pass + dark-mode audit across every component (catches token leftovers, refines micro-interactions, verifies contrast, checks every screen for stragglers)

Refs #111