### PR TITLE
docs: catch CHANGELOG / README up with the UI refresh

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,71 @@ Automated sections are appended by `.github/workflows/changelog.yml` per push
 to `alpha`, `beta`, and `main` using the heading format
 `## [VERSION] - YYYY-MM-DD (branch)`.
 
-## [Unreleased] — CI/CD overhaul
+## [Unreleased]
+
+### Added — UI refresh: design system, theme modes, per-site branding
+
+A six-PR sweep across the portal and the standalone installer (#111).
+The portal now has a coherent design language with full per-site /
+per-user customisation.
+
+- **Design tokens** (#114) — `web/public_html/assets/css/portal.css`
+  `:root` block refreshed with a Linear-style indigo palette
+  (`#5e6ad2` default), expanded type scale, modern semi-bold (600)
+  headings, Stripe-style multi-layer shadows, refined motion tokens
+  (cubic-bezier easings), and an extended spacing scale.
+- **Per-site branding flow** (#116) — `tblSites.primaryColor` and
+  `tblSites.faviconPath` (new column via migration `037_site_favicon.sql`)
+  flow into the portal's CSS tokens at render time. `header.php`
+  injects `--portal-primary` and `--portal-primary-rgb` as an inline
+  style on `<html>`; the hover / active / subtle variants are derived
+  with `color-mix()` so the whole indigo family shifts when an admin
+  picks a different brand colour. `Site::branding('favicon')` added.
+- **Theme modes + colour-blind safe palette** (#117) — three theme
+  modes (light / dark / `auto` following `prefers-color-scheme`)
+  with a 3-state toggle in the navbar. New CB-safe palette via
+  `[data-portal-cb="on"]` swapping the semantic tokens (success /
+  danger / warning / accent) for a Wong-derived palette
+  distinguishable for deutan + protan colour blindness. The
+  standalone installer mirrors all of it inline.
+- **Navbar + top chrome polish** (#118) — active nav-link state
+  becomes primary-coloured on a primary-subtle background (was just
+  font-weight); avatar gains primary-tinted ring on dropdown
+  hover/open; dropdown menus use layered shadow + branded item
+  hover/active states; mobile collapse gets a top-border separator.
+- **Forms / cards / alerts / buttons / data-list** (#119) — every
+  Bootstrap class consuming pages already use (`.form-control`,
+  `.form-label`, `.form-text`, `.card`, `.alert`, `.btn-success`,
+  `.btn-outline-*`, `.form-check-input`, validation classes) now
+  reads from the design tokens. `portal-data-list` wrapped in a
+  single rounded container with branded row hover. Empty-state and
+  badge components use tokens (CB-safe automatically). New auth-shell
+  card pattern picks up login + forgot/reset password screens
+  without markup changes.
+- **Dashboard hero + stat widgets + app card grid** (#120) — new
+  greeting hero at the top (time-of-day aware, first-name, site-aware
+  subtitle); stat widgets get 4 px brand-coloured left accent + lift
+  on hover with token-driven colours (CB-safe-aware); app cards get a
+  proper hover treatment (lift + layered shadow + primary border
+  accent), inline `<style>` block removed.
+- **Final polish + dark-mode audit** (#121) — Bootstrap tables, modals,
+  pagination, list-group, progress, spinners, tooltips all now read
+  from the design tokens. Breadcrumb uses a typographic `›` separator
+  (was `/`). Footer gets an inset top-shadow. Dropzone hover uses
+  `--portal-primary-subtle`. Explicit dark-mode overrides for tables,
+  modals, progress, and portal-badge variants.
+
+### Added — Installation wizard styling polish (#114 + #115)
+
+- `web/install/index.php` standalone styling rewritten across all six
+  step layouts (welcome, DB config, schema, admin, finalize, complete)
+  to match the portal's design language. Step indicator badges, card
+  shadows, form fields, button-row separators, and alert palettes all
+  refreshed inline (the installer runs before `bootstrap.php` so it
+  cannot load `portal.css`).
+- Same theme + CB toggles in the installer header (inline SVG icons
+  so the installer doesn't load Font Awesome). Identical FOUC script
+  and `localStorage` keys as the portal.
 
 ### Added — Multi-branch SFTP deploy + auto-versioning
 

--- a/README.md
+++ b/README.md
@@ -14,8 +14,8 @@ A modular internal portal platform for organisations, providing centralised acce
 | **Routing**        | Front-controller + DB-backed router (tblRoutes)                                  | Clean URLs, app isolation, easy overrides        |
 | **Auth**           | Local accounts, MS365 OAuth, Google OAuth, WebAuthn/PassKeys, account linking    | Multi-provider SSO, passwordless support         |
 | **Multi-Site**     | Umbrella multi-site with subdomain, path-prefix, and session detection modes     | One install serves multiple locations/divisions  |
-| **UI**             | Bootstrap 5.3.3, Font Awesome 6.5.1, custom CSS design system                   | Responsive, WCAG compliant, dark mode            |
-| **PDF**            | dompdf 2.0 (in `_libraries/`, manually uploaded)                                 | Server-side PDF without external service         |
+| **UI**             | Bootstrap 5.3.3 + design tokens; light/dark/auto theme + CB-safe palette         | Responsive, WCAG-conscious, per-site themable    |
+| **PDF**            | dompdf 3.1.5 (fetched at deploy time by `tools/download-dompdf.sh`)              | Server-side PDF; pinned version vendored in CI   |
 | **Email**          | Microsoft Graph "SendAs" via shared mailbox                                      | DKIM/DMARC compliance, modern auth               |
 | **Bot Protection** | CloudFlare Turnstile (preferred) / reCAPTCHA                                     | Reduces spam without degrading UX                |
 
@@ -210,6 +210,7 @@ branch protection).
 | 8     | Translations / i18n (I18n framework, RTL support, language switcher)            | Done             |
 | 9     | Polish & Hardening (PWA, WCAG 2.1, Security Hardening)                          | Done             |
 | 10    | Multi-Site Support (umbrella orgs, site detection, 4-tier permissions)          | Done             |
+| 11    | UI Refresh + Design System (themes, CB-safe palette, per-site branding)         | Done             |
 
 ---
 


### PR DESCRIPTION
## Summary

The UI refresh sequence (#111) landed across six PRs without bringing the project docs along. This PR closes that gap.

## Files

```text
CHANGELOG.md   (+66 -1)
README.md      (+3 -2)
```

## What changed

### CHANGELOG.md

- Renamed `[Unreleased] — CI/CD overhaul` → plain `[Unreleased]` so both the CI/CD work and the new UI refresh sit under one umbrella (per Keep a Changelog).
- New `### Added — UI refresh: design system, theme modes, per-site branding` section summarising all six PRs (#114, #116, #117, #118, #119, #120, #121) and what each delivered.
- New `### Added — Installation wizard styling polish` section describing the installer rewrite from #114/#115.

### README.md

- Tech Stack → UI row updated: now reads "Bootstrap 5.3.3 + design tokens; light/dark/auto theme + CB-safe palette"
- Tech Stack → PDF row updated: reflects dompdf is fetched at deploy time (pinned v3.1.5), not manually uploaded
- Roadmap → new Phase 11 entry "UI Refresh + Design System" marked Done

## Test plan

- [ ] Render CHANGELOG.md and README.md on the GitHub web UI — verify the new sections read cleanly
- [ ] Auto-deploy doesn't fire (no `web/**` change in this PR — correct behaviour)

Refs #111