### PR TITLE
chore: prep release v0.10.0 — version bump + CHANGELOG stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+## [0.10.0] - 2026-05-22
+
 ### Added — UI refresh: design system, theme modes, per-site branding
 
 A six-PR sweep across the portal and the standalone installer (#111).

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebMS Intra
 
-> **Version:** 0.9.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
+> **Version:** 0.10.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
 
 A modular internal portal platform for organisations, providing centralised access to internal tools, expense management, leadership directory, multi-site support, and more.
 

--- a/web/core/App.php
+++ b/web/core/App.php
@@ -53,7 +53,7 @@ class App
     private static bool $userLoaded = false;
 
     /** @var string Portal version number */
-    private static string $version = '0.8.1';
+    private static string $version = '0.10.0';
 
     /**
      * Initialise the App registry. Called from bootstrap.php after DB and settings are ready.


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.10.0**. Bumps the version + stamps the CHANGELOG so a subsequent \`git tag v0.10.0\` picks up clean release notes via release.yml.

## Why v0.10.0

Per your decision, the UI refresh sequence (#111: PRs #114, #116, #117, #118, #119, #120, #121) plus the per-site branding + "Powered by WebMS Intra" attribution (#123 + #124) warrants a minor version bump. 0.10.0 is a clean cut without taking the bigger 1.0 step.

## Files

```text
web/core/App.php   ($version '0.8.1' → '0.10.0' — fallback value)
README.md          (banner "Version: 0.9.0" → "Version: 0.10.0")
CHANGELOG.md       (new [0.10.0] - 2026-05-22 heading wrapping the existing UI refresh content)
```

## After merge

After this PR **and** PR #124 (meta-generator) both land on main, you can tag the release:

```bash
git fetch origin
git checkout main
git pull --ff-only
git tag -a v0.10.0 -m "v0.10.0 — UI refresh + per-site branding + Powered by"
git push origin v0.10.0
```

The push of the tag fires \`release.yml\`, which:
- Detects the v* tag pattern
- Extracts release notes from the [0.10.0] section of CHANGELOG.md
- Creates a GitHub Release with those notes
- Tagged as non-prerelease (since the tag doesn't contain -beta or -rc)

## Test plan

- [ ] PR Security Checks passes
- [ ] After merge: \`App::version()\` returns \"0.10.0\" (or whatever \`tblSettings.portal.version\` is set to, if any)
- [ ] After tagging: GitHub Releases page shows v0.10.0 with the UI refresh content as the release notes

Refs #111