### PR TITLE
feat: Prayer Requests app (logged-in + anonymous public submission)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Added — Prayer Requests app
+
+A new portal app at `/prayer-requests` for collecting and tracking prayer
+requests, with built-in moderation and an anonymous public-submission route.
+
+- **Logged-in submissions** with per-request visibility — *leadership only*
+  (default) or *congregation feed* (visible to all members of the site).
+- **Anonymous "display as Anonymous" toggle** for logged-in submitters —
+  members see "Anonymous"; leaders still see who submitted for pastoral
+  follow-up.
+- **Public anonymous route** at `/prayer-requests/anonymous` (no login).
+  Protected by CSRF + Captcha + RateLimiter. Hard-coded to leadership-only
+  visibility and `pending` status for moderator review.
+- **Lifecycle**: pending → active → answered (with optional praise /
+  testimony note) → archived. Moderators see a status-grouped queue and
+  per-request quick actions.
+- **Per-site settings** seeded with sane defaults — feature toggle,
+  anonymous allowed, congregation feed allowed, require moderation,
+  allow testimony.
+- **Help guide** at `/help/prayer-requests` and a tile on the Help Centre
+  landing page.
+- Migration `web/sql/039_prayer_requests.sql` + `tblPrayerRequests`
+  definition added to `full_schema.sql`.
+
 ## [0.10.0] - 2026-05-22
 
 ### Added — UI refresh: design system, theme modes, per-site branding

--- a/web/public_html/help/index.php
+++ b/web/public_html/help/index.php
@@ -130,6 +130,21 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
         </a>
     </div>
 
+    <!-- Prayer Requests -->
+    <div class="col-12 col-sm-6 col-lg-4">
+        <a href="/help/prayer-requests" class="text-decoration-none text-reset">
+            <div class="portal-card portal-card-branded h-100 p-4">
+                <div class="d-flex align-items-center gap-3 mb-3">
+                    <span class="d-inline-flex align-items-center justify-content-center rounded-3 bg-success bg-opacity-10 text-success" style="width:48px;height:48px;">
+                        <i class="fa-solid fa-hands-praying fa-lg"></i>
+                    </span>
+                    <h5 class="mb-0">Prayer Requests</h5>
+                </div>
+                <p class="text-secondary mb-0 small">Submitting prayer requests, choosing visibility, anonymous submissions, and the moderation lifecycle.</p>
+            </div>
+        </a>
+    </div>
+
     <!-- Translations & Languages -->
     <div class="col-12 col-sm-6 col-lg-4">
         <a href="/help/translations" class="text-decoration-none text-reset">

