### PR TITLE
docs(help): in-app help for theme cycle, CB-safe palette, and per-site branding

### DIFF
--- a/web/public_html/help/admin.php
+++ b/web/public_html/help/admin.php
@@ -46,6 +46,7 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
         <h6 class="card-title mb-2"><i class="fa-solid fa-list me-1"></i>On this page</h6>
         <div class="d-flex flex-wrap gap-2">
             <a href="#settings" class="badge text-bg-secondary text-decoration-none">Settings Management</a>
+            <a href="#site-branding" class="badge text-bg-secondary text-decoration-none">Site Branding</a>
             <a href="#roles" class="badge text-bg-secondary text-decoration-none">User Roles</a>
             <a href="#gatekeeper" class="badge text-bg-secondary text-decoration-none">Dev Site Access (Gatekeeper)</a>
             <a href="#logs" class="badge text-bg-secondary text-decoration-none">Viewing Logs</a>
@@ -161,6 +162,70 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
         <div class="list-group-item d-flex gap-2">
             <code class="text-nowrap">expenses.displayIcon</code>
             <span class="text-secondary">-- The Font Awesome icon class used for the app (e.g., <code>fa-solid fa-receipt</code>).</span>
+        </div>
+    </div>
+</div>
+
+<!-- Section: Site Branding -->
+<div class="portal-card p-4 mb-4" id="site-branding">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-palette me-2 text-primary"></i>Site Branding</h2>
+
+    <p>Each site in this install can have its own visual identity. Branding values are configured at <a href="/admin/sites">/admin/sites/</a> by umbrella admins.</p>
+
+    <h5 class="mt-3 mb-3">What you can customise per site</h5>
+
+    <div class="list-group list-group-flush mb-3">
+        <div class="list-group-item d-flex gap-3 align-items-start">
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-signature"></i></span>
+            <div>
+                <strong>Site name</strong>
+                <p class="mb-0 small text-secondary">Display name in the navbar, browser tab title, and footer. Required.</p>
+            </div>
+        </div>
+        <div class="list-group-item d-flex gap-3 align-items-start">
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-image"></i></span>
+            <div>
+                <strong>Logo path</strong>
+                <p class="mb-0 small text-secondary">URL or path to the navbar logo. Default <code>/assets/images/logo.svg</code> shows the WebMS Intra mark.</p>
+            </div>
+        </div>
+        <div class="list-group-item d-flex gap-3 align-items-start">
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-droplet"></i></span>
+            <div>
+                <strong>Primary colour</strong>
+                <p class="mb-0 small text-secondary">Hex colour for buttons, focus rings, active nav links, app card hover, and other accents. Default <code>#5e6ad2</code> (indigo). Hover and active variants auto-derive from this colour.</p>
+            </div>
+        </div>
+        <div class="list-group-item d-flex gap-3 align-items-start">
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-star"></i></span>
+            <div>
+                <strong>Favicon path</strong>
+                <p class="mb-0 small text-secondary">URL or path to the browser-tab icon. Leave blank to use the WebMS Intra default.</p>
+            </div>
+        </div>
+        <div class="list-group-item d-flex gap-3 align-items-start">
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-copyright"></i></span>
+            <div>
+                <strong>Copyright organisation</strong>
+                <p class="mb-0 small text-secondary">Name shown in the footer copyright line. Defaults to "MWBM Partners Ltd" if blank.</p>
+            </div>
+        </div>
+    </div>
+
+    <h5 class="mt-4 mb-3">"Powered by WebMS Intra" attribution</h5>
+
+    <p>When a site uses <strong>custom branding</strong> (any of the fields above differs from the WebMS Intra default), the footer shows a small "Powered by WebMS Intra" attribution after the copyright line. A <code>&lt;meta name="generator"&gt;</code> tag is also added to the page <code>&lt;head&gt;</code> for site analysers.</p>
+
+    <p>Sites still running the default WebMS Intra branding do <em>not</em> show the attribution &mdash; the copyright line already names the product.</p>
+
+    <h6 class="mt-3 mb-2">Hiding the attribution</h6>
+
+    <p>To hide the "Powered by" attribution across all sites in this install, set the global setting <code>branding.hidePoweredBy</code> to <code>true</code> at <a href="/settings">/settings/</a>. Default is <code>false</code> (show attribution on custom-branded sites).</p>
+
+    <div class="alert alert-info d-flex gap-2 mt-3" role="alert">
+        <i class="fa-solid fa-circle-info mt-1"></i>
+        <div>
+            <strong>Tip:</strong> Branding changes apply immediately on the next page load &mdash; no deploy or cache clear needed. The hover/active/subtle colour variants automatically shift with the primary colour in modern browsers (Chrome 111+, Safari 16.2+, Firefox 113+); older browsers fall back to the indigo defaults.
         </div>
     </div>
 </div>

