### PR TITLE
fix(ui): add <meta name="generator"> — completes the 'name + footer' attribution pair

### DIFF
--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -323,6 +323,11 @@ Markup lives in `web/core/templates/footer.php`; styling is in the
 `.portal-powered-by-mark` rules in `portal.css`. The mark class is a
 hook for future hyperlinking when the WebMS Intra landing page exists.
 
+The same detection ALSO drives a `<meta name="generator" content="WebMS Intra">`
+tag in `web/core/templates/header.php`. This is the standard SaaS / CMS
+attribution mechanism — invisible to humans, picked up by site analysers
+like Wappalyzer + "View page source" + browser dev tools.
+
 ---
 
 ## Theme modes + colour-blind palette

--- a/web/core/templates/header.php
+++ b/web/core/templates/header.php
@@ -43,6 +43,13 @@ $siteName    = Site::branding('name') ?? App::settings('site.name') ?? 'Portal';
 $siteColor   = Site::branding('color') ?? '#5e6ad2';
 $siteFavicon = Site::branding('favicon') ?? '/assets/images/favicon.ico';
 
+// 🏷️ "Powered by WebMS Intra" attribution — same rule as the footer span.
+// Custom-branded sites get a <meta name="generator"> tag so site analysers
+// (Wappalyzer, browser dev tools, etc.) can attribute the platform.
+// Admins opt out via the `branding.hidePoweredBy` setting.
+$showPoweredByMeta = (App::settings('branding.hidePoweredBy') !== 'true')
+    && (Site::usesCustomBranding() === true);
+
 // 🎨 Derive --portal-primary-rgb (comma-separated R,G,B) from the hex colour
 // so portal.css's rgba()-based focus rings and shadows tint correctly.
 // Accepts #RGB / #RRGGBB; falls back to the indigo default on bad input.
@@ -80,6 +87,9 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-i
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <meta name="csrf-token" content="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
     <meta name="theme-color" content="<?php echo htmlspecialchars($siteColor, ENT_QUOTES, 'UTF-8'); ?>">
+    <?php if ($showPoweredByMeta === true): ?>
+    <meta name="generator" content="WebMS Intra">
+    <?php endif; ?>
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="apple-mobile-web-app-status-bar-style" content="black-translucent">
     <link rel="manifest" href="/manifest.json">


### PR DESCRIPTION
## Why this exists

PR #123 implemented the **footer** half of your "powered by WebMS Intra" instruction. I also pushed a second commit to that branch with the **name** half (`<meta name=\"generator\">`) per your AskUserQuestion answer — but PR #123 squash-merged before the second commit was on the PR, so only the footer half landed on main.

This is a tiny fix-up PR that adds the missed commit.

## What's in it

One change to `web/core/templates/header.php`:

```php
// After computing $siteName / $siteColor / $siteFavicon:
$showPoweredByMeta = (App::settings('branding.hidePoweredBy') !== 'true')
    && (Site::usesCustomBranding() === true);
```

Plus inside `<head>`, right after the existing `<meta name="theme-color">`:

```html
<?php if ($showPoweredByMeta === true): ?>
<meta name="generator" content="WebMS Intra">
<?php endif; ?>
```

Plus a small DEV_NOTES note about it sitting in the same "Powered by WebMS Intra" subsection that PR #123 added.

## Same activation rule as the footer

Both halves now share `Site::usesCustomBranding()` + `branding.hidePoweredBy`. Toggle the setting → both disappear. Reset a site to default branding → both disappear.

## Files

```text
web/core/templates/header.php   (+10 lines)
DEV_NOTES.md                    (+5 lines)
```

## Test plan

- [ ] Auto-deploy fires on merge (touches `web/**`)
- [ ] Custom-branded site (any branding field changed): view source shows `<meta name="generator" content="WebMS Intra">` in `<head>`
- [ ] Default WebMS Intra site: meta tag is absent
- [ ] Set `branding.hidePoweredBy` to `'true'`: meta tag disappears even on custom-branded sites

Refs #111, follow-up to #123