### PR TITLE
feat(ui): PR 6 — final polish + dark-mode audit across components

### DIFF
--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -1232,6 +1232,233 @@ body.d-flex.vh-100 > .card h1 {
 }
 
 /* ============================================================================
+   PR 6 — Final polish + component sweep
+
+   Picks up the Bootstrap components the earlier PRs didn't touch: tables,
+   modals, pagination, list-group, progress, spinner, tooltip. Also refines
+   breadcrumbs / footer / dropzone with the design tokens. Each rule lifts
+   the component in light AND dark mode (dark-mode-specific overrides where
+   the token cascade alone isn't enough).
+   ============================================================================ */
+
+/* ----- Tables ----- */
+.table {
+    --bs-table-bg: var(--portal-surface);
+    --bs-table-color: var(--portal-text);
+    --bs-table-border-color: var(--portal-border);
+    --bs-table-hover-bg: var(--portal-surface-hover);
+    --bs-table-hover-color: var(--portal-text);
+    --bs-table-striped-bg: var(--portal-bg);
+    --bs-table-striped-color: var(--portal-text);
+    color: var(--portal-text);
+    border-color: var(--portal-border);
+}
+.table > :not(caption) > * > * {
+    background-color: transparent;
+    border-bottom-color: var(--portal-border);
+    color: inherit;
+}
+.table thead th {
+    color: var(--portal-text-muted);
+    font-weight: var(--portal-font-weight-bold);
+    font-size: var(--portal-font-size-xs);
+    text-transform: uppercase;
+    letter-spacing: 0.04em;
+    border-bottom: 1px solid var(--portal-border);
+    padding-top: 0.625rem;
+    padding-bottom: 0.625rem;
+    background-color: var(--portal-bg);
+}
+.table tbody td {
+    padding: 0.6875rem 0.75rem;
+    vertical-align: middle;
+}
+.table-hover tbody tr:hover {
+    background-color: var(--portal-primary-subtle);
+}
+
+/* ----- Modals ----- */
+.modal-content {
+    background-color: var(--portal-surface);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-lg);
+    box-shadow: var(--portal-shadow-xl);
+}
+.modal-header {
+    background-color: var(--portal-surface);
+    border-bottom: 1px solid var(--portal-border);
+    padding: 1rem 1.25rem;
+}
+.modal-title {
+    font-weight: var(--portal-font-weight-bold);
+    letter-spacing: var(--portal-letter-spacing-tight);
+    color: var(--portal-text);
+}
+.modal-body { padding: 1.25rem; }
+.modal-footer {
+    background-color: var(--portal-surface);
+    border-top: 1px solid var(--portal-border);
+    padding: 0.875rem 1.25rem;
+}
+.modal-backdrop.show { opacity: 0.45; }
+
+/* ----- Pagination ----- */
+.pagination {
+    --bs-pagination-color: var(--portal-text);
+    --bs-pagination-bg: var(--portal-surface);
+    --bs-pagination-border-color: var(--portal-border);
+    --bs-pagination-hover-color: var(--portal-primary);
+    --bs-pagination-hover-bg: var(--portal-primary-subtle);
+    --bs-pagination-hover-border-color: var(--portal-border-strong);
+    --bs-pagination-focus-color: var(--portal-primary);
+    --bs-pagination-focus-bg: var(--portal-primary-subtle);
+    --bs-pagination-focus-box-shadow: 0 0 0 3px rgba(var(--portal-primary-rgb), 0.18);
+    --bs-pagination-active-color: var(--portal-text-on-primary);
+    --bs-pagination-active-bg: var(--portal-primary);
+    --bs-pagination-active-border-color: var(--portal-primary);
+    --bs-pagination-disabled-color: var(--portal-text-subtle);
+    --bs-pagination-disabled-bg: var(--portal-surface);
+    --bs-pagination-disabled-border-color: var(--portal-border);
+}
+.page-link {
+    transition: background-color var(--portal-transition-fast),
+                color var(--portal-transition-fast),
+                border-color var(--portal-transition-fast);
+}
+
+/* ----- List group ----- */
+.list-group {
+    --bs-list-group-bg: var(--portal-surface);
+    --bs-list-group-color: var(--portal-text);
+    --bs-list-group-border-color: var(--portal-border);
+    --bs-list-group-action-hover-bg: var(--portal-surface-hover);
+    --bs-list-group-action-hover-color: var(--portal-text);
+    --bs-list-group-action-active-color: var(--portal-text);
+    --bs-list-group-action-active-bg: var(--portal-primary-subtle);
+    --bs-list-group-active-color: var(--portal-text-on-primary);
+    --bs-list-group-active-bg: var(--portal-primary);
+    --bs-list-group-active-border-color: var(--portal-primary);
+    border-radius: var(--portal-radius-md);
+}
+.list-group-item {
+    padding: 0.75rem 1rem;
+    transition: background-color var(--portal-transition-fast),
+                color var(--portal-transition-fast);
+}
+
+/* ----- Progress bars ----- */
+.progress {
+    background-color: var(--portal-surface-hover);
+    border-radius: var(--portal-radius-sm);
+    height: 0.5rem;
+    overflow: hidden;
+}
+.progress-bar {
+    background-color: var(--portal-primary);
+    transition: width var(--portal-transition-slow);
+}
+.progress-bar.bg-success { background-color: var(--portal-success) !important; }
+.progress-bar.bg-warning { background-color: var(--portal-warning) !important; }
+.progress-bar.bg-danger  { background-color: var(--portal-danger)  !important; }
+.progress-bar.bg-info    { background-color: var(--portal-accent)  !important; }
+
+/* ----- Spinners (Bootstrap .spinner-border) ----- */
+.spinner-border { color: var(--portal-primary); }
+.spinner-border.text-success { color: var(--portal-success) !important; }
+.spinner-border.text-danger  { color: var(--portal-danger)  !important; }
+.spinner-border.text-warning { color: var(--portal-warning) !important; }
+
+/* ----- Tooltips ----- */
+.tooltip {
+    --bs-tooltip-bg: var(--portal-text);
+    --bs-tooltip-color: var(--portal-bg);
+    --bs-tooltip-border-radius: var(--portal-radius-sm);
+    --bs-tooltip-padding-x: 0.5rem;
+    --bs-tooltip-padding-y: 0.375rem;
+    --bs-tooltip-font-size: var(--portal-font-size-xs);
+}
+
+/* ----- Breadcrumb polish ----- */
+.portal-breadcrumb .breadcrumb {
+    background-color: transparent;
+    padding: 0;
+    margin: 0;
+}
+.portal-breadcrumb .breadcrumb-item + .breadcrumb-item::before {
+    content: "›";       /* prettier chevron than the default slash */
+    color: var(--portal-text-subtle);
+    font-weight: 400;
+    padding-inline: 0.4rem;
+}
+.portal-breadcrumb .breadcrumb-item a {
+    color: var(--portal-text-muted);
+    text-decoration: none;
+    transition: color var(--portal-transition-fast);
+}
+.portal-breadcrumb .breadcrumb-item a:hover { color: var(--portal-primary); }
+.portal-breadcrumb .breadcrumb-item.active {
+    color: var(--portal-text);
+    font-weight: var(--portal-font-weight-medium);
+}
+
+/* ----- Footer polish ----- */
+.portal-footer {
+    box-shadow: 0 -1px 0 var(--portal-border);
+    border-top: 0;       /* shadow replaces the previous border */
+    padding: var(--portal-spacing-lg) 0;
+}
+.portal-footer a {
+    color: var(--portal-text-muted);
+    text-decoration: none;
+    transition: color var(--portal-transition-fast);
+}
+.portal-footer a:hover { color: var(--portal-primary); }
+
+/* ----- Dropzone refinement ----- */
+.portal-dropzone:hover,
+.portal-dropzone.dragover {
+    background-color: var(--portal-primary-subtle);
+}
+.portal-dropzone-icon {
+    color: var(--portal-text-subtle);
+    opacity: 1;          /* was 0.5 — token gives proper dark-mode handling */
+}
+
+/* ----- Focus rings (sweep) -----
+   Use the --portal-shadow-focus token for buttons so focus reads correctly
+   in both light + dark mode (the token has dark-mode overrides). */
+.btn:focus-visible { box-shadow: var(--portal-shadow-focus); }
+
+/* ============================================================================
+   PR 6 — Dark-mode overrides for components that need extra polish
+   ============================================================================ */
+
+[data-bs-theme="dark"] .table thead th {
+    background-color: var(--portal-bg);
+    color: var(--portal-text-muted);
+}
+[data-bs-theme="dark"] .modal-content {
+    box-shadow: 0 24px 48px -12px rgba(0, 0, 0, 0.6),
+                0 8px 16px -6px rgba(0, 0, 0, 0.4);
+}
+[data-bs-theme="dark"] .progress { background-color: var(--portal-surface-hover); }
+
+/* Dark-mode badge variants — the light-mode tints don't read on dark.
+   Use slightly lighter text + alpha-blended bg derived from the same hue. */
+[data-bs-theme="dark"] .portal-badge-pending {
+    background-color: rgba(217, 119, 6, 0.22); color: #fde68a;
+}
+[data-bs-theme="dark"] .portal-badge-approved {
+    background-color: rgba(22, 163, 74, 0.22); color: #bbf7d0;
+}
+[data-bs-theme="dark"] .portal-badge-rejected {
+    background-color: rgba(220, 38, 38, 0.22); color: #fecaca;
+}
+[data-bs-theme="dark"] .portal-badge-paid {
+    background-color: rgba(6, 182, 212, 0.22); color: #a5f3fc;
+}
+
+/* ============================================================================
    PR 5 — Dashboard hero + stat widgets + app card grid
 
    The dashboard becomes the actual landing experience: a greeting hero at


### PR DESCRIPTION
## Summary

The **closing PR** of the UI refresh (#111). Picks up the Bootstrap components the earlier PRs didn't touch and refines a few details that were almost-there. CSS-only — no markup changes.

## Files

```text
web/public_html/assets/css/portal.css   (+227 lines)
```

## Components newly polished

| Component | Why it matters |
|---|---|
| **Tables** | Used heavily in admin (activity log, error log, user management). Now token-driven with uppercase tracked headers + branded row hover. |
| **Modals** | The `/admin/sites/` New/Edit modal + any future modal. Token-driven surface, 12px radius, layered shadow. |
| **Pagination** | Long lists get a properly-branded pager. Primary on active, primary-subtle on hover/focus. |
| **List group** | Used in various admin/settings pages. Tokens + branded hover/active. |
| **Progress bars** | Migration runner, upload progress. Token-driven; semantic colour variants. |
| **Spinners** | Loading states. Default colour follows brand primary. |
| **Tooltips** | High-contrast tooltip that flips light/dark with the theme. |

## Components refined

| Component | Change |
|---|---|
| **Breadcrumb** | Typographic chevron `›` separator (was a slash). Link/active treatment with tokens. |
| **Footer** | Inset top-shadow instead of a hard border line. Primary-on-hover links. |
| **Dropzone** | Hover bg uses `--portal-primary-subtle` (proper dark-mode reading). Icon colour uses `--portal-text-subtle` instead of opacity. |
| **Focus rings on buttons** | Now use `--portal-shadow-focus` token which has dark-mode overrides built in. |

## Dark-mode audit additions

Explicit `[data-bs-theme="dark"]` overrides added for:

- Table header backgrounds (the bg-tint reads differently in dark)
- Modal shadows (heavier dark shadows so the modal lifts off the page bg)
- Progress bar tracks
- All four portal-badge variants (light-mode tints don't read on dark — used alpha-blended bg + lighter text colours per status)

## Test plan

After merge + auto-deploy:

- [ ] `/admin/users` or `/admin/activity` — table rows look polished, header is uppercase tracked, row hover tints indigo
- [ ] `/admin/sites` New/Edit modal — opens with proper rounded corners, layered shadow, token-driven palette
- [ ] Breadcrumbs (anywhere) — separator is `›` not `/`
- [ ] Page footer — soft inset shadow, hover-tinted links
- [ ] Migration runner (if you have one with a progress bar) — bar reads as indigo, semantic variants if used
- [ ] Toggle dark mode — every refinement above stays readable; modals lift correctly; badges read clearly
- [ ] Toggle CB-safe — semantic table/progress/badge colours shift to the CB palette via the tokens

## End of the UI refresh sequence

After this merges:

```text
✓ PR 1 (#114)  design tokens refresh + installer styling
✓ PR 2 (#116)  per-site branding into CSS tokens
✓ PR 2.5 (#117) system-auto theme + colour-blind safe palette + installer parity
✓ PR 3 (#118)  navbar + top chrome polish
✓ PR 4 (#119)  forms / cards / alerts / buttons + data-list polish
✓ PR 5 (#120)  dashboard hero + stat widgets + app card grid
✓ PR 6 (this)  final polish + dark-mode audit across components
```

Six PRs, all CSS-driven (with light targeted PHP for the hero greeting and the favicon/branding handling in PR 2). The portal now has:

- Linear-style indigo design language with consistent shadows / radius / typography
- Three theme modes (light / dark / system-auto)
- Colour-blind safe palette toggle
- Per-site brand customisation flowing into CSS tokens
- Polished installer matching the same design language
- Every major Bootstrap component overridden to use the design tokens

Refs #111 (closes when this merges)