--- a/web/public_html/help/getting-started.php
+++ b/web/public_html/help/getting-started.php
@@ -41,7 +41,7 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
             <a href="#first-time" class="badge text-bg-secondary text-decoration-none">First-Time Setup</a>
             <a href="#navigating" class="badge text-bg-secondary text-decoration-none">Navigating the Portal</a>
             <a href="#csv-export" class="badge text-bg-secondary text-decoration-none">Exporting Data</a>
-            <a href="#dark-mode" class="badge text-bg-secondary text-decoration-none">Dark Mode</a>
+            <a href="#personalisation" class="badge text-bg-secondary text-decoration-none">Personalisation (theme + accessibility)</a>
         </div>
     </div>
 </div>
@@ -225,42 +225,71 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
     </div>
 </div>
 
-<!-- Section 5: Dark Mode -->
-<div class="portal-card p-4 mb-4" id="dark-mode">
-    <h2 class="h4 mb-3"><i class="fa-solid fa-moon me-2 text-primary"></i>Dark Mode</h2>
+<!-- Section 5: Personalisation -->
+<div class="portal-card p-4 mb-4" id="personalisation">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-palette me-2 text-primary"></i>Personalisation (theme + accessibility)</h2>
 
-    <p>The portal includes a built-in dark mode for comfortable viewing in low-light environments.</p>
+    <p>Two small buttons sit near your avatar in the navigation bar — one for theme, one for an accessibility-friendly colour palette. Both remember your preference per browser.</p>
 
-    <h5 class="mt-3 mb-3">How to toggle dark mode</h5>
+    <h5 class="mt-4 mb-3">Theme — light / dark / auto</h5>
+
+    <p>Click the <i class="fa-solid fa-circle-half-stroke"></i> button to cycle through three states:</p>
 
     <div class="list-group list-group-flush mb-3">
         <div class="list-group-item d-flex gap-3 align-items-start">
-            <span class="badge text-bg-primary rounded-pill mt-1">1</span>
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-sun"></i></span>
             <div>
-                <strong>Locate the moon icon</strong>
-                <p class="mb-0 small text-secondary">Look for the <i class="fa-solid fa-moon"></i> button in the navigation bar (top-right area, near your avatar).</p>
+                <strong>Light</strong>
+                <p class="mb-0 small text-secondary">Light surfaces, dark text. The portal's default visual.</p>
             </div>
         </div>
         <div class="list-group-item d-flex gap-3 align-items-start">
-            <span class="badge text-bg-primary rounded-pill mt-1">2</span>
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-moon"></i></span>
             <div>
-                <strong>Click the toggle</strong>
-                <p class="mb-0 small text-secondary">The theme switches instantly between light and dark modes. No page reload is required.</p>
+                <strong>Dark</strong>
+                <p class="mb-0 small text-secondary">Dark surfaces, light text. Easier on the eyes in low light.</p>
             </div>
         </div>
         <div class="list-group-item d-flex gap-3 align-items-start">
-            <span class="badge text-bg-primary rounded-pill mt-1">3</span>
+            <span class="badge text-bg-primary rounded-pill mt-1"><i class="fa-solid fa-circle-half-stroke"></i></span>
             <div>