--- a/web/public_html/help/prayer-requests.php
+++ b/web/public_html/help/prayer-requests.php
@@ -1,0 +1,168 @@
+<?php
+// Path: public_html/help/prayer-requests.php
+/**
+ * -----------------------------------------------------------------------------
+ * Help Centre — Prayer Requests Guide 🙏
+ * -----------------------------------------------------------------------------
+ * Walkthrough of submitting prayer requests (logged-in + anonymous public
+ * route), visibility options, the moderation lifecycle, and testimony notes.
+ * -----------------------------------------------------------------------------
+ * @package    Portal\Help
+ * @license    All Rights Reserved
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+$pageTitle   = 'Help - Prayer Requests';
+$pageSection = 'help';
+$breadcrumbs = ['Dashboard' => '/', 'Help' => '/help', 'Prayer Requests' => ''];
+
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-hands-praying me-2"></i>Prayer Requests Guide</h1>
+        <p class="text-secondary mb-0">Submit prayer requests, choose how widely they're shared, and follow the moderation lifecycle.</p>
+    </div>
+    <a href="/help" class="btn btn-outline-secondary btn-sm mt-2 mt-md-0">
+        <i class="fa-solid fa-arrow-left me-1"></i>Back to Help Centre
+    </a>
+</div>
+
+<!-- 🧭 Table of contents -->
+<div class="card mb-4 border-0 bg-body-tertiary">
+    <div class="card-body">
+        <h6 class="card-title mb-2"><i class="fa-solid fa-list me-1"></i>On this page</h6>
+        <div class="d-flex flex-wrap gap-2">
+            <a href="#submitting" class="badge text-bg-secondary text-decoration-none">Submitting a Request</a>
+            <a href="#visibility" class="badge text-bg-secondary text-decoration-none">Visibility Options</a>
+            <a href="#anonymous" class="badge text-bg-secondary text-decoration-none">Anonymous Submissions</a>
+            <a href="#lifecycle" class="badge text-bg-secondary text-decoration-none">Moderation Lifecycle</a>
+            <a href="#testimony" class="badge text-bg-secondary text-decoration-none">Testimonies</a>
+            <a href="#admins" class="badge text-bg-secondary text-decoration-none">For Moderators</a>
+        </div>
+    </div>
+</div>
+
+<!-- 1️⃣ Submitting -->
+<section id="submitting" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-pen-to-square me-2"></i>Submitting a Request</h2>
+    <p>
+        From <a href="/prayer-requests">Prayer Requests</a> click
+        <em>Submit a Request</em>. You'll be asked for a short subject and the body of
+        your request. Up to 4000 characters of text are accepted.
+    </p>
+    <p>
+        Once submitted, your request goes to the leadership team. If your site requires
+        moderation (the default), it stays in a <em>Pending</em> queue until a leader
+        approves it.
+    </p>
+</section>
+
+<!-- 2️⃣ Visibility -->
+<section id="visibility" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-eye me-2"></i>Visibility Options</h2>
+    <p>You choose who can see each request:</p>
+    <ul>
+        <li>
+            <span class="badge bg-secondary-subtle text-secondary-emphasis">
+                <i class="fa-solid fa-user-shield me-1"></i>Leadership only
+            </span>
+            — visible only to pastors and site admins for confidential prayer.
+            This is the default.
+        </li>
+        <li>
+            <span class="badge bg-info-subtle text-info-emphasis">
+                <i class="fa-solid fa-people-group me-1"></i>Congregation
+            </span>
+            — appears on the prayer feed visible to all logged-in members of this site.
+            A moderator can change visibility at any time.
+        </li>
+    </ul>
+    <p class="text-muted small">
+        Your site admin can disable the congregation feed entirely under
+        <em>Site Settings → Prayer Requests</em>.
+    </p>
+</section>
+
+<!-- 3️⃣ Anonymous -->
+<section id="anonymous" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-user-secret me-2"></i>Anonymous Submissions</h2>
+    <p>There are two ways a request can be anonymous:</p>
+    <ol>
+        <li>
+            <strong>Logged-in, displayed anonymously.</strong> When submitting, tick
+            "<em>Display my name as Anonymous</em>". Other members see "Anonymous";
+            leaders still see your real name for pastoral follow-up.
+        </li>
+        <li>
+            <strong>Public anonymous route.</strong> Visitors without a portal account
+            can submit via <code>/prayer-requests/anonymous</code>. These submissions
+            are protected by CAPTCHA and rate limiting, and are always:
+            <ul>
+                <li>Sent to <em>leadership only</em> (never broadcast)</li>
+                <li>Marked as <em>pending</em> for moderator review</li>
+                <li>Treated as anonymous by default — name &amp; email are optional</li>
+            </ul>
+        </li>
+    </ol>
+</section>
+
+<!-- 4️⃣ Lifecycle -->
+<section id="lifecycle" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-arrow-rotate-right me-2"></i>Moderation Lifecycle</h2>
+    <p>Each request moves through these statuses:</p>
+    <div class="d-flex flex-wrap gap-2 mb-3">
+        <span class="badge bg-warning"><i class="fa-solid fa-hourglass-half me-1"></i>Pending</span>
+        <span>→</span>
+        <span class="badge bg-success"><i class="fa-solid fa-hands-praying me-1"></i>Active</span>
+        <span>→</span>
+        <span class="badge bg-info"><i class="fa-solid fa-check-double me-1"></i>Answered</span>
+        <span>→</span>
+        <span class="badge bg-secondary"><i class="fa-solid fa-box-archive me-1"></i>Archived</span>
+    </div>
+    <ul class="small">
+        <li><strong>Pending</strong> — awaiting moderator approval.</li>
+        <li><strong>Active</strong> — published; appears on the leadership view (and the congregation feed if visibility is set accordingly).</li>
+        <li><strong>Answered</strong> — closed with an optional praise / testimony note.</li>
+        <li><strong>Archived</strong> — hidden from feeds but retained in the database.</li>
+    </ul>
+</section>
+
+<!-- 5️⃣ Testimony -->
+<section id="testimony" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-seedling me-2"></i>Testimonies</h2>
+    <p>
+        When a request is answered, a moderator can attach a short praise or testimony
+        note. If the request is shared with the congregation, this note appears on
+        the public feed alongside the original request, encouraging the wider church
+        family.
+    </p>
+    <p class="text-muted small">
+        Testimonies can be disabled site-wide via <em>Site Settings → Prayer Requests
+        → Allow Testimony</em>.
+    </p>
+</section>
+
+<!-- 6️⃣ Admins -->
+<section id="admins" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-gauge-high me-2"></i>For Moderators</h2>
+    <p>
+        Site admins and leadership see a <em>Moderate</em> button on the prayer-requests
+        landing page. The moderation queue is grouped by status, with quick-action
+        buttons to approve, mark answered, or archive each request.
+    </p>
+    <p>
+        Inside any request, the <em>Moderator actions</em> card lets you change
+        visibility or add a testimony note when marking answered.
+    </p>
+    <p class="text-muted small">
+        Anonymous submissions made by logged-in members still record the real submitter
+        so moderators can offer pastoral follow-up. Submissions via the public anonymous
+        route only contain the optional name &amp; email the submitter provided.
+    </p>
+</section>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/prayer-requests/anonymous-save.php
+++ b/web/public_html/prayer-requests/anonymous-save.php
@@ -1,0 +1,152 @@
+<?php
+// Path: public_html/prayer-requests/anonymous-save.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Anonymous Public Save Handler 🙏
+ * -----------------------------------------------------------------------------
+ * POST endpoint for the public anonymous submission form.
+ *
+ * Hardening:
+ *   • Session + CSRF (token issued by anonymous.php)
+ *   • Captcha::verify() (Turnstile / reCAPTCHA)
+ *   • RateLimiter::isBlocked() — same IP-based limiter used by login
+ *   • Always pending + leadership + isAnonymous=1 (no congregation broadcast)
+ *   • Always redirects to a generic success page (no enumeration / abuse signal)
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Captcha;
+use Portal\Core\Logger;
+use Portal\Core\RateLimiter;
+use Portal\Core\Site;
+
+// 🛡️ Only POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /prayer-requests/anonymous', true, 302);
+    exit();
+}
+
+Auth::ensureSession();
+
+// 🚦 Feature gates — bounce silently if disabled
+$featureEnabled   = (App::settings('prayerRequests.enabled') ?? 'true') === 'true';
+$anonymousEnabled = (App::settings('prayerRequests.allowAnonymous') ?? 'true') === 'true';
+if ($featureEnabled === false || $anonymousEnabled === false) {
+    header('Location: /prayer-requests/anonymous', true, 302);
+    exit();
+}
+
+// 🔐 CSRF
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    Logger::activity('PrayerRequestAnonRejected', 'Invalid CSRF on anonymous prayer-request save');
+    header('Location: /prayer-requests/anonymous?err=' . urlencode('Security check failed. Please try again.'), true, 302);
+    exit();
+}
+
+// 🤖 Captcha
+if (Captcha::verify($_POST) === false) {
+    Logger::activity('PrayerRequestAnonRejected', 'Captcha failed on anonymous prayer-request save');
+    header('Location: /prayer-requests/anonymous?err=' . urlencode('Captcha verification failed. Please try again.'), true, 302);
+    exit();
+}
+
+// 🚦 Rate-limit (per IP); behave silently like the forgot-password flow
+if (RateLimiter::isBlocked() === true) {
+    Logger::activity('PrayerRequestAnonBlocked', 'Rate-limited anonymous prayer-request submission');
+    // Show success page anyway — don't tell automated abusers they're blocked
+    header('Location: /prayer-requests/anonymous?submitted=1', true, 302);
+    exit();
+}
+
+// 📥 Input
+$name    = trim((string) ($_POST['name'] ?? ''));
+$email   = trim((string) ($_POST['email'] ?? ''));
+$subject = trim((string) ($_POST['subject'] ?? ''));
+$body    = trim((string) ($_POST['body'] ?? ''));
+
+// 🛡️ Validate
+if ($subject === '' || $body === '') {
+    header('Location: /prayer-requests/anonymous?err=' . urlencode('Subject and request text are required.'), true, 302);
+    exit();
+}
+if ($email !== '' && filter_var($email, FILTER_VALIDATE_EMAIL) === false) {
+    header('Location: /prayer-requests/anonymous?err=' . urlencode('Please enter a valid email address (or leave it blank).'), true, 302);
+    exit();
+}
+
+// 🧹 Truncate to column limits
+$name    = mb_substr($name, 0, 100);
+$email   = mb_substr($email, 0, 255);
+$subject = mb_substr($subject, 0, 255);
+$body    = mb_substr($body, 0, 4000);
+
+// 🌐 Capture context
+$siteId = Site::id();
+$ip = $_SERVER['HTTP_CF_CONNECTING_IP']
+    ?? $_SERVER['HTTP_X_FORWARDED_FOR']
+    ?? $_SERVER['REMOTE_ADDR']
+    ?? '';
+if (str_contains((string) $ip, ',') === true) {
+    $ip = trim(explode(',', (string) $ip)[0]);
+}
+$ip = mb_substr((string) $ip, 0, 45);
+
+// 💾 Insert — always pending, leadership-only, anonymous
+$visibility  = 'leadership';
+$status      = 'pending';
+$isAnonymous = 1;
+
+$stmt = $mysqli->prepare(
+    'INSERT INTO tblPrayerRequests '
+    . '(siteID, submitterName, submitterEmail, submitterIP, subject, body, '
+    . 'visibility, status, isAnonymous) '
+    . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
+);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'PR_ANON_INSERT_PREP', $mysqli->error, '');
+    // Still redirect to success to avoid leaking server state
+    header('Location: /prayer-requests/anonymous?submitted=1', true, 302);
+    exit();
+}
+
+// 🪪 NULL-friendly binds: pass empty strings as NULL where appropriate
+$nameOrNull  = ($name === '') ? null : $name;
+$emailOrNull = ($email === '') ? null : $email;
+
+$stmt->bind_param(
+    'isssssssi',
+    $siteId,
+    $nameOrNull,
+    $emailOrNull,
+    $ip,
+    $subject,
+    $body,
+    $visibility,
+    $status,
+    $isAnonymous
+);
+$ok = $stmt->execute();
+$newId = (int) $stmt->insert_id;
+$stmt->close();
+
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'PR_ANON_INSERT_FAIL', $mysqli->error, '');
+} else {
+    Logger::activity('PrayerRequestAnonSubmitted', 'Anonymous request #' . $newId . ' submitted from IP ' . $ip);
+}
+
+// ✅ Always show success — even on failure, prevent fingerprinting
+header('Location: /prayer-requests/anonymous?submitted=1', true, 302);
+exit();

--- a/web/public_html/prayer-requests/anonymous.php
+++ b/web/public_html/prayer-requests/anonymous.php
@@ -1,0 +1,164 @@
+<?php
+// Path: public_html/prayer-requests/anonymous.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Anonymous Public Submission Form 🙏
+ * -----------------------------------------------------------------------------
+ * Public route (no login) that lets visitors submit a prayer request.
+ * Uses a standalone layout (similar to the login / forgot-password pages)
+ * and is protected by Turnstile/reCAPTCHA + RateLimiter.
+ *
+ * Anonymous submissions are forced to:
+ *   • visibility = leadership (members opt-in to congregation feed only when
+ *     logged in — anonymous folks don't get a public broadcast right)
+ *   • isAnonymous = 1
+ *   • status = pending (always moderated)
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+
+use Portal\Core\App;
+use Portal\Core\Asset;
+use Portal\Core\Auth;
+use Portal\Core\Captcha;
+
+// 🛡️ Always start a session so CSRF tokens are issued for this anonymous form
+Auth::ensureSession();
+
+// 🚦 Feature gates
+$featureEnabled   = (App::settings('prayerRequests.enabled') ?? 'true') === 'true';
+$anonymousEnabled = (App::settings('prayerRequests.allowAnonymous') ?? 'true') === 'true';
+
+$siteName  = (string) (App::settings('site.name') ?? 'Portal');
+$submitted = isset($_GET['submitted']) === true && $_GET['submitted'] === '1';
+$flashErr  = (string) ($_GET['err'] ?? '');
+?>
+<!doctype html>
+<html lang="en" data-bs-theme="light">
+<head>
+    <meta charset="utf-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <title>Submit a Prayer Request &bull; <?php echo htmlspecialchars($siteName, ENT_QUOTES, 'UTF-8'); ?></title>
+
+    <!-- 🚫 Public form — don't index in search engines -->
+    <meta name="robots" content="noindex, nofollow">
+
+    <!-- 🎨 Stylesheets (CDN with local fallback) -->
+    <?php echo Asset::bootstrapCss(); ?>
+    <?php echo Asset::fontAwesomeCss(); ?>
+    <?php echo Asset::portalCss(); ?>
+
+    <!-- 🌙 Prevent FOUC: apply saved theme before first paint -->
+    <script>
+    (function(){
+        var t = localStorage.getItem('portal-theme');
+        if (t === 'dark' || t === 'light') {
+            document.documentElement.setAttribute('data-bs-theme', t);
+        }
+    })();
+    </script>
+
+    <!-- 🤖 Captcha script (if configured) -->
+    <?php echo Captcha::scriptTag(); ?>
+</head>
+<body class="d-flex align-items-center justify-content-center min-vh-100 py-4">
+<div class="card shadow p-4" style="min-width:320px;max-width:560px;width:100%;">
+
+    <!-- 🏷️ Header -->
+    <div class="text-center mb-3">
+        <i class="fa-solid fa-hands-praying fa-2x text-muted mb-2"></i>
+        <h1 class="h4 mb-1">Submit a Prayer Request</h1>
+        <p class="text-muted small mb-0">
+            <?php echo htmlspecialchars($siteName, ENT_QUOTES, 'UTF-8'); ?>
+        </p>
+    </div>
+
+    <?php if ($featureEnabled === false || $anonymousEnabled === false): ?>
+        <div class="alert alert-warning small mb-0">
+            <i class="fa-solid fa-circle-info me-1"></i>
+            Anonymous prayer-request submissions are not currently being accepted on this site.
+        </div>
+    <?php elseif ($submitted === true): ?>
+        <div class="alert alert-success small" role="alert">
+            <i class="fa-solid fa-circle-check me-1"></i>
+            Thank you for sharing your request — our leadership team will be praying for you.
+        </div>
+        <a href="/" class="btn btn-outline-secondary w-100">
+            <i class="fa-solid fa-arrow-left me-1"></i> Back to Home
+        </a>
+    <?php else: ?>
+
+        <?php if ($flashErr !== ''): ?>
+            <div class="alert alert-danger small">
+                <i class="fa-solid fa-circle-exclamation me-1"></i>
+                <?php echo htmlspecialchars($flashErr, ENT_QUOTES, 'UTF-8'); ?>
+            </div>
+        <?php endif; ?>
+
+        <p class="text-muted small">
+            Use this form if you don't have an account.  Requests submitted here go
+            <strong>only to the leadership team</strong> for confidential prayer.
+        </p>
+
+        <form method="post" action="/prayer-requests/anonymous/save" novalidate>
+            <input type="hidden" name="csrf_token"
+                   value="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
+
+            <div class="mb-3">
+                <label for="name" class="form-label small">Your Name <span class="text-muted">(optional)</span></label>
+                <input type="text" class="form-control form-control-sm" id="name" name="name"
+                       maxlength="100" autocomplete="name">
+            </div>
+
+            <div class="mb-3">
+                <label for="email" class="form-label small">Your Email <span class="text-muted">(optional, for follow-up)</span></label>
+                <input type="email" class="form-control form-control-sm" id="email" name="email"
+                       maxlength="255" autocomplete="email">
+            </div>
+
+            <div class="mb-3">
+                <label for="subject" class="form-label small">
+                    Subject <span class="text-danger">*</span>
+                </label>
+                <input type="text" class="form-control" id="subject" name="subject"
+                       maxlength="255" required
+                       placeholder="A short title">
+            </div>
+
+            <div class="mb-3">
+                <label for="body" class="form-label small">
+                    Request <span class="text-danger">*</span>
+                </label>
+                <textarea class="form-control" id="body" name="body" rows="5"
+                          maxlength="4000" required
+                          placeholder="Share what you'd like prayer for…"></textarea>
+            </div>
+
+            <?php echo Captcha::widget(); ?>
+
+            <button type="submit" class="btn btn-success w-100 mb-2">
+                <i class="fa-solid fa-paper-plane me-1"></i> Submit Request
+            </button>
+
+            <p class="small text-muted text-center mb-0">
+                Have an account? <a href="/login">Sign in</a> for more options.
+            </p>
+        </form>
+
+    <?php endif; ?>
+
+</div>
+
+<!-- 📦 JavaScript (CDN with local fallback) -->
+<?php echo Asset::bootstrapJs(); ?>
+</body>
+</html>

--- a/web/public_html/prayer-requests/index.php
+++ b/web/public_html/prayer-requests/index.php
@@ -1,0 +1,292 @@
+<?php
+// Path: public_html/prayer-requests/index.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Landing & Congregation Feed 🙏
+ * -----------------------------------------------------------------------------
+ * Logged-in landing page for the Prayer Requests app. Shows:
+ *   • The current user's own submitted requests (any status, any visibility)
+ *   • Congregation-visible active requests (if that setting is enabled)
+ * Leaders / admins see additional shortcuts to the moderation queue.
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+// 📌 Page metadata
+$pageTitle   = 'Prayer Requests';
+$pageSection = 'prayer-requests';
+$breadcrumbs = ['Dashboard' => '/', 'Prayer Requests' => ''];
+
+// 🛡️ Require an authenticated session
+Auth::ensureSession();
+Auth::requireLogin();
+
+$siteId = Site::id();
+$user   = App::user();
+$userId = (int) ($user['userID'] ?? 0);
+$isMod  = App::isAdmin();
+
+// 🔎 Feature flags
+$featureEnabled       = (App::settings('prayerRequests.enabled') ?? 'true') === 'true';
+$congregationEnabled  = (App::settings('prayerRequests.allowCongregationFeed') ?? 'true') === 'true';
+$anonymousEnabled     = (App::settings('prayerRequests.allowAnonymous') ?? 'true') === 'true';
+
+// -----------------------------------------------------------------------------
+// 📋 Fetch the current user's own requests (newest first, limit 20)
+// -----------------------------------------------------------------------------
+$myRequests = [];
+$stmt = $mysqli->prepare(
+    'SELECT requestID, subject, visibility, status, isAnonymous, '
+    . 'answeredAt, createdAt '
+    . 'FROM tblPrayerRequests '
+    . 'WHERE siteID = ? AND submitterID = ? '
+    . 'ORDER BY createdAt DESC LIMIT 20'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $siteId, $userId);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    while ($row = $result->fetch_assoc()) {
+        $myRequests[] = $row;
+    }
+    $stmt->close();
+}
+
+// -----------------------------------------------------------------------------
+// 🌿 Fetch active congregation-visible requests (if feature enabled)
+// -----------------------------------------------------------------------------
+$congFeed = [];
+if ($congregationEnabled === true && $featureEnabled === true) {
+    $stmt = $mysqli->prepare(
+        'SELECT pr.requestID, pr.subject, pr.body, pr.isAnonymous, '
+        . 'pr.status, pr.answeredAt, pr.testimony, pr.createdAt, '
+        . 'u.fullName AS submitterFullName '
+        . 'FROM tblPrayerRequests pr '
+        . 'LEFT JOIN tblUsers u ON u.userID = pr.submitterID '
+        . 'WHERE pr.siteID = ? AND pr.visibility = \'congregation\' '
+        . 'AND pr.status IN (\'active\',\'answered\') '
+        . 'ORDER BY pr.createdAt DESC LIMIT 25'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('i', $siteId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($row = $result->fetch_assoc()) {
+            $congFeed[] = $row;
+        }
+        $stmt->close();
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 🧮 Moderator queue counts (only if user is admin)
+// -----------------------------------------------------------------------------
+$pendingCount = 0;
+if ($isMod === true) {
+    $stmt = $mysqli->prepare(
+        'SELECT COUNT(*) AS cnt FROM tblPrayerRequests '
+        . 'WHERE siteID = ? AND status = \'pending\''
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('i', $siteId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $pendingCount = (int) ($row['cnt'] ?? 0);
+        $stmt->close();
+    }
+}
+
+// 📄 Render shared header
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+/**
+ * 🎨 Helper — render a Bootstrap-coloured status badge for a request row
+ */
+$renderStatusBadge = static function (string $status): string {
+    $map = [
+        'pending'  => ['warning', 'fa-hourglass-half', 'Pending'],
+        'active'   => ['success', 'fa-hands-praying',  'Active'],
+        'answered' => ['info',    'fa-check-double',   'Answered'],
+        'archived' => ['secondary','fa-box-archive',   'Archived'],
+    ];
+    [$colour, $icon, $label] = $map[$status] ?? ['secondary', 'fa-circle', ucfirst($status)];
+    return '<span class="badge bg-' . $colour . '"><i class="fa-solid ' . $icon . ' me-1"></i>'
+        . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . '</span>';
+};
+?>
+
+<!-- 🙏 Page header -->
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+    <h1 class="mb-0"><i class="fa-solid fa-hands-praying me-2"></i>Prayer Requests</h1>
+    <div class="d-flex gap-2 flex-wrap">
+        <?php if ($featureEnabled === true): ?>
+            <a href="/prayer-requests/submit" class="btn btn-success">
+                <i class="fa-solid fa-plus me-1"></i> Submit a Request
+            </a>
+        <?php endif; ?>
+        <?php if ($isMod === true): ?>
+            <a href="/prayer-requests/manage" class="btn btn-outline-primary">
+                <i class="fa-solid fa-gauge-high me-1"></i> Moderate
+                <?php if ($pendingCount > 0): ?>
+                    <span class="badge bg-warning text-dark ms-1"><?php echo $pendingCount; ?></span>
+                <?php endif; ?>
+            </a>
+        <?php endif; ?>
+    </div>
+</div>
+
+<?php if ($featureEnabled === false): ?>
+    <div class="alert alert-warning">
+        <i class="fa-solid fa-triangle-exclamation me-1"></i>
+        Prayer Requests are disabled for this site.
+        <?php if ($isMod === true): ?>
+            Visit <a href="/settings" class="alert-link">Site Settings</a> to re-enable.
+        <?php endif; ?>
+    </div>
+<?php else: ?>
+
+    <?php if ($anonymousEnabled === true): ?>
+        <div class="alert alert-info small">
+            <i class="fa-solid fa-circle-info me-1"></i>
+            Visitors without an account can submit anonymously at
+            <a href="/prayer-requests/anonymous" class="alert-link">/prayer-requests/anonymous</a>.
+        </div>
+    <?php endif; ?>
+
+    <!-- 📋 My Requests -->
+    <section class="mb-5">
+        <h2 class="h5 mb-3"><i class="fa-solid fa-user me-2"></i>My Requests</h2>
+
+        <?php if (count($myRequests) === 0): ?>
+            <div class="alert alert-light border">
+                You haven't submitted any prayer requests yet.
+                <a href="/prayer-requests/submit" class="alert-link">Submit your first request</a>.
+            </div>
+        <?php else: ?>
+            <div class="portal-data-list">
+                <div class="portal-data-row portal-data-header d-none d-md-flex">
+                    <div class="col-md-5">Subject</div>
+                    <div class="col-md-2">Visibility</div>
+                    <div class="col-md-2">Status</div>
+                    <div class="col-md-2">Submitted</div>
+                    <div class="col-md-1 text-end">View</div>
+                </div>
+                <?php foreach ($myRequests as $req): ?>
+                    <div class="portal-data-row">
+                        <div class="col-12 col-md-5">
+                            <strong><?php echo htmlspecialchars($req['subject'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                            <?php if ((int) $req['isAnonymous'] === 1): ?>
+                                <span class="badge bg-secondary ms-1">Anon</span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <?php if ($req['visibility'] === 'congregation'): ?>
+                                <span class="badge bg-info-subtle text-info-emphasis">
+                                    <i class="fa-solid fa-people-group me-1"></i>Congregation
+                                </span>
+                            <?php else: ?>
+                                <span class="badge bg-secondary-subtle text-secondary-emphasis">
+                                    <i class="fa-solid fa-user-shield me-1"></i>Leadership
+                                </span>
+                            <?php endif; ?>
+                        </div>
+                        <div class="col-6 col-md-2">
+                            <?php echo $renderStatusBadge((string) $req['status']); ?>
+                        </div>
+                        <div class="col-6 col-md-2 small text-muted">
+                            <?php echo htmlspecialchars(date('Y-m-d', strtotime((string) $req['createdAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                        </div>
+                        <div class="col-6 col-md-1 text-end">
+                            <a href="/prayer-requests/view?id=<?php echo (int) $req['requestID']; ?>"
+                               class="btn btn-sm btn-outline-secondary">
+                                <i class="fa-solid fa-eye"></i>
+                            </a>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        <?php endif; ?>
+    </section>
+
+    <!-- 🌿 Congregation feed -->
+    <?php if ($congregationEnabled === true): ?>
+        <section class="mb-5">
+            <h2 class="h5 mb-3">
+                <i class="fa-solid fa-people-group me-2"></i>Congregation Prayer Feed
+            </h2>
+
+            <?php if (count($congFeed) === 0): ?>
+                <div class="alert alert-light border">
+                    No congregation-visible prayer requests yet.
+                </div>
+            <?php else: ?>
+                <div class="row g-3">
+                    <?php foreach ($congFeed as $req): ?>
+                        <?php
+                        $name = (int) $req['isAnonymous'] === 1
+                            ? 'Anonymous'
+                            : ($req['submitterFullName'] ?? 'Anonymous');
+                        $isAnswered = $req['status'] === 'answered';
+                        ?>
+                        <div class="col-12 col-md-6 col-lg-4">
+                            <div class="card h-100 shadow-sm">
+                                <div class="card-body">
+                                    <div class="d-flex justify-content-between align-items-start mb-2">
+                                        <h3 class="h6 mb-0">
+                                            <?php echo htmlspecialchars($req['subject'], ENT_QUOTES, 'UTF-8'); ?>
+                                        </h3>
+                                        <?php echo $renderStatusBadge((string) $req['status']); ?>
+                                    </div>
+                                    <p class="text-muted small mb-2">
+                                        <i class="fa-solid fa-user me-1"></i>
+                                        <?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?>
+                                        &middot;
+                                        <?php echo htmlspecialchars(date('Y-m-d', strtotime((string) $req['createdAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                                    </p>
+                                    <p class="card-text small">
+                                        <?php
+                                        $body = (string) $req['body'];
+                                        $body = strlen($body) > 220 ? substr($body, 0, 217) . '…' : $body;
+                                        echo nl2br(htmlspecialchars($body, ENT_QUOTES, 'UTF-8'));
+                                        ?>
+                                    </p>
+                                    <?php if ($isAnswered === true && (string) ($req['testimony'] ?? '') !== ''): ?>
+                                        <div class="alert alert-success small mb-0">
+                                            <i class="fa-solid fa-seedling me-1"></i>
+                                            <strong>Testimony:</strong>
+                                            <?php
+                                            $t = (string) $req['testimony'];
+                                            $t = strlen($t) > 180 ? substr($t, 0, 177) . '…' : $t;
+                                            echo nl2br(htmlspecialchars($t, ENT_QUOTES, 'UTF-8'));
+                                            ?>
+                                        </div>
+                                    <?php endif; ?>
+                                </div>
+                                <div class="card-footer bg-transparent border-0 pt-0">
+                                    <a href="/prayer-requests/view?id=<?php echo (int) $req['requestID']; ?>"
+                                       class="btn btn-sm btn-outline-secondary w-100">
+                                        <i class="fa-solid fa-eye me-1"></i> View
+                                    </a>
+                                </div>
+                            </div>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+        </section>
+    <?php endif; ?>
+
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/prayer-requests/manage.php
+++ b/web/public_html/prayer-requests/manage.php
@@ -1,0 +1,253 @@
+<?php
+// Path: public_html/prayer-requests/manage.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Moderation Queue 🛡️
+ * -----------------------------------------------------------------------------
+ * Admin-only moderation view. Lists pending, active, answered, and archived
+ * requests with quick-action buttons that POST to moderate.php.
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+// 📌 Page metadata
+$pageTitle   = 'Moderate Prayer Requests';
+$pageSection = 'prayer-requests';
+$breadcrumbs = [
+    'Dashboard'        => '/',
+    'Prayer Requests'  => '/prayer-requests',
+    'Moderate'         => '',
+];
+
+// 🛡️ Admin only
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    $pageTitle = 'Forbidden';
+    require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+    echo '<div class="alert alert-danger"><i class="fa-solid fa-lock me-1"></i>Moderator access required.</div>';
+    echo '<a href="/prayer-requests" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i> Back</a>';
+    require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php';
+    exit();
+}
+
+$siteId = Site::id();
+
+// 🔍 Filter parameters
+$filterStatus = (string) ($_GET['status'] ?? 'pending');
+$validStatuses = ['pending', 'active', 'answered', 'archived'];
+if (in_array($filterStatus, $validStatuses, true) === false) {
+    $filterStatus = 'pending';
+}
+
+// 📋 Fetch rows (siteID-scoped + status-filtered)
+$rows = [];
+$stmt = $mysqli->prepare(
+    'SELECT pr.*, u.fullName AS submitterFullName, m.fullName AS moderatorFullName '
+    . 'FROM tblPrayerRequests pr '
+    . 'LEFT JOIN tblUsers u ON u.userID = pr.submitterID '
+    . 'LEFT JOIN tblUsers m ON m.userID = pr.moderatorID '
+    . 'WHERE pr.siteID = ? AND pr.status = ? '
+    . 'ORDER BY pr.createdAt DESC LIMIT 100'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('is', $siteId, $filterStatus);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    while ($r = $result->fetch_assoc()) {
+        $rows[] = $r;
+    }
+    $stmt->close();
+}
+
+// 📊 Tab counters
+$counts = ['pending' => 0, 'active' => 0, 'answered' => 0, 'archived' => 0];
+$stmt = $mysqli->prepare(
+    'SELECT status, COUNT(*) AS cnt FROM tblPrayerRequests '
+    . 'WHERE siteID = ? GROUP BY status'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('i', $siteId);
+    $stmt->execute();
+    $result = $stmt->get_result();
+    while ($r = $result->fetch_assoc()) {
+        $counts[(string) $r['status']] = (int) $r['cnt'];
+    }
+    $stmt->close();
+}
+
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+$csrf = Auth::csrfToken();
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+    <h1 class="mb-0"><i class="fa-solid fa-gauge-high me-2"></i>Moderate Prayer Requests</h1>
+    <a href="/prayer-requests" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left me-1"></i> Back
+    </a>
+</div>
+
+<!-- 🗂️ Status tabs -->
+<ul class="nav nav-tabs mb-3">
+    <?php
+    $tabs = [
+        'pending'  => ['label' => 'Pending',  'icon' => 'fa-hourglass-half'],
+        'active'   => ['label' => 'Active',   'icon' => 'fa-hands-praying'],
+        'answered' => ['label' => 'Answered', 'icon' => 'fa-check-double'],
+        'archived' => ['label' => 'Archived', 'icon' => 'fa-box-archive'],
+    ];
+    foreach ($tabs as $key => $info):
+        $active = $filterStatus === $key ? ' active' : '';
+    ?>
+        <li class="nav-item">
+            <a class="nav-link<?php echo $active; ?>"
+               href="/prayer-requests/manage?status=<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>">
+                <i class="fa-solid <?php echo $info['icon']; ?> me-1"></i>
+                <?php echo htmlspecialchars($info['label'], ENT_QUOTES, 'UTF-8'); ?>
+                <span class="badge bg-secondary ms-1"><?php echo (int) $counts[$key]; ?></span>
+            </a>
+        </li>
+    <?php endforeach; ?>
+</ul>
+
+<?php if (count($rows) === 0): ?>
+    <div class="alert alert-light border">
+        No requests in this status.
+    </div>
+<?php else: ?>
+    <div class="portal-data-list">
+        <div class="portal-data-row portal-data-header d-none d-md-flex">
+            <div class="col-md-4">Subject</div>
+            <div class="col-md-2">Submitter</div>
+            <div class="col-md-2">Visibility</div>
+            <div class="col-md-2">Submitted</div>
+            <div class="col-md-2 text-end">Actions</div>
+        </div>
+
+        <?php foreach ($rows as $req): ?>
+            <?php
+            $submitterDisplay = (int) $req['isAnonymous'] === 1
+                ? 'Anonymous'
+                : (string) ($req['submitterFullName'] ?? '(unknown)');
+            $modSeesRealName = (int) $req['isAnonymous'] === 1 && $req['submitterFullName'] !== null;
+            $anonContactName  = (string) ($req['submitterName']  ?? '');
+            $anonContactEmail = (string) ($req['submitterEmail'] ?? '');
+            ?>
+            <div class="portal-data-row">
+                <div class="col-12 col-md-4">
+                    <strong>
+                        <a href="/prayer-requests/view?id=<?php echo (int) $req['requestID']; ?>">
+                            <?php echo htmlspecialchars((string) $req['subject'], ENT_QUOTES, 'UTF-8'); ?>
+                        </a>
+                    </strong>
+                    <p class="small text-muted mb-0">
+                        <?php
+                        $excerpt = (string) $req['body'];
+                        $excerpt = strlen($excerpt) > 120 ? substr($excerpt, 0, 117) . '…' : $excerpt;
+                        echo htmlspecialchars($excerpt, ENT_QUOTES, 'UTF-8');
+                        ?>
+                    </p>
+                </div>
+                <div class="col-6 col-md-2 small">
+                    <?php echo htmlspecialchars($submitterDisplay, ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($modSeesRealName === true): ?>
+                        <div class="text-warning-emphasis small">
+                            <i class="fa-solid fa-eye me-1"></i>
+                            <?php echo htmlspecialchars((string) $req['submitterFullName'], ENT_QUOTES, 'UTF-8'); ?>
+                        </div>
+                    <?php endif; ?>
+                    <?php if ($anonContactName !== '' || $anonContactEmail !== ''): ?>
+                        <div class="text-muted small">
+                            <?php if ($anonContactName !== ''): ?>
+                                <i class="fa-solid fa-user me-1"></i>
+                                <?php echo htmlspecialchars($anonContactName, ENT_QUOTES, 'UTF-8'); ?><br>
+                            <?php endif; ?>
+                            <?php if ($anonContactEmail !== ''): ?>
+                                <i class="fa-solid fa-envelope me-1"></i>
+                                <a href="mailto:<?php echo htmlspecialchars($anonContactEmail, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <?php echo htmlspecialchars($anonContactEmail, ENT_QUOTES, 'UTF-8'); ?>
+                                </a>
+                            <?php endif; ?>
+                        </div>
+                    <?php endif; ?>
+                </div>
+                <div class="col-6 col-md-2 small">
+                    <?php if ($req['visibility'] === 'congregation'): ?>
+                        <span class="badge bg-info-subtle text-info-emphasis">
+                            <i class="fa-solid fa-people-group me-1"></i>Congregation
+                        </span>
+                    <?php else: ?>
+                        <span class="badge bg-secondary-subtle text-secondary-emphasis">
+                            <i class="fa-solid fa-user-shield me-1"></i>Leadership
+                        </span>
+                    <?php endif; ?>
+                </div>
+                <div class="col-6 col-md-2 small text-muted">
+                    <?php echo htmlspecialchars(date('Y-m-d H:i', strtotime((string) $req['createdAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                </div>
+                <div class="col-6 col-md-2 text-end">
+                    <div class="btn-group btn-group-sm" role="group">
+                        <a href="/prayer-requests/view?id=<?php echo (int) $req['requestID']; ?>"
+                           class="btn btn-outline-secondary" title="View">
+                            <i class="fa-solid fa-eye"></i>
+                        </a>
+
+                        <?php if ($req['status'] === 'pending'): ?>
+                            <form method="post" action="/prayer-requests/moderate" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                                <input type="hidden" name="requestID" value="<?php echo (int) $req['requestID']; ?>">
+                                <input type="hidden" name="action" value="approve">
+                                <input type="hidden" name="redirect" value="manage">
+                                <input type="hidden" name="status_filter" value="<?php echo htmlspecialchars($filterStatus, ENT_QUOTES, 'UTF-8'); ?>">
+                                <button type="submit" class="btn btn-outline-success" title="Approve">
+                                    <i class="fa-solid fa-check"></i>
+                                </button>
+                            </form>
+                        <?php endif; ?>
+
+                        <?php if ($req['status'] === 'active'): ?>
+                            <form method="post" action="/prayer-requests/moderate" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                                <input type="hidden" name="requestID" value="<?php echo (int) $req['requestID']; ?>">
+                                <input type="hidden" name="action" value="answer">
+                                <input type="hidden" name="redirect" value="manage">
+                                <input type="hidden" name="status_filter" value="<?php echo htmlspecialchars($filterStatus, ENT_QUOTES, 'UTF-8'); ?>">
+                                <button type="submit" class="btn btn-outline-info" title="Mark answered">
+                                    <i class="fa-solid fa-check-double"></i>
+                                </button>
+                            </form>
+                        <?php endif; ?>
+
+                        <?php if ($req['status'] !== 'archived'): ?>
+                            <form method="post" action="/prayer-requests/moderate" class="d-inline">
+                                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                                <input type="hidden" name="requestID" value="<?php echo (int) $req['requestID']; ?>">
+                                <input type="hidden" name="action" value="archive">
+                                <input type="hidden" name="redirect" value="manage">
+                                <input type="hidden" name="status_filter" value="<?php echo htmlspecialchars($filterStatus, ENT_QUOTES, 'UTF-8'); ?>">
+                                <button type="submit" class="btn btn-outline-warning" title="Archive">
+                                    <i class="fa-solid fa-box-archive"></i>
+                                </button>
+                            </form>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/prayer-requests/moderate.php
+++ b/web/public_html/prayer-requests/moderate.php
@@ -1,0 +1,176 @@
+<?php
+// Path: public_html/prayer-requests/moderate.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Moderation Action Handler 🛡️
+ * -----------------------------------------------------------------------------
+ * POST endpoint that executes moderator actions on a single request:
+ *   • approve                 — pending → active
+ *   • archive                 — * → archived
+ *   • answer                  — active → answered (optional testimony)
+ *   • visibility-leadership   — flip visibility to leadership
+ *   • visibility-congregation — flip visibility to congregation
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+// 🛡️ POST only
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /prayer-requests/manage', true, 302);
+    exit();
+}
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+// 🔐 CSRF
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    Logger::activity('PrayerRequestModRejected', 'Invalid CSRF on prayer-requests/moderate');
+    header('Location: /prayer-requests/manage', true, 302);
+    exit();
+}
+
+$siteId    = Site::id();
+$user      = App::user();
+$modId     = (int) ($user['userID'] ?? 0);
+$requestId = (int) ($_POST['requestID'] ?? 0);
+$action    = (string) ($_POST['action'] ?? '');
+$testimony = trim((string) ($_POST['testimony'] ?? ''));
+
+$redirect      = (string) ($_POST['redirect'] ?? 'manage');
+$statusFilter  = (string) ($_POST['status_filter'] ?? '');
+
+if ($requestId <= 0 || $action === '') {
+    header('Location: /prayer-requests/manage', true, 302);
+    exit();
+}
+
+// 🔍 Load the row (siteID-scoped — prevents cross-site tampering)
+$stmt = $mysqli->prepare(
+    'SELECT requestID, status, visibility FROM tblPrayerRequests '
+    . 'WHERE siteID = ? AND requestID = ? LIMIT 1'
+);
+$row = null;
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $siteId, $requestId);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+if ($row === null) {
+    header('Location: /prayer-requests/manage', true, 302);
+    exit();
+}
+
+// 🛠️ Decide the SQL update
+$newStatus     = null;
+$newVisibility = null;
+$setAnswered   = false;
+$setTestimony  = null;
+
+switch ($action) {
+    case 'approve':
+        $newStatus = 'active';
+        break;
+    case 'archive':
+        $newStatus = 'archived';
+        break;
+    case 'answer':
+        $newStatus   = 'answered';
+        $setAnswered = true;
+        if ((App::settings('prayerRequests.allowTestimony') ?? 'true') === 'true'
+            && $testimony !== ''
+        ) {
+            $setTestimony = mb_substr($testimony, 0, 4000);
+        }
+        break;
+    case 'visibility-leadership':
+        $newVisibility = 'leadership';
+        break;
+    case 'visibility-congregation':
+        if ((App::settings('prayerRequests.allowCongregationFeed') ?? 'true') === 'true') {
+            $newVisibility = 'congregation';
+        } else {
+            $newVisibility = 'leadership';
+        }
+        break;
+    default:
+        header('Location: /prayer-requests/manage', true, 302);
+        exit();
+}
+
+// 🛠️ Build dynamic UPDATE
+$set    = ['moderatorID = ?', 'moderatedAt = NOW()'];
+$types  = 'i';
+$params = [$modId];
+
+if ($newStatus !== null) {
+    $set[]    = 'status = ?';
+    $types   .= 's';
+    $params[] = $newStatus;
+}
+if ($newVisibility !== null) {
+    $set[]    = 'visibility = ?';
+    $types   .= 's';
+    $params[] = $newVisibility;
+}
+if ($setAnswered === true) {
+    $set[] = 'answeredAt = NOW()';
+}
+if ($setTestimony !== null) {
+    $set[]    = 'testimony = ?';
+    $types   .= 's';
+    $params[] = $setTestimony;
+}
+
+$sql = 'UPDATE tblPrayerRequests SET ' . implode(', ', $set)
+     . ' WHERE siteID = ? AND requestID = ? LIMIT 1';
+$types   .= 'ii';
+$params[] = $siteId;
+$params[] = $requestId;
+
+$stmt = $mysqli->prepare($sql);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'PR_MOD_UPDATE_PREP', $mysqli->error, '');
+    header('Location: /prayer-requests/manage', true, 302);
+    exit();
+}
+$stmt->bind_param($types, ...$params);
+$ok = $stmt->execute();
+$stmt->close();
+
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'PR_MOD_UPDATE_FAIL', $mysqli->error, '');
+} else {
+    Logger::activity(
+        'PrayerRequestModerated',
+        'Request #' . $requestId . ' action=' . $action
+    );
+}
+
+// 🔀 Redirect back to the right place
+if ($redirect === 'view') {
+    header('Location: /prayer-requests/view?id=' . $requestId, true, 302);
+} else {
+    $qs = $statusFilter !== '' ? '?status=' . urlencode($statusFilter) : '';
+    header('Location: /prayer-requests/manage' . $qs, true, 302);
+}
+exit();

--- a/web/public_html/prayer-requests/save.php
+++ b/web/public_html/prayer-requests/save.php
@@ -1,0 +1,137 @@
+<?php
+// Path: public_html/prayer-requests/save.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Save Handler (Logged-in) 🙏
+ * -----------------------------------------------------------------------------
+ * POST endpoint for logged-in members submitting a new prayer request.
+ *   - Verifies CSRF
+ *   - Validates subject / body / visibility / anonymous flag
+ *   - Honours requireModeration setting (pending vs active)
+ *   - Honours allowCongregationFeed setting (downgrades to leadership if off)
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+// 🛡️ Only POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /prayer-requests/submit', true, 302);
+    exit();
+}
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+// 🚦 Feature gate
+if ((App::settings('prayerRequests.enabled') ?? 'true') !== 'true') {
+    header('Location: /prayer-requests', true, 302);
+    exit();
+}
+
+// 🔐 CSRF
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    Logger::activity('PrayerRequestRejected', 'Invalid CSRF on prayer-requests/save');
+    header('Location: /prayer-requests/submit?err=' . urlencode('Security check failed. Please try again.'), true, 302);
+    exit();
+}
+
+// 📥 Input
+$subject     = trim((string) ($_POST['subject'] ?? ''));
+$body        = trim((string) ($_POST['body'] ?? ''));
+$visibility  = (string) ($_POST['visibility'] ?? 'leadership');
+$isAnonymous = isset($_POST['isAnonymous']) === true && $_POST['isAnonymous'] === '1' ? 1 : 0;
+
+// 🛡️ Validate
+if ($subject === '' || $body === '') {
+    header('Location: /prayer-requests/submit?err=' . urlencode('Subject and request text are required.'), true, 302);
+    exit();
+}
+if (mb_strlen($subject) > 255) {
+    $subject = mb_substr($subject, 0, 255);
+}
+if (mb_strlen($body) > 4000) {
+    $body = mb_substr($body, 0, 4000);
+}
+if ($visibility !== 'leadership' && $visibility !== 'congregation') {
+    $visibility = 'leadership';
+}
+
+// 🔒 Downgrade visibility if congregation feed is disabled site-wide
+if ($visibility === 'congregation'
+    && (App::settings('prayerRequests.allowCongregationFeed') ?? 'true') !== 'true'
+) {
+    $visibility = 'leadership';
+}
+
+// 🚦 Decide initial status based on moderation setting
+$requireModeration = (App::settings('prayerRequests.requireModeration') ?? 'true') === 'true';
+$initialStatus     = $requireModeration === true ? 'pending' : 'active';
+
+// 🌐 Capture context
+$siteId = Site::id();
+$user   = App::user();
+$userId = (int) ($user['userID'] ?? 0);
+
+$ip = $_SERVER['HTTP_CF_CONNECTING_IP']
+    ?? $_SERVER['HTTP_X_FORWARDED_FOR']
+    ?? $_SERVER['REMOTE_ADDR']
+    ?? '';
+if (str_contains((string) $ip, ',') === true) {
+    $ip = trim(explode(',', (string) $ip)[0]);
+}
+$ip = mb_substr((string) $ip, 0, 45);
+
+// 💾 Insert
+$stmt = $mysqli->prepare(
+    'INSERT INTO tblPrayerRequests '
+    . '(siteID, submitterID, submitterIP, subject, body, visibility, status, isAnonymous) '
+    . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'PR_INSERT_PREP', $mysqli->error, '');
+    header('Location: /prayer-requests/submit?err=' . urlencode('Something went wrong. Please try again.'), true, 302);
+    exit();
+}
+
+$stmt->bind_param(
+    'iissssi' . 'i',
+    $siteId,
+    $userId,
+    $ip,
+    $subject,
+    $body,
+    $visibility,
+    $initialStatus,
+    $isAnonymous
+);
+$ok = $stmt->execute();
+$newId = (int) $stmt->insert_id;
+$stmt->close();
+
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'PR_INSERT_FAIL', $mysqli->error, '');
+    header('Location: /prayer-requests/submit?err=' . urlencode('Failed to save your request. Please try again.'), true, 302);
+    exit();
+}
+
+Logger::activity('PrayerRequestSubmitted', 'Request #' . $newId . ' submitted (status=' . $initialStatus . ')');
+
+// 🔀 Redirect — pending shows a "thanks, awaiting review" message; active jumps straight to view
+if ($initialStatus === 'pending') {
+    header('Location: /prayer-requests?submitted=1', true, 302);
+} else {
+    header('Location: /prayer-requests/view?id=' . $newId, true, 302);
+}
+exit();

--- a/web/public_html/prayer-requests/submit.php
+++ b/web/public_html/prayer-requests/submit.php
@@ -1,0 +1,156 @@
+<?php
+// Path: public_html/prayer-requests/submit.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — Submit Form (Logged-in) 🙏
+ * -----------------------------------------------------------------------------
+ * Renders the prayer-request submission form for authenticated members.
+ * Members can choose visibility (leadership-only or congregation feed) and
+ * may opt to display their request anonymously. The POST handler lives in
+ * save.php and validates + persists the row.
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+// 📌 Page metadata
+$pageTitle   = 'Submit Prayer Request';
+$pageSection = 'prayer-requests';
+$breadcrumbs = [
+    'Dashboard'        => '/',
+    'Prayer Requests'  => '/prayer-requests',
+    'Submit'           => '',
+];
+
+// 🛡️ Require login
+Auth::ensureSession();
+Auth::requireLogin();
+
+// 🚦 Feature gate
+$featureEnabled      = (App::settings('prayerRequests.enabled') ?? 'true') === 'true';
+$congregationEnabled = (App::settings('prayerRequests.allowCongregationFeed') ?? 'true') === 'true';
+$requireModeration   = (App::settings('prayerRequests.requireModeration') ?? 'true') === 'true';
+
+if ($featureEnabled === false) {
+    header('Location: /prayer-requests', true, 302);
+    exit();
+}
+
+// 💬 Read flash error from query string (set by save.php)
+$flashError = (string) ($_GET['err'] ?? '');
+
+// 📄 Include shared header template
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-4">
+    <h1 class="mb-0"><i class="fa-solid fa-pen-to-square me-2"></i>Submit a Prayer Request</h1>
+    <a href="/prayer-requests" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left me-1"></i> Back
+    </a>
+</div>
+
+<?php if ($flashError !== ''): ?>
+    <div class="alert alert-danger">
+        <i class="fa-solid fa-circle-exclamation me-1"></i>
+        <?php echo htmlspecialchars($flashError, ENT_QUOTES, 'UTF-8'); ?>
+    </div>
+<?php endif; ?>
+
+<div class="card shadow-sm">
+    <div class="card-body">
+        <form method="post" action="/prayer-requests/save" novalidate>
+            <input type="hidden" name="csrf_token"
+                   value="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
+
+            <!-- 📝 Subject -->
+            <div class="mb-3">
+                <label for="subject" class="form-label">
+                    Subject <span class="text-danger">*</span>
+                </label>
+                <input type="text" class="form-control" id="subject" name="subject"
+                       maxlength="255" required autofocus
+                       placeholder="A short title (e.g. 'Healing for my mother')">
+            </div>
+
+            <!-- 📜 Body -->
+            <div class="mb-3">
+                <label for="body" class="form-label">
+                    Request <span class="text-danger">*</span>
+                </label>
+                <textarea class="form-control" id="body" name="body" rows="6"
+                          maxlength="4000" required
+                          placeholder="Share what you'd like prayer for…"></textarea>
+                <div class="form-text">Up to 4000 characters.</div>
+            </div>
+
+            <!-- 👁️ Visibility -->
+            <div class="mb-3">
+                <label class="form-label d-block">Visibility</label>
+
+                <div class="form-check">
+                    <input class="form-check-input" type="radio" name="visibility"
+                           id="vis-leadership" value="leadership" checked>
+                    <label class="form-check-label" for="vis-leadership">
+                        <i class="fa-solid fa-user-shield me-1"></i>
+                        <strong>Leadership only</strong>
+                        <div class="small text-muted">
+                            Visible only to pastors/leaders for confidential prayer.
+                        </div>
+                    </label>
+                </div>
+
+                <?php if ($congregationEnabled === true): ?>
+                    <div class="form-check mt-2">
+                        <input class="form-check-input" type="radio" name="visibility"
+                               id="vis-congregation" value="congregation">
+                        <label class="form-check-label" for="vis-congregation">
+                            <i class="fa-solid fa-people-group me-1"></i>
+                            <strong>Share with the congregation</strong>
+                            <div class="small text-muted">
+                                Will appear on the public prayer feed for all logged-in members.
+                            </div>
+                        </label>
+                    </div>
+                <?php endif; ?>
+            </div>
+
+            <!-- 🕶️ Anonymous toggle -->
+            <div class="form-check mb-4">
+                <input class="form-check-input" type="checkbox" name="isAnonymous"
+                       id="isAnonymous" value="1">
+                <label class="form-check-label" for="isAnonymous">
+                    Display my name as <strong>Anonymous</strong> on the congregation feed
+                </label>
+                <div class="form-text">
+                    Leaders will still see who submitted the request for follow-up.
+                </div>
+            </div>
+
+            <?php if ($requireModeration === true): ?>
+                <div class="alert alert-info small">
+                    <i class="fa-solid fa-circle-info me-1"></i>
+                    Your request will be reviewed by a moderator before it goes live.
+                </div>
+            <?php endif; ?>
+
+            <div class="d-flex gap-2">
+                <button type="submit" class="btn btn-success">
+                    <i class="fa-solid fa-paper-plane me-1"></i> Submit Request
+                </button>
+                <a href="/prayer-requests" class="btn btn-outline-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/prayer-requests/view.php
+++ b/web/public_html/prayer-requests/view.php
@@ -1,0 +1,236 @@
+<?php
+// Path: public_html/prayer-requests/view.php
+/**
+ * -----------------------------------------------------------------------------
+ * Prayer Requests — View Single Request 🙏
+ * -----------------------------------------------------------------------------
+ * Displays a single prayer request. Access rules:
+ *   • Submitter can always view their own request (any status)
+ *   • Site admins / leaders can view any request
+ *   • Other logged-in members can view if status IN (active|answered)
+ *     AND visibility = 'congregation'
+ *
+ * @package   Portal\PrayerRequests
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+// 📌 Page metadata (subject filled in once row is loaded)
+$pageTitle   = 'Prayer Request';
+$pageSection = 'prayer-requests';
+$breadcrumbs = [
+    'Dashboard'        => '/',
+    'Prayer Requests'  => '/prayer-requests',
+    'View'             => '',
+];
+
+// 🛡️ Require login
+Auth::ensureSession();
+Auth::requireLogin();
+
+$siteId    = Site::id();
+$user      = App::user();
+$userId    = (int) ($user['userID'] ?? 0);
+$isMod     = App::isAdmin();
+$requestId = (int) ($_GET['id'] ?? 0);
+
+if ($requestId <= 0) {
+    header('Location: /prayer-requests', true, 302);
+    exit();
+}
+
+// 🔍 Load the request (siteID-scoped)
+$stmt = $mysqli->prepare(
+    'SELECT pr.*, '
+    . 'u.fullName AS submitterFullName, '
+    . 'm.fullName AS moderatorFullName '
+    . 'FROM tblPrayerRequests pr '
+    . 'LEFT JOIN tblUsers u ON u.userID = pr.submitterID '
+    . 'LEFT JOIN tblUsers m ON m.userID = pr.moderatorID '
+    . 'WHERE pr.siteID = ? AND pr.requestID = ? LIMIT 1'
+);
+$req = null;
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $siteId, $requestId);
+    $stmt->execute();
+    $req = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+if ($req === null) {
+    http_response_code(404);
+    $pageTitle = 'Not Found';
+    require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+    echo '<div class="alert alert-warning"><i class="fa-solid fa-circle-exclamation me-1"></i>Prayer request not found.</div>';
+    echo '<a href="/prayer-requests" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i> Back</a>';
+    require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php';
+    exit();
+}
+
+// 🛡️ Access control
+$isOwner = ($userId > 0 && (int) ($req['submitterID'] ?? 0) === $userId);
+$isCongregationVisible = ($req['visibility'] === 'congregation'
+    && in_array($req['status'], ['active', 'answered'], true));
+
+if ($isOwner === false && $isMod === false && $isCongregationVisible === false) {
+    http_response_code(403);
+    $pageTitle = 'Forbidden';
+    require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+    echo '<div class="alert alert-danger"><i class="fa-solid fa-lock me-1"></i>You do not have access to this prayer request.</div>';
+    echo '<a href="/prayer-requests" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i> Back</a>';
+    require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php';
+    exit();
+}
+
+// 🏷️ Now that we have the row, refine the page title
+$pageTitle = (string) $req['subject'];
+
+// 🎨 Display helpers
+$submitterDisplay = (int) $req['isAnonymous'] === 1
+    ? 'Anonymous'
+    : (string) ($req['submitterFullName'] ?? 'Unknown');
+
+// 🛡️ Mods always see real submitter name even for anonymous posts (for follow-up)
+$modSubmitterDisplay = $isMod === true && (int) $req['isAnonymous'] === 1
+    ? (string) ($req['submitterFullName'] ?? '(unknown)')
+    : '';
+
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+$statusBadges = [
+    'pending'  => ['warning',   'fa-hourglass-half', 'Pending review'],
+    'active'   => ['success',   'fa-hands-praying',  'Active'],
+    'answered' => ['info',      'fa-check-double',   'Answered'],
+    'archived' => ['secondary', 'fa-box-archive',    'Archived'],
+];
+$badge = $statusBadges[$req['status']] ?? ['secondary', 'fa-circle', ucfirst((string) $req['status'])];
+?>
+
+<div class="d-flex justify-content-between align-items-start mb-4 flex-wrap gap-2">
+    <div>
+        <h1 class="mb-1"><?php echo htmlspecialchars((string) $req['subject'], ENT_QUOTES, 'UTF-8'); ?></h1>
+        <div>
+            <span class="badge bg-<?php echo $badge[0]; ?> me-1">
+                <i class="fa-solid <?php echo $badge[1]; ?> me-1"></i><?php echo $badge[2]; ?>
+            </span>
+            <?php if ($req['visibility'] === 'congregation'): ?>
+                <span class="badge bg-info-subtle text-info-emphasis">
+                    <i class="fa-solid fa-people-group me-1"></i>Congregation
+                </span>
+            <?php else: ?>
+                <span class="badge bg-secondary-subtle text-secondary-emphasis">
+                    <i class="fa-solid fa-user-shield me-1"></i>Leadership only
+                </span>
+            <?php endif; ?>
+        </div>
+    </div>
+    <div class="d-flex gap-2">
+        <?php if ($isMod === true): ?>
+            <a href="/prayer-requests/manage" class="btn btn-outline-primary">
+                <i class="fa-solid fa-gauge-high me-1"></i> Moderate
+            </a>
+        <?php endif; ?>
+        <a href="/prayer-requests" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-arrow-left me-1"></i> Back
+        </a>
+    </div>
+</div>
+
+<div class="card shadow-sm mb-4">
+    <div class="card-body">
+        <p class="text-muted small mb-3">
+            <i class="fa-solid fa-user me-1"></i>
+            <?php echo htmlspecialchars($submitterDisplay, ENT_QUOTES, 'UTF-8'); ?>
+            <?php if ($modSubmitterDisplay !== ''): ?>
+                <span class="badge bg-warning-subtle text-warning-emphasis ms-1" title="Visible to moderators only">
+                    posted by <?php echo htmlspecialchars($modSubmitterDisplay, ENT_QUOTES, 'UTF-8'); ?>
+                </span>
+            <?php endif; ?>
+            &middot;
+            <?php echo htmlspecialchars(date('Y-m-d H:i', strtotime((string) $req['createdAt'])), ENT_QUOTES, 'UTF-8'); ?>
+        </p>
+
+        <div class="mb-0" style="white-space: pre-wrap;">
+            <?php echo nl2br(htmlspecialchars((string) $req['body'], ENT_QUOTES, 'UTF-8')); ?>
+        </div>
+    </div>
+</div>
+
+<?php if ($req['status'] === 'answered' && (string) ($req['testimony'] ?? '') !== ''): ?>
+    <div class="card shadow-sm mb-4 border-success">
+        <div class="card-body">
+            <h2 class="h5 text-success mb-2">
+                <i class="fa-solid fa-seedling me-2"></i>Praise / Testimony
+            </h2>
+            <p class="text-muted small mb-3">
+                <?php if ($req['answeredAt'] !== null): ?>
+                    <i class="fa-solid fa-calendar-check me-1"></i>
+                    <?php echo htmlspecialchars(date('Y-m-d', strtotime((string) $req['answeredAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                <?php endif; ?>
+            </p>
+            <div style="white-space: pre-wrap;">
+                <?php echo nl2br(htmlspecialchars((string) $req['testimony'], ENT_QUOTES, 'UTF-8')); ?>
+            </div>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php if ($isMod === true): ?>
+    <!-- 🛡️ Moderator quick actions -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-body">
+            <h2 class="h6 mb-3"><i class="fa-solid fa-gauge-high me-1"></i>Moderator actions</h2>
+            <form method="post" action="/prayer-requests/moderate" class="row g-2 align-items-end">
+                <input type="hidden" name="csrf_token"
+                       value="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="requestID" value="<?php echo (int) $req['requestID']; ?>">
+                <input type="hidden" name="redirect"  value="view">
+
+                <div class="col-md-3">
+                    <label for="modAction" class="form-label small mb-1">Action</label>
+                    <select name="action" id="modAction" class="form-select form-select-sm" required>
+                        <option value="approve">Approve (→ active)</option>
+                        <option value="archive">Archive</option>
+                        <option value="answer">Mark answered</option>
+                        <option value="visibility-leadership">Set visibility: Leadership</option>
+                        <option value="visibility-congregation">Set visibility: Congregation</option>
+                    </select>
+                </div>
+                <div class="col-md-7">
+                    <label for="testimony" class="form-label small mb-1">
+                        Testimony (only used when marking answered)
+                    </label>
+                    <input type="text" id="testimony" name="testimony"
+                           class="form-control form-control-sm"
+                           maxlength="2000"
+                           placeholder="Optional praise note">
+                </div>
+                <div class="col-md-2">
+                    <button type="submit" class="btn btn-sm btn-primary w-100">
+                        <i class="fa-solid fa-check me-1"></i> Apply
+                    </button>
+                </div>
+            </form>
+
+            <?php if ($req['moderatorFullName'] !== null && $req['moderatedAt'] !== null): ?>
+                <p class="text-muted small mt-3 mb-0">
+                    Last moderated by
+                    <?php echo htmlspecialchars((string) $req['moderatorFullName'], ENT_QUOTES, 'UTF-8'); ?>
+                    on
+                    <?php echo htmlspecialchars(date('Y-m-d H:i', strtotime((string) $req['moderatedAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                </p>
+            <?php endif; ?>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/sql/039_prayer_requests.sql
+++ b/web/sql/039_prayer_requests.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- 039 — Prayer Requests app
+-- =============================================================================
+-- Per-site prayer request submission, moderation, and tracking. Supports:
+--   • Logged-in submissions (linked to user)
+--   • Anonymous submissions via a public route (CAPTCHA + rate-limited)
+--   • Per-request visibility (leadership-only or congregation feed)
+--   • Status lifecycle: pending → active → answered (+ optional testimony) → archived
+-- =============================================================================
+
+-- 🙏 tblPrayerRequests — submitted prayer requests, per-site scoped
+CREATE TABLE IF NOT EXISTS `tblPrayerRequests` (
+    `requestID`      INT          NOT NULL AUTO_INCREMENT,
+    `siteID`         INT          NOT NULL
+                     COMMENT 'FK → tblSites — the site the request was submitted to',
+    `submitterID`    INT          DEFAULT NULL
+                     COMMENT 'FK → tblUsers — NULL for anonymous public submissions',
+    `submitterName`  VARCHAR(100) DEFAULT NULL
+                     COMMENT 'Optional display name supplied by an anonymous submitter',
+    `submitterEmail` VARCHAR(255) DEFAULT NULL
+                     COMMENT 'Optional contact email supplied by an anonymous submitter (for follow-up)',
+    `submitterIP`    VARCHAR(45)  DEFAULT NULL
+                     COMMENT 'IPv4 or IPv6 of the submitter — for spam analysis only',
+    `subject`        VARCHAR(255) NOT NULL
+                     COMMENT 'Short title for the request',
+    `body`           TEXT         NOT NULL
+                     COMMENT 'Full text of the prayer request',
+    `visibility`     ENUM('leadership','congregation') NOT NULL DEFAULT 'leadership'
+                     COMMENT 'Who can see the request once published. Submitter chooses; moderator may override',
+    `status`         ENUM('pending','active','answered','archived') NOT NULL DEFAULT 'pending'
+                     COMMENT 'Lifecycle: pending=awaiting moderation, active=published, answered=closed with optional testimony, archived=hidden',
+    `isAnonymous`    TINYINT(1)   NOT NULL DEFAULT 0
+                     COMMENT '1 = display "Anonymous" as the submitter in any visible view',
+    `testimony`      TEXT         DEFAULT NULL
+                     COMMENT 'Optional praise / testimony note attached when status moves to answered',
+    `answeredAt`     DATETIME     DEFAULT NULL
+                     COMMENT 'When the request was marked answered',
+    `moderatorID`    INT          DEFAULT NULL
+                     COMMENT 'FK → tblUsers — last admin who moderated this request',
+    `moderatedAt`    DATETIME     DEFAULT NULL,
+    `createdAt`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`requestID`),
+    KEY `idx_site_status` (`siteID`, `status`),
+    KEY `idx_submitter`   (`submitterID`),
+    CONSTRAINT `fk_pr_site` FOREIGN KEY (`siteID`)
+        REFERENCES `tblSites` (`siteID`) ON DELETE RESTRICT,
+    CONSTRAINT `fk_pr_submitter` FOREIGN KEY (`submitterID`)
+        REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_pr_moderator` FOREIGN KEY (`moderatorID`)
+        REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Prayer requests submitted by members or anonymously via the public route.';
+
+-- =============================================================================
+-- Seed default settings
+-- =============================================================================
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'prayerRequests.enabled',              'true',  'true',  0),
+    (NULL, 'prayerRequests.allowAnonymous',       'true',  'true',  0),
+    (NULL, 'prayerRequests.allowCongregationFeed','true',  'true',  0),
+    (NULL, 'prayerRequests.requireModeration',    'true',  'true',  0),
+    (NULL, 'prayerRequests.allowTestimony',       'true',  'true',  0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+-- =============================================================================
+-- Seed routes (mostly protected; one public anonymous route)
+-- =============================================================================
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('prayer-requests',                'prayer-requests/index.php',           1),
+    ('prayer-requests/submit',         'prayer-requests/submit.php',          1),
+    ('prayer-requests/save',           'prayer-requests/save.php',            1),
+    ('prayer-requests/view',           'prayer-requests/view.php',            1),
+    ('prayer-requests/manage',         'prayer-requests/manage.php',          1),
+    ('prayer-requests/moderate',       'prayer-requests/moderate.php',        1),
+    ('prayer-requests/anonymous',      'prayer-requests/anonymous.php',       0),
+    ('prayer-requests/anonymous/save', 'prayer-requests/anonymous-save.php',  0),
+    ('help/prayer-requests',           'help/prayer-requests.php',            0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -1836,9 +1836,80 @@ ON DUPLICATE KEY UPDATE `filename` = `filename`;
 INSERT INTO `tblMigrations` (`filename`) VALUES ('038_branding_powered_by.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('039_prayer_requests.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
 -- Seed the branding.hidePoweredBy setting (matches migration 038)
 INSERT INTO `tblSettings`
     (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`)
 VALUES
     (NULL, 'branding.hidePoweredBy', 'false', 'false', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+-- =============================================================================
+-- 🙏 tblPrayerRequests — prayer-request submissions (matches migration 039)
+-- =============================================================================
+CREATE TABLE IF NOT EXISTS `tblPrayerRequests` (
+    `requestID`      INT          NOT NULL AUTO_INCREMENT,
+    `siteID`         INT          NOT NULL
+                     COMMENT 'FK → tblSites — the site the request was submitted to',
+    `submitterID`    INT          DEFAULT NULL
+                     COMMENT 'FK → tblUsers — NULL for anonymous public submissions',
+    `submitterName`  VARCHAR(100) DEFAULT NULL
+                     COMMENT 'Optional display name supplied by an anonymous submitter',
+    `submitterEmail` VARCHAR(255) DEFAULT NULL
+                     COMMENT 'Optional contact email supplied by an anonymous submitter (for follow-up)',
+    `submitterIP`    VARCHAR(45)  DEFAULT NULL
+                     COMMENT 'IPv4 or IPv6 of the submitter — for spam analysis only',
+    `subject`        VARCHAR(255) NOT NULL
+                     COMMENT 'Short title for the request',
+    `body`           TEXT         NOT NULL
+                     COMMENT 'Full text of the prayer request',
+    `visibility`     ENUM('leadership','congregation') NOT NULL DEFAULT 'leadership'
+                     COMMENT 'Who can see the request once published',
+    `status`         ENUM('pending','active','answered','archived') NOT NULL DEFAULT 'pending'
+                     COMMENT 'Lifecycle: pending → active → answered → archived',
+    `isAnonymous`    TINYINT(1)   NOT NULL DEFAULT 0
+                     COMMENT '1 = display "Anonymous" as the submitter in any visible view',
+    `testimony`      TEXT         DEFAULT NULL
+                     COMMENT 'Optional praise / testimony note attached when status moves to answered',
+    `answeredAt`     DATETIME     DEFAULT NULL
+                     COMMENT 'When the request was marked answered',
+    `moderatorID`    INT          DEFAULT NULL
+                     COMMENT 'FK → tblUsers — last admin who moderated this request',
+    `moderatedAt`    DATETIME     DEFAULT NULL,
+    `createdAt`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`      DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`requestID`),
+    KEY `idx_site_status` (`siteID`, `status`),
+    KEY `idx_submitter`   (`submitterID`),
+    CONSTRAINT `fk_pr_site` FOREIGN KEY (`siteID`)
+        REFERENCES `tblSites` (`siteID`) ON DELETE RESTRICT,
+    CONSTRAINT `fk_pr_submitter` FOREIGN KEY (`submitterID`)
+        REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_pr_moderator` FOREIGN KEY (`moderatorID`)
+        REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Prayer requests submitted by members or anonymously via the public route.';
+
+-- Seed default prayer-request settings (matches migration 039)
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'prayerRequests.enabled',              'true',  'true',  0),
+    (NULL, 'prayerRequests.allowAnonymous',       'true',  'true',  0),
+    (NULL, 'prayerRequests.allowCongregationFeed','true',  'true',  0),
+    (NULL, 'prayerRequests.requireModeration',    'true',  'true',  0),
+    (NULL, 'prayerRequests.allowTestimony',       'true',  'true',  0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+-- Seed prayer-request routes (matches migration 039)
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('prayer-requests',                'prayer-requests/index.php',           1),
+    ('prayer-requests/submit',         'prayer-requests/submit.php',          1),
+    ('prayer-requests/save',           'prayer-requests/save.php',            1),
+    ('prayer-requests/view',           'prayer-requests/view.php',            1),
+    ('prayer-requests/manage',         'prayer-requests/manage.php',          1),
+    ('prayer-requests/moderate',       'prayer-requests/moderate.php',        1),
+    ('prayer-requests/anonymous',      'prayer-requests/anonymous.php',       0),
+    ('prayer-requests/anonymous/save', 'prayer-requests/anonymous-save.php',  0),
+    ('help/prayer-requests',           'help/prayer-requests.php',            0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);


### PR DESCRIPTION
## Summary

New portal app at `/prayer-requests` for collecting and tracking prayer requests, with built-in moderation and an anonymous public-submission route.

- **Logged-in submissions** with per-request visibility — *leadership only* (default) or *congregation feed* (visible to all members of the site).
- **\"Display as anonymous\" toggle** for logged-in submitters — members see *Anonymous*, but leaders still see who submitted for pastoral follow-up.
- **Public anonymous route** `/prayer-requests/anonymous` (no login). Protected by CSRF + Captcha + RateLimiter. Hard-coded to leadership-only visibility and `pending` status for moderator review.
- **Moderation lifecycle**: pending → active → answered (optional testimony) → archived. Mods get a status-grouped queue + per-request quick actions.
- **Per-site settings** seeded with sane defaults — feature toggle, anonymous allowed, congregation feed allowed, require moderation, allow testimony.
- **Help guide** at `/help/prayer-requests` and a tile on the Help Centre landing page.

## Schema

- New migration `web/sql/039_prayer_requests.sql` creates `tblPrayerRequests` + seeds five settings + nine routes.
- `web/sql/full_schema.sql` updated to include the table definition and seed blocks so fresh installs are wired up out of the box.

## Security notes

Pre-commit review checks all clean:

- All SQL uses prepared statements with `?` placeholders + `bind_param` (10 `prepare` calls / 10 `bind_param` calls).
- All output goes through `htmlspecialchars(\$v, ENT_QUOTES, 'UTF-8')` (or `nl2br()` of same).
- Every POST handler (`save.php`, `anonymous-save.php`, `moderate.php`) verifies CSRF before any side-effect.
- `manage.php` + `moderate.php` enforce `App::isAdmin()` with `403` for non-admins.
- `view.php` enforces owner / admin / congregation-visible access checks.
- Anonymous route is rate-limited and CAPTCHA-gated; failures redirect to the generic success page (no fingerprinting).
- Every query is `siteID`-scoped — no cross-site tampering.
- No dangerous functions, no secrets in code, no sensitive data in logs.

## Test plan

- [ ] Run migration `039_prayer_requests.sql` via Admin → Migrations
- [ ] Log in as a member → submit a leadership-only request → confirm it shows in *My Requests*
- [ ] Log in as a member → submit a congregation request → confirm it appears in *Congregation Feed* (once approved if moderation is on)
- [ ] Submit anonymously via `/prayer-requests/anonymous` (no login) → verify CAPTCHA gate + success redirect
- [ ] As admin → approve a pending request → mark answered with a testimony → verify testimony renders on the view page
- [ ] As admin → archive a request → confirm it disappears from feeds
- [ ] Verify visibility-change actions on the view page work
- [ ] Verify the new tile on `/help` and the guide at `/help/prayer-requests`

🤖 Generated with [Claude Code](https://claude.com/claude-code)