-                <strong>Your preference is saved</strong>
-                <p class="mb-0 small text-secondary">The portal remembers your choice in your browser's local storage. It will be applied automatically on your next visit.</p>
+                <strong>Auto</strong>
+                <p class="mb-0 small text-secondary">Follows your operating system's theme preference. If your OS switches to dark mode in the evening (e.g. macOS / Windows scheduled), the portal switches with it without a refresh.</p>
             </div>
         </div>
     </div>
 
+    <h5 class="mt-4 mb-3">Colour-blind safe palette</h5>
+
+    <p>The <i class="fa-solid fa-eye-low-vision"></i> button toggles an accessibility-friendly colour palette designed for the most common forms of colour-blindness (deuteranopia + protanopia, affecting roughly 5% of men globally).</p>
+
+    <p>When enabled, the portal swaps its status colours for combinations that don't rely on red/green contrast:</p>
+
+    <div class="list-group list-group-flush mb-3 small">
+        <div class="list-group-item">
+            <strong>Success / approved</strong>
+            <span class="text-secondary"> — bluish-green instead of pure green</span>
+        </div>
+        <div class="list-group-item">
+            <strong>Danger / rejected</strong>
+            <span class="text-secondary"> — vermillion (orange-red) instead of pure red</span>
+        </div>
+        <div class="list-group-item">
+            <strong>Warning / pending</strong>
+            <span class="text-secondary"> — bright orange (high contrast, distinguishable)</span>
+        </div>
+        <div class="list-group-item">
+            <strong>Info / accent</strong>
+            <span class="text-secondary"> — sky blue (always distinguishable)</span>
+        </div>
+    </div>
+
+    <p class="small text-secondary mb-3">The button shows as tinted when the palette is active. Your site's brand colour is unaffected — only status colours change.</p>
+
     <div class="alert alert-info d-flex gap-2" role="alert">
         <i class="fa-solid fa-circle-info mt-1"></i>
         <div>
-            <strong>Note:</strong> Dark mode is per-browser. If you use multiple browsers or devices, you will need to set it on each one separately.
+            <strong>Note:</strong> Both preferences are stored per-browser. If you use multiple browsers or devices, you'll need to set them on each one separately.
         </div>
     </div>
 </div>


### PR DESCRIPTION
## Summary

The UI refresh introduced user-facing features that weren't documented anywhere users actually look:

- Three-state theme cycle (light / dark / **auto** — the new bit)
- Colour-blind safe palette toggle
- Per-site branding (admin-side)
- "Powered by WebMS Intra" attribution rule (admin-side)

This PR adds in-app help pages for each. Pure docs — no code changes.

## Files

```text
web/public_html/help/getting-started.php   (+46 -16 — replace Dark Mode with Personalisation section)
web/public_html/help/admin.php             (+64 — new Site Branding section)
```

## What changed

### `/help/getting-started` — Personalisation section (replaces old Dark Mode)

End-users now see:

- **Theme cycle** — three list items explaining light / dark / auto with their respective icons. The "auto follows your OS" detail is the key new info users wouldn't otherwise discover.
- **Colour-blind safe palette** — what it is (Wong palette, deutan + protan safe), how to enable (the eye icon), what changes (status colours), what doesn't change (the site's brand colour).
- **Note** updated to cover BOTH preferences being per-browser (was just dark mode before).

### `/help/admin` — Site Branding section (new)

Admins now have a documented reference for:

- The five branding fields available per site (siteName, logoPath, primaryColor, faviconPath, copyrightOrg) — what each one drives in the UI
- The `Site::usesCustomBranding()` rule that triggers the "Powered by WebMS Intra" attribution
- How to hide attribution globally via `branding.hidePoweredBy` at /settings/

## Test plan

After merge + auto-deploy:

- [ ] Visit `/help/getting-started` — Personalisation section renders cleanly, the three theme states are documented with their icons
- [ ] Visit `/help/admin` — Site Branding section appears between Settings Management and User Roles
- [ ] On-this-page badges in both pages link to the new section IDs
- [ ] Dark mode + CB-safe mode: pages stay readable (uses the design tokens, nothing custom)

Refs #111