### PR TITLE
feat(captcha): multi-provider support (Turnstile / reCAPTCHA v2+v3 / hCaptcha) with drag-and-drop priority

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,25 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Added — Multi-provider Captcha
+
+The captcha layer now supports three providers and admin-configurable priority:
+
+- **Providers**: Cloudflare Turnstile (default first), Google reCAPTCHA
+  (v2 checkbox or v3 invisible/score), and hCaptcha.
+- **Admin UI** at `/admin/captcha` with drag-and-drop priority ordering
+  (SortableJS) and per-provider site/secret-key inputs. reCAPTCHA gets
+  a v2/v3 toggle plus action name + score-threshold inputs for v3.
+- **Priority** is stored as `auth.captcha.priority` (comma-separated keys).
+  The active provider is the first in the list with both keys configured;
+  if nothing is configured the captcha is silently skipped.
+- **reCAPTCHA v3** verification enforces both action match (anti-replay)
+  and score threshold; default action `submit`, default threshold `0.5`.
+- Migration `web/sql/040_captcha_providers.sql` adds hCaptcha key slots,
+  v3 action/threshold settings, priority setting, and admin routes.
+- `Captcha::activeProvider()`, `Captcha::listProviders()`, and
+  `Captcha::normalisePriority()` are new public helpers used by the UI.
+
 ### Added — Prayer Requests app
 
 A new portal app at `/prayer-requests` for collecting and tracking prayer

--- a/web/core/Captcha.php
+++ b/web/core/Captcha.php
@@ -4,41 +4,56 @@
  * -----------------------------------------------------------------------------
  * Centralised Captcha Helper 🤖
  * -----------------------------------------------------------------------------
- * Replaces the loose captchaScriptTag(), captchaWidget(), and captchaVerify()
- * functions that were previously defined inline in the login page and duplicated
- * in the expenses submission form.
+ * Provider-agnostic captcha helper.  At call sites you don't care which
+ * provider is configured — you just call:
  *
- * Provider priority:  Cloudflare Turnstile  >  Google reCAPTCHA v2  >  none
+ *   Captcha::scriptTag()             // <script> tag(s) for the active provider
+ *   Captcha::widget()                // widget markup (or invisible hidden input for v3)
+ *   Captcha::verify($_POST)          // server-side verification
+ *   Captcha::isConfigured()          // true if at least one provider is wired up
+ *   Captcha::activeProvider()        // the provider key currently in effect (or '')
  *
- * The active provider is determined by checking the global $SETTINGS array for
- * configured site key / secret key pairs:
+ * Supported providers:
+ *   • turnstile     Cloudflare Turnstile
+ *   • hcaptcha      hCaptcha
+ *   • recaptcha     Google reCAPTCHA — v2 (checkbox) or v3 (score-based)
+ *                   (controlled by setting `auth.recaptcha.version`)
  *
- *   Turnstile:   $SETTINGS['auth']['turnstile']['siteKey']
- *                $SETTINGS['auth']['turnstile']['secretKey']
+ * Provider priority:
+ *   Driven by setting `auth.captcha.priority` — a comma-separated list of
+ *   provider keys (lowercase).  The first provider in the list with both a
+ *   site key AND a secret key configured is used.
  *
- *   reCAPTCHA:   $SETTINGS['auth']['recaptcha']['siteKey']
- *                $SETTINGS['auth']['recaptcha']['secretKey']
+ *   Default priority:  turnstile, recaptcha, hcaptcha
  *
- * If neither provider has keys configured, all methods gracefully degrade:
- *   - scriptTag() and widget() return empty strings (no markup injected)
- *   - verify() returns true (captcha is silently skipped)
- *   - isConfigured() returns false
+ *   Admins can re-order via the drag-and-drop UI at /admin/captcha which
+ *   POSTs the new order into this same setting.
  *
- * Server-side verification uses cURL to POST to the provider's siteverify
- * endpoint.  The cURL call is handled internally (self::curlPost) to keep
- * this class self-contained and avoid a dependency on Auth's visibility.
+ * Setting keys consumed:
  *
- * Public methods:
- *   Captcha::scriptTag()           <script> tag for the active provider
- *   Captcha::widget()              HTML widget div for the active provider
- *   Captcha::verify(array $post)   server-side captcha verification
- *   Captcha::isConfigured()        true if any provider has keys set
+ *   auth.captcha.priority           (string) e.g. "turnstile,recaptcha,hcaptcha"
+ *
+ *   auth.turnstile.siteKey
+ *   auth.turnstile.secretKey
+ *
+ *   auth.recaptcha.siteKey
+ *   auth.recaptcha.secretKey
+ *   auth.recaptcha.version          "v2" (default) or "v3"
+ *   auth.recaptcha.v3.action        action name (default "submit"), v3 only
+ *   auth.recaptcha.v3.threshold     min score 0.0-1.0 (default 0.5), v3 only
+ *
+ *   auth.hcaptcha.siteKey
+ *   auth.hcaptcha.secretKey
+ *
+ * Graceful degradation:
+ *   If no provider is configured, scriptTag() / widget() return empty strings
+ *   and verify() returns true (no captcha → request proceeds).
  * -----------------------------------------------------------------------------
  * @package    Portal\Core
  * @author     MWBM Partners Ltd (t/a MWservices)
  * @copyright  2025-present MWBM Partners Ltd (t/a MWservices)
- * @license   All Rights Reserved
- * @version    0.1.0
+ * @license    All Rights Reserved
+ * @version    0.10.0
  * @link       https://github.com/MWBMPartners/WebMS-Intra
  * -----------------------------------------------------------------------------
  */
@@ -49,255 +64,357 @@ namespace Portal\Core;
 
 class Captcha
 {
-    // 🌐 ---------------------------------------------------------------------------
-    // Provider constants
-    // -----------------------------------------------------------------------------
+    // 🌐 Provider identifiers
+    public const PROVIDER_TURNSTILE = 'turnstile';
+    public const PROVIDER_RECAPTCHA = 'recaptcha';
+    public const PROVIDER_HCAPTCHA  = 'hcaptcha';
 
-    /** @var string Turnstile client-side API script URL */
-    private const TURNSTILE_SCRIPT_URL =
-        'https://challenges.cloudflare.com/turnstile/v0/api.js';
+    /** @var string[] Default provider priority — applied when the setting is empty */
+    private const DEFAULT_PRIORITY = [
+        self::PROVIDER_TURNSTILE,
+        self::PROVIDER_RECAPTCHA,
+        self::PROVIDER_HCAPTCHA,
+    ];
 
-    /** @var string Turnstile server-side verification endpoint */
-    private const TURNSTILE_VERIFY_URL =
-        'https://challenges.cloudflare.com/turnstile/v0/siteverify';
-
-    /** @var string reCAPTCHA client-side API script URL */
-    private const RECAPTCHA_SCRIPT_URL =
-        'https://www.google.com/recaptcha/api.js';
-
-    /** @var string reCAPTCHA server-side verification endpoint */
-    private const RECAPTCHA_VERIFY_URL =
-        'https://www.google.com/recaptcha/api/siteverify';
-
-    /** @var string POST field name used by Turnstile for the client response token */
+    // 🌐 Endpoint URLs
+    private const TURNSTILE_SCRIPT_URL = 'https://challenges.cloudflare.com/turnstile/v0/api.js';
+    private const TURNSTILE_VERIFY_URL = 'https://challenges.cloudflare.com/turnstile/v0/siteverify';
     private const TURNSTILE_POST_FIELD = 'cf-turnstile-response';
 
-    /** @var string POST field name used by reCAPTCHA for the client response token */
+    private const RECAPTCHA_SCRIPT_URL = 'https://www.google.com/recaptcha/api.js';
+    private const RECAPTCHA_VERIFY_URL = 'https://www.google.com/recaptcha/api/siteverify';
     private const RECAPTCHA_POST_FIELD = 'g-recaptcha-response';
+
+    private const HCAPTCHA_SCRIPT_URL  = 'https://js.hcaptcha.com/1/api.js';
+    private const HCAPTCHA_VERIFY_URL  = 'https://hcaptcha.com/siteverify';
+    private const HCAPTCHA_POST_FIELD  = 'h-captcha-response';
+
+    /** @var string|null Cached active provider key for the current request lifecycle */
+    private static ?string $cachedActive = null;
 
     // 🏗️ ===========================================================================
     // Public API
     // ===========================================================================
 
     /**
-     * Return the <script> tag required by the active captcha provider.
+     * Return the active provider key for this request, or empty string if none configured.
      *
-     * The script is loaded with `async defer` to avoid blocking page rendering.
-     * If no captcha provider is configured, returns an empty string so templates
-     * can unconditionally echo the result without conditional guards.
+     * Walks the priority list and returns the first provider with both siteKey and
+     * secretKey set.  Cached for the duration of the request.
+     *
+     * @return string One of PROVIDER_* constants, or '' if no provider is configured
+     */
+    public static function activeProvider(): string
+    {
+        if (self::$cachedActive !== null) {
+            return self::$cachedActive;
+        }
+
+        global $SETTINGS;
+        $priority = self::resolvePriority($SETTINGS);
+
+        foreach ($priority as $provider) {
+            if (self::isProviderConfigured($provider, $SETTINGS) === true) {
+                self::$cachedActive = $provider;
+                return $provider;
+            }
+        }
+
+        self::$cachedActive = '';
+        return '';
+    }
+
+    /**
+     * Return the <script> tag(s) required by the active captcha provider.
+     *
+     * For reCAPTCHA v3 the script URL includes ?render=SITE_KEY so the v3
+     * runtime is initialised immediately.  All script tags are async+defer.
      *
      * @return string HTML <script> tag, or empty string if no provider is active
      */
     public static function scriptTag(): string
     {
         global $SETTINGS;
+        $active = self::activeProvider();
 
-        // 🔍 Priority 1: Cloudflare Turnstile
-        $turnstileSiteKey = self::setting($SETTINGS, 'auth', 'turnstile', 'siteKey');
-        if ($turnstileSiteKey !== '') {
+        if ($active === self::PROVIDER_TURNSTILE) {
             return '<script src="' . self::esc(self::TURNSTILE_SCRIPT_URL) . '" async defer></script>';
         }
 
-        // 🔍 Priority 2: Google reCAPTCHA v2
-        $recaptchaSiteKey = self::setting($SETTINGS, 'auth', 'recaptcha', 'siteKey');
-        if ($recaptchaSiteKey !== '') {
+        if ($active === self::PROVIDER_HCAPTCHA) {
+            return '<script src="' . self::esc(self::HCAPTCHA_SCRIPT_URL) . '" async defer></script>';
+        }
+
+        if ($active === self::PROVIDER_RECAPTCHA) {
+            $version = self::setting($SETTINGS, 'auth', 'recaptcha', 'version');
+            if ($version === 'v3') {
+                $siteKey = self::setting($SETTINGS, 'auth', 'recaptcha', 'siteKey');
+                // 📌 v3 needs the site key on the script URL to initialise grecaptcha
+                $url = self::RECAPTCHA_SCRIPT_URL . '?render=' . rawurlencode($siteKey);
+                return '<script src="' . self::esc($url) . '" async defer></script>';
+            }
+            // 🔲 v2 (default) — plain script
             return '<script src="' . self::esc(self::RECAPTCHA_SCRIPT_URL) . '" async defer></script>';
         }
 
-        // 🚫 No provider configured
         return '';
     }
 
     /**
      * Return the HTML widget markup for the active captcha provider.
      *
-     * For Turnstile this is a <div class="cf-turnstile"> with a data-sitekey
-     * attribute.  For reCAPTCHA it is a <div class="g-recaptcha"> with the
-     * same attribute pattern.  Returns an empty string if no provider is active.
+     * Turnstile / hCaptcha / reCAPTCHA v2:  visible widget div.
+     * reCAPTCHA v3:                          invisible — hidden input + inline JS
+     *                                        that auto-fetches a token on page load
+     *                                        and refreshes it every ~110s (token
+     *                                        TTL is 120s).
      *
-     * @return string HTML div element, or empty string
+     * @return string HTML, or empty string if no provider is active
      */
     public static function widget(): string
     {
         global $SETTINGS;
+        $active = self::activeProvider();
 
-        // 🔍 Priority 1: Cloudflare Turnstile
-        $turnstileSiteKey = self::setting($SETTINGS, 'auth', 'turnstile', 'siteKey');
-        if ($turnstileSiteKey !== '') {
-            return '<div class="cf-turnstile" data-sitekey="'
-                . self::esc($turnstileSiteKey)
-                . '"></div>';
+        if ($active === self::PROVIDER_TURNSTILE) {
+            $siteKey = self::setting($SETTINGS, 'auth', 'turnstile', 'siteKey');
+            return '<div class="cf-turnstile" data-sitekey="' . self::esc($siteKey) . '"></div>';
         }
 
-        // 🔍 Priority 2: Google reCAPTCHA v2
-        $recaptchaSiteKey = self::setting($SETTINGS, 'auth', 'recaptcha', 'siteKey');
-        if ($recaptchaSiteKey !== '') {
-            return '<div class="g-recaptcha" data-sitekey="'
-                . self::esc($recaptchaSiteKey)
-                . '"></div>';
+        if ($active === self::PROVIDER_HCAPTCHA) {
+            $siteKey = self::setting($SETTINGS, 'auth', 'hcaptcha', 'siteKey');
+            return '<div class="h-captcha" data-sitekey="' . self::esc($siteKey) . '"></div>';
         }
 
-        // 🚫 No provider configured
+        if ($active === self::PROVIDER_RECAPTCHA) {
+            $version = self::setting($SETTINGS, 'auth', 'recaptcha', 'version');
+            $siteKey = self::setting($SETTINGS, 'auth', 'recaptcha', 'siteKey');
+
+            if ($version === 'v3') {
+                $action  = self::setting($SETTINGS, 'auth', 'recaptcha', 'v3.action');
+                if ($action === '') {
+                    $action = 'submit';
+                }
+                // 🕶️ Invisible widget: hidden input fed by grecaptcha.execute()
+                // The script is loaded with ?render=siteKey so grecaptcha is auto-initialised.
+                return ''
+                    . '<input type="hidden" name="' . self::esc(self::RECAPTCHA_POST_FIELD)
+                    . '" id="g-recaptcha-response">'
+                    . '<script>(function(){'
+                    . 'function exec(){if(typeof grecaptcha==="undefined"||!grecaptcha.ready){return;}'
+                    . 'grecaptcha.ready(function(){'
+                    . 'grecaptcha.execute(' . json_encode($siteKey) . ',{action:' . json_encode($action) . '})'
+                    . '.then(function(t){var f=document.getElementById("g-recaptcha-response");if(f){f.value=t;}});'
+                    . '});}'
+                    . 'exec();setInterval(exec,110000);'
+                    . '})();</script>';
+            }
+
+            // 🔲 v2 checkbox widget
+            return '<div class="g-recaptcha" data-sitekey="' . self::esc($siteKey) . '"></div>';
+        }
+
         return '';
     }
 
     /**
      * Verify the captcha response submitted by the client.
      *
-     * Inspects $postData for the appropriate token field depending on the active
-     * provider, then sends a server-side POST to the provider's siteverify
-     * endpoint using cURL.
+     * Returns true when the active provider's verification succeeded, OR when
+     * no provider is configured (graceful skip).
      *
-     * Behaviour summary:
-     *   - Turnstile configured  -> checks "cf-turnstile-response" field
-     *   - reCAPTCHA configured   -> checks "g-recaptcha-response" field
-     *   - Neither configured     -> returns true (graceful skip)
+     * @param array<string,mixed> $postData The $_POST superglobal (or equivalent)
      *
-     * @param array $postData The $_POST superglobal (or equivalent array)
-     *
-     * @return bool True if the captcha verification succeeded, or if no captcha
-     *              is configured (allowing the form submission to proceed)
+     * @return bool True if verification succeeded or no captcha is configured
      */
     public static function verify(array $postData): bool
     {
         global $SETTINGS;
+        $active = self::activeProvider();
 
-        // 🔍 Priority 1: Cloudflare Turnstile verification
-        $turnstileSecret = self::setting($SETTINGS, 'auth', 'turnstile', 'secretKey');
-        if ($turnstileSecret !== '') {
-            return self::verifyTurnstile($turnstileSecret, $postData);
+        if ($active === self::PROVIDER_TURNSTILE) {
+            $secret = self::setting($SETTINGS, 'auth', 'turnstile', 'secretKey');
+            return self::verifyTurnstile($secret, $postData);
         }
 
-        // 🔍 Priority 2: Google reCAPTCHA verification
-        $recaptchaSecret = self::setting($SETTINGS, 'auth', 'recaptcha', 'secretKey');
-        if ($recaptchaSecret !== '') {
-            return self::verifyRecaptcha($recaptchaSecret, $postData);
+        if ($active === self::PROVIDER_HCAPTCHA) {
+            $secret = self::setting($SETTINGS, 'auth', 'hcaptcha', 'secretKey');
+            return self::verifyHcaptcha($secret, $postData);
         }
 
-        // ✅ No captcha configured – allow the request to proceed
+        if ($active === self::PROVIDER_RECAPTCHA) {
+            $secret  = self::setting($SETTINGS, 'auth', 'recaptcha', 'secretKey');
+            $version = self::setting($SETTINGS, 'auth', 'recaptcha', 'version');
+            if ($version === 'v3') {
+                return self::verifyRecaptchaV3($secret, $postData, $SETTINGS);
+            }
+            return self::verifyRecaptchaV2($secret, $postData);
+        }
+
+        // ✅ No captcha configured — allow
         return true;
     }
 
     /**
      * Check whether any captcha provider has keys configured.
      *
-     * Returns true if either Turnstile or reCAPTCHA has both a site key AND
-     * a secret key set to non-empty values.  Useful for conditionally showing
-     * captcha-related UI hints or toggling form validation rules.
-     *
      * @return bool True if at least one provider is fully configured
      */
     public static function isConfigured(): bool
     {
+        return self::activeProvider() !== '';
+    }
+
+    /**
+     * Return the full set of providers we know about with their human-readable
+     * names and current configuration status.  Used by the admin UI to render
+     * the drag-and-drop priority list.
+     *
+     * @return array<int,array{key:string,label:string,configured:bool}>
+     */
+    public static function listProviders(): array
+    {
         global $SETTINGS;
+        $priority = self::resolvePriority($SETTINGS);
 
-        // 🔍 Check Turnstile keys
-        $turnstileSite   = self::setting($SETTINGS, 'auth', 'turnstile', 'siteKey');
-        $turnstileSecret = self::setting($SETTINGS, 'auth', 'turnstile', 'secretKey');
-        if ($turnstileSite !== '' && $turnstileSecret !== '') {
-            return true;
+        // 🔍 Make sure every known provider appears in the list (in case the
+        // stored priority drops one).  Known providers missing from priority
+        // are appended at the end.
+        $all = [
+            self::PROVIDER_TURNSTILE => 'Cloudflare Turnstile',
+            self::PROVIDER_HCAPTCHA  => 'hCaptcha',
+            self::PROVIDER_RECAPTCHA => 'Google reCAPTCHA',
+        ];
+        foreach (array_keys($all) as $k) {
+            if (in_array($k, $priority, true) === false) {
+                $priority[] = $k;
+            }
         }
 
-        // 🔍 Check reCAPTCHA keys
-        $recaptchaSite   = self::setting($SETTINGS, 'auth', 'recaptcha', 'siteKey');
-        $recaptchaSecret = self::setting($SETTINGS, 'auth', 'recaptcha', 'secretKey');
-        if ($recaptchaSite !== '' && $recaptchaSecret !== '') {
-            return true;
+        $result = [];
+        foreach ($priority as $key) {
+            if (isset($all[$key]) === false) {
+                continue; // unknown key — skip
+            }
+            $result[] = [
+                'key'        => $key,
+                'label'      => $all[$key],
+                'configured' => self::isProviderConfigured($key, $SETTINGS),
+            ];
         }
+        return $result;
+    }
 
-        return false;
+    /**
+     * Validate and normalise a user-supplied priority list before it's persisted.
+     *
+     * Returns a comma-separated string of valid lowercase provider keys, with
+     * duplicates removed and unknown values discarded.  Empty input falls back
+     * to the default priority.
+     *
+     * @param string[]|string $input Either a comma-separated string or an array of keys
+     *
+     * @return string Cleaned comma-separated string suitable for storing
+     */
+    public static function normalisePriority(array|string $input): string
+    {
+        $known = [self::PROVIDER_TURNSTILE, self::PROVIDER_RECAPTCHA, self::PROVIDER_HCAPTCHA];
+        $items = is_array($input) === true
+            ? $input
+            : explode(',', $input);
+
+        $seen = [];
+        foreach ($items as $raw) {
+            $key = strtolower(trim((string) $raw));
+            if ($key === '' || in_array($key, $known, true) === false) {
+                continue;
+            }
+            if (in_array($key, $seen, true) === true) {
+                continue;
+            }
+            $seen[] = $key;
+        }
+        if (count($seen) === 0) {
+            return implode(',', self::DEFAULT_PRIORITY);
+        }
+        return implode(',', $seen);
     }
 
     // 🛡️ ===========================================================================
     // Provider-specific verification
     // ===========================================================================
 
-    /**
-     * Verify a Cloudflare Turnstile response token.
-     *
-     * Extracts the "cf-turnstile-response" field from the POST data and sends
-     * it to Cloudflare's siteverify endpoint along with the secret key and the
-     * visitor's IP address.
-     *
-     * @param string $secretKey The Turnstile secret key from settings
-     * @param array  $postData  The $_POST array containing the turnstile token
-     *
-     * @return bool True if the token is valid
-     */
-    private static function verifyTurnstile(string $secretKey, array $postData): bool
+    private static function verifyTurnstile(string $secret, array $post): bool
     {
-        // 📝 Extract the client-side token from POST data
-        $token = $postData[self::TURNSTILE_POST_FIELD] ?? '';
-        if ($token === '') {
-            // 🚫 No token submitted – the widget was likely not completed
+        $token = (string) ($post[self::TURNSTILE_POST_FIELD] ?? '');
+        if ($secret === '' || $token === '') {
             return false;
         }
+        $json = self::postVerify(self::TURNSTILE_VERIFY_URL, $secret, $token);
+        return $json !== null
+            && isset($json['success']) === true
+            && $json['success'] === true;
+    }
 
-        // 🌐 POST to Cloudflare's verification endpoint
-        $response = self::curlPost(self::TURNSTILE_VERIFY_URL, [
-            'secret'   => $secretKey,
-            'response' => $token,
-            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
-        ]);
-
-        // 🔍 Parse the JSON response and check the success flag
-        if ($response === null) {
-            // 📝 Log the cURL failure – treat as verification failure
-            Logger::errorPlatform('Captcha', 'Warning', 'CURL_FAIL', 'Turnstile verify request failed', '');
+    private static function verifyHcaptcha(string $secret, array $post): bool
+    {
+        $token = (string) ($post[self::HCAPTCHA_POST_FIELD] ?? '');
+        if ($secret === '' || $token === '') {
             return false;
         }
+        $json = self::postVerify(self::HCAPTCHA_VERIFY_URL, $secret, $token);
+        return $json !== null
+            && isset($json['success']) === true
+            && $json['success'] === true;
+    }
 
-        $json = json_decode($response, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            Logger::errorPlatform('Captcha', 'Warning', 'JSON_FAIL', 'Turnstile response was not valid JSON', $response);
+    private static function verifyRecaptchaV2(string $secret, array $post): bool
+    {
+        $token = (string) ($post[self::RECAPTCHA_POST_FIELD] ?? '');
+        if ($secret === '' || $token === '') {
             return false;
         }
-
-        return isset($json['success']) && $json['success'] === true;
+        $json = self::postVerify(self::RECAPTCHA_VERIFY_URL, $secret, $token);
+        return $json !== null
+            && isset($json['success']) === true
+            && $json['success'] === true;
     }
 
     /**
-     * Verify a Google reCAPTCHA v2 response token.
-     *
-     * Extracts the "g-recaptcha-response" field from the POST data and sends
-     * it to Google's siteverify endpoint along with the secret key and the
-     * visitor's IP address.
-     *
-     * @param string $secretKey The reCAPTCHA secret key from settings
-     * @param array  $postData  The $_POST array containing the reCAPTCHA token
-     *
-     * @return bool True if the token is valid
+     * Verify a reCAPTCHA v3 response, enforcing both action match AND score threshold.
      */
-    private static function verifyRecaptcha(string $secretKey, array $postData): bool
+    private static function verifyRecaptchaV3(string $secret, array $post, array $settings): bool
     {
-        // 📝 Extract the client-side token from POST data
-        $token = $postData[self::RECAPTCHA_POST_FIELD] ?? '';
-        if ($token === '') {
-            // 🚫 No token submitted – the widget was likely not completed
+        $token = (string) ($post[self::RECAPTCHA_POST_FIELD] ?? '');
+        if ($secret === '' || $token === '') {
+            return false;
+        }
+        $json = self::postVerify(self::RECAPTCHA_VERIFY_URL, $secret, $token);
+        if ($json === null || ($json['success'] ?? false) !== true) {
             return false;
         }
 
-        // 🌐 POST to Google's verification endpoint
-        $response = self::curlPost(self::RECAPTCHA_VERIFY_URL, [
-            'secret'   => $secretKey,
-            'response' => $token,
-            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
-        ]);
-
-        // 🔍 Parse the JSON response and check the success flag
-        if ($response === null) {
-            Logger::errorPlatform('Captcha', 'Warning', 'CURL_FAIL', 'reCAPTCHA verify request failed', '');
+        // 🛡️ Action match — guards against token replay from a different page
+        $expectedAction = self::setting($settings, 'auth', 'recaptcha', 'v3.action');
+        if ($expectedAction === '') {
+            $expectedAction = 'submit';
+        }
+        $actualAction = (string) ($json['action'] ?? '');
+        if ($actualAction !== $expectedAction) {
+            Logger::activity('CaptchaRejected', 'reCAPTCHA v3 action mismatch (expected=' . $expectedAction . ', got=' . $actualAction . ')');
             return false;
         }
 
-        $json = json_decode($response, true);
-        if (json_last_error() !== JSON_ERROR_NONE) {
-            Logger::errorPlatform('Captcha', 'Warning', 'JSON_FAIL', 'reCAPTCHA response was not valid JSON', $response);
+        // 🎯 Score threshold
+        $thresholdStr = self::setting($settings, 'auth', 'recaptcha', 'v3.threshold');
+        $threshold    = $thresholdStr === '' ? 0.5 : (float) $thresholdStr;
+        $score        = (float) ($json['score'] ?? 0.0);
+        if ($score < $threshold) {
+            Logger::activity('CaptchaRejected', 'reCAPTCHA v3 score below threshold (score=' . $score . ', threshold=' . $threshold . ')');
             return false;
         }
 
-        // 📝 Google returns success as a boolean true
-        return isset($json['success']) && $json['success'] === true;
+        return true;
     }
 
     // 🔧 ===========================================================================
@@ -305,17 +422,101 @@ class Captcha
     // ===========================================================================
 
     /**
-     * Safely extract a nested setting value from the $SETTINGS array.
+     * Read the priority setting and return a clean array of provider keys.
      *
-     * Walks through up to three levels of keys and returns the string value,
-     * or an empty string if any level is missing or the final value is empty.
+     * Walks `auth.captcha.priority` from the global settings array.  Unknown
+     * tokens, duplicates and empty entries are dropped.  Falls back to the
+     * DEFAULT_PRIORITY list if the setting is empty.
      *
-     * @param array  $settings The global $SETTINGS multidimensional array
-     * @param string $key1     First-level key  (e.g. "auth")
-     * @param string $key2     Second-level key (e.g. "turnstile")
-     * @param string $key3     Third-level key  (e.g. "siteKey")
+     * @param array<string,mixed> $settings
      *
-     * @return string The setting value, or empty string if not found
+     * @return string[]
+     */
+    private static function resolvePriority(array $settings): array
+    {
+        $raw = '';
+        if (isset($settings['auth']['captcha']['priority']) === true
+            && is_string($settings['auth']['captcha']['priority']) === true
+        ) {
+            $raw = $settings['auth']['captcha']['priority'];
+        }
+
+        $known = [self::PROVIDER_TURNSTILE, self::PROVIDER_RECAPTCHA, self::PROVIDER_HCAPTCHA];
+        $items = $raw === '' ? [] : explode(',', $raw);
+
+        $clean = [];
+        foreach ($items as $token) {
+            $k = strtolower(trim((string) $token));
+            if ($k === '' || in_array($k, $known, true) === false) {
+                continue;
+            }
+            if (in_array($k, $clean, true) === true) {
+                continue;
+            }
+            $clean[] = $k;
+        }
+
+        if (count($clean) === 0) {
+            return self::DEFAULT_PRIORITY;
+        }
+        return $clean;
+    }
+
+    /**
+     * Whether a given provider has both site and secret keys set.
+     */
+    private static function isProviderConfigured(string $provider, array $settings): bool
+    {
+        $siteKey = '';
+        $secret  = '';
+        switch ($provider) {
+            case self::PROVIDER_TURNSTILE:
+                $siteKey = self::setting($settings, 'auth', 'turnstile', 'siteKey');
+                $secret  = self::setting($settings, 'auth', 'turnstile', 'secretKey');
+                break;
+            case self::PROVIDER_RECAPTCHA:
+                $siteKey = self::setting($settings, 'auth', 'recaptcha', 'siteKey');
+                $secret  = self::setting($settings, 'auth', 'recaptcha', 'secretKey');
+                break;
+            case self::PROVIDER_HCAPTCHA:
+                $siteKey = self::setting($settings, 'auth', 'hcaptcha', 'siteKey');
+                $secret  = self::setting($settings, 'auth', 'hcaptcha', 'secretKey');
+                break;
+            default:
+                return false;
+        }
+        return $siteKey !== '' && $secret !== '';
+    }
+
+    /**
+     * Single POST helper that fires the standard siteverify request and
+     * returns the decoded JSON response, or null on transport / parse failure.
+     *
+     * @return array<string,mixed>|null
+     */
+    private static function postVerify(string $url, string $secret, string $token): ?array
+    {
+        $response = self::curlPost($url, [
+            'secret'   => $secret,
+            'response' => $token,
+            'remoteip' => $_SERVER['REMOTE_ADDR'] ?? '',
+        ]);
+        if ($response === null) {
+            Logger::errorPlatform('Captcha', 'Warning', 'CURL_FAIL', 'siteverify request failed', $url);
+            return null;
+        }
+        $json = json_decode($response, true);
+        if (json_last_error() !== JSON_ERROR_NONE || is_array($json) === false) {
+            Logger::errorPlatform('Captcha', 'Warning', 'JSON_FAIL', 'siteverify response was not valid JSON', $response);
+            return null;
+        }
+        return $json;
+    }
+
+    /**
+     * Safely extract a nested setting value (string) from the $SETTINGS array.
+     *
+     * Returns '' on any missing-key / wrong-type condition.
      */
     private static function setting(array $settings, string $key1, string $key2, string $key3): string
     {
@@ -325,71 +526,54 @@ class Captcha
         if (isset($settings[$key1][$key2]) === false || is_array($settings[$key1][$key2]) === false) {
             return '';
         }
-        $value = $settings[$key1][$key2][$key3] ?? '';
-        if (is_string($value) === false) {
-            return '';
+
+        // 🌿 Support compound third-key segments like "v3.action" (which were stored
+        // under settings[key1][key2]['v3']['action'] when the dot-notation loader split them).
+        if (str_contains($key3, '.') === true) {
+            $parts = explode('.', $key3);
+            $node  = $settings[$key1][$key2];
+            foreach ($parts as $p) {
+                if (is_array($node) === false || array_key_exists($p, $node) === false) {
+                    return '';
+                }
+                $node = $node[$p];
+            }
+            return is_string($node) === true ? $node : '';
         }
-        return $value;
+
+        $value = $settings[$key1][$key2][$key3] ?? '';
+        return is_string($value) === true ? $value : '';
     }
 
     /**
-     * Execute an HTTP POST request using cURL.
-     *
-     * This is a self-contained cURL wrapper so that Captcha does not depend on
-     * Auth::curlPost() (which is currently declared private in Auth.php).  The
-     * implementation mirrors the pattern used across the portal.
-     *
-     * @param string $url  The endpoint URL to POST to
-     * @param array  $data Associative array of POST fields
+     * HTTP POST helper using cURL.
      *
      * @return string|null Response body on success, or null on failure
      */
     private static function curlPost(string $url, array $data): ?string
     {
-        // 🌐 Initialise the cURL handle
         $ch = curl_init($url);
         if ($ch === false) {
             return null;
         }
-
-        // 📝 Configure cURL options
         curl_setopt($ch, CURLOPT_POST, true);
         curl_setopt($ch, CURLOPT_POSTFIELDS, http_build_query($data));
         curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
         curl_setopt($ch, CURLOPT_TIMEOUT, 15);
-
-        // 🔐 Ensure SSL certificate verification is enabled (security best practice)
         curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, true);
         curl_setopt($ch, CURLOPT_SSL_VERIFYHOST, 2);
-
-        // 🚀 Execute the request
         $response = curl_exec($ch);
-
-        // 🔍 Check for cURL errors
         if ($response === false) {
             $errno  = curl_errno($ch);
             $errmsg = curl_error($ch);
-            curl_close($ch);
-            Logger::errorPlatform(
-                'cURL',
-                'Error',
-                (string) $errno,
-                $errmsg,
-                'URL: ' . $url
-            );
+            Logger::errorPlatform('cURL', 'Error', (string) $errno, $errmsg, 'URL: ' . $url);
             return null;
         }
-
-        curl_close($ch);
         return (string) $response;
     }
 
     /**
-     * Escape a string for safe use inside an HTML attribute value.
-     *
-     * @param string $value Raw string
-     *
-     * @return string HTML-safe string
+     * HTML-attribute-safe escape.
      */
     private static function esc(string $value): string
     {

--- a/web/public_html/admin/captcha/index.php
+++ b/web/public_html/admin/captcha/index.php
@@ -1,0 +1,330 @@
+<?php
+// Path: public_html/admin/captcha/index.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Captcha Provider Configuration 🤖
+ * -----------------------------------------------------------------------------
+ * Dedicated admin page for the multi-provider captcha system. Supports:
+ *   • Drag-and-drop priority ordering (SortableJS via CDN with fallback)
+ *   • Per-provider site / secret key inputs
+ *   • reCAPTCHA v2 vs v3 toggle (with action + score-threshold for v3)
+ *   • Live "configured / not configured" status badges
+ *   • Highlight of which provider is currently active given the priority + keys
+ *
+ * Umbrella (root) admins can do everything; site admins are also allowed —
+ * the captcha settings are global, so the underlying setting writes are
+ * site-agnostic (siteID = NULL).
+ *
+ * @package   Portal\Admin
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Captcha;
+use Portal\Core\Router;
+
+// 📌 Page metadata
+$pageTitle   = 'Captcha Providers';
+$pageSection = 'admin';
+$breadcrumbs = ['Dashboard' => '/', 'Admin' => '/admin', 'Captcha' => ''];
+
+// 🛡️ Admin access check
+if (App::isAdmin() === false) {
+    Router::renderError(403);
+    return;
+}
+
+// 💬 Flash message from save handler
+$flashMsg  = $_SESSION['flash_msg']  ?? '';
+$flashType = $_SESSION['flash_type'] ?? '';
+unset($_SESSION['flash_msg'], $_SESSION['flash_type']);
+
+// -----------------------------------------------------------------------------
+// 📋 Pull current config snapshot
+// -----------------------------------------------------------------------------
+$providers       = Captcha::listProviders();   // ordered per priority
+$activeProvider  = Captcha::activeProvider();  // '' if nothing configured
+
+$turnstileSite   = (string) (App::settings('auth.turnstile.siteKey')   ?? '');
+$turnstileSecret = (string) (App::settings('auth.turnstile.secretKey') ?? '');
+
+$recaptchaSite   = (string) (App::settings('auth.recaptcha.siteKey')   ?? '');
+$recaptchaSecret = (string) (App::settings('auth.recaptcha.secretKey') ?? '');
+$recaptchaVer    = (string) (App::settings('auth.recaptcha.version')   ?? 'v2');
+$recaptchaV3Act  = (string) (App::settings('auth.recaptcha.v3.action')    ?? 'submit');
+$recaptchaV3Thr  = (string) (App::settings('auth.recaptcha.v3.threshold') ?? '0.5');
+
+$hcaptchaSite    = (string) (App::settings('auth.hcaptcha.siteKey')   ?? '');
+$hcaptchaSecret  = (string) (App::settings('auth.hcaptcha.secretKey') ?? '');
+
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+$csrf = Auth::csrfToken();
+
+/**
+ * 🎨 Render a "Configured / Not configured" badge for the priority list rows.
+ */
+$statusBadge = static function (bool $configured): string {
+    if ($configured === true) {
+        return '<span class="badge bg-success"><i class="fa-solid fa-check me-1"></i>Configured</span>';
+    }
+    return '<span class="badge bg-secondary"><i class="fa-solid fa-circle-minus me-1"></i>Not configured</span>';
+};
+
+/**
+ * 🎨 Render the human-readable label + icon for a provider key.
+ */
+$providerIcon = static function (string $key): string {
+    return match ($key) {
+        'turnstile' => '<i class="fa-solid fa-shield-halved text-warning me-2"></i>',
+        'recaptcha' => '<i class="fa-brands fa-google text-primary me-2"></i>',
+        'hcaptcha'  => '<i class="fa-solid fa-h me-2"></i>',
+        default     => '<i class="fa-solid fa-robot me-2"></i>',
+    };
+};
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-robot me-2"></i>Captcha Providers</h1>
+        <p class="text-secondary mb-0">
+            Configure provider keys and drag to set the fallback priority.
+        </p>
+    </div>
+    <a href="/admin" class="btn btn-outline-secondary">
+        <i class="fa-solid fa-arrow-left me-1"></i> Back to Admin
+    </a>
+</div>
+
+<?php if ($flashMsg !== ''): ?>
+    <div class="alert alert-<?php echo htmlspecialchars((string) $flashType, ENT_QUOTES, 'UTF-8'); ?> alert-dismissible fade show" role="alert">
+        <?php echo htmlspecialchars((string) $flashMsg, ENT_QUOTES, 'UTF-8'); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<div class="alert alert-info">
+    <i class="fa-solid fa-circle-info me-1"></i>
+    <strong>How it works:</strong>
+    The active provider is the first item below that has both a site key and a secret key.
+    Drag to re-order. If nothing is configured, forms that use captcha will simply skip it.
+    <?php if ($activeProvider !== ''): ?>
+        Current active provider:
+        <strong><?php echo htmlspecialchars(ucfirst($activeProvider), ENT_QUOTES, 'UTF-8'); ?></strong>.
+    <?php else: ?>
+        <strong>No provider is currently active.</strong>
+    <?php endif; ?>
+</div>
+
+<!-- ============================================================================ -->
+<!-- 🪜 Priority list (drag-and-drop) -->
+<!-- ============================================================================ -->
+<div class="card shadow-sm mb-4">
+    <div class="card-header bg-body-tertiary">
+        <h2 class="h6 mb-0"><i class="fa-solid fa-arrows-up-down me-2"></i>Provider Priority</h2>
+    </div>
+    <div class="card-body">
+        <form method="post" action="/admin/captcha/save" id="priorityForm">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <input type="hidden" name="action"     value="priority">
+            <input type="hidden" name="priority"   id="priorityField"
+                   value="<?php echo htmlspecialchars(implode(',', array_column($providers, 'key')), ENT_QUOTES, 'UTF-8'); ?>">
+
+            <ul id="captchaPriorityList" class="list-group mb-3">
+                <?php foreach ($providers as $p): ?>
+                    <li class="list-group-item d-flex align-items-center justify-content-between"
+                        data-key="<?php echo htmlspecialchars($p['key'], ENT_QUOTES, 'UTF-8'); ?>"
+                        style="cursor: grab;">
+                        <div>
+                            <i class="fa-solid fa-grip-vertical text-muted me-3" aria-hidden="true"></i>
+                            <?php echo $providerIcon($p['key']); ?>
+                            <strong><?php echo htmlspecialchars($p['label'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                            <?php if ($activeProvider === $p['key']): ?>
+                                <span class="badge bg-primary ms-2">Active</span>
+                            <?php endif; ?>
+                        </div>
+                        <?php echo $statusBadge((bool) $p['configured']); ?>
+                    </li>
+                <?php endforeach; ?>
+            </ul>
+
+            <button type="submit" class="btn btn-primary">
+                <i class="fa-solid fa-save me-1"></i> Save Priority
+            </button>
+            <span class="small text-muted ms-2">
+                Tip: drag rows to reorder. Active provider is decided top-to-bottom.
+            </span>
+        </form>
+    </div>
+</div>
+
+<!-- ============================================================================ -->
+<!-- 🔑 Provider key inputs -->
+<!-- ============================================================================ -->
+<form method="post" action="/admin/captcha/save">
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+    <input type="hidden" name="action"     value="keys">
+
+    <!-- ☁️ Cloudflare Turnstile -->
+    <div class="card shadow-sm mb-3">
+        <div class="card-header bg-body-tertiary d-flex align-items-center">
+            <h3 class="h6 mb-0 flex-grow-1">
+                <i class="fa-solid fa-shield-halved text-warning me-2"></i>Cloudflare Turnstile
+            </h3>
+            <?php echo $statusBadge($turnstileSite !== '' && $turnstileSecret !== ''); ?>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="turnstile_site" class="form-label">Site Key</label>
+                    <input type="text" class="form-control" id="turnstile_site" name="turnstile_site"
+                           value="<?php echo htmlspecialchars($turnstileSite, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                </div>
+                <div class="col-md-6">
+                    <label for="turnstile_secret" class="form-label">Secret Key</label>
+                    <input type="password" class="form-control" id="turnstile_secret" name="turnstile_secret"
+                           value="<?php echo htmlspecialchars($turnstileSecret, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                </div>
+            </div>
+            <p class="form-text mb-0">
+                Get keys at
+                <a href="https://dash.cloudflare.com/?to=/:account/turnstile" target="_blank" rel="noopener noreferrer">
+                    Cloudflare Turnstile dashboard <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>
+                </a>.
+            </p>
+        </div>
+    </div>
+
+    <!-- 🅖 Google reCAPTCHA -->
+    <div class="card shadow-sm mb-3">
+        <div class="card-header bg-body-tertiary d-flex align-items-center">
+            <h3 class="h6 mb-0 flex-grow-1">
+                <i class="fa-brands fa-google text-primary me-2"></i>Google reCAPTCHA
+            </h3>
+            <?php echo $statusBadge($recaptchaSite !== '' && $recaptchaSecret !== ''); ?>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="recaptcha_site" class="form-label">Site Key</label>
+                    <input type="text" class="form-control" id="recaptcha_site" name="recaptcha_site"
+                           value="<?php echo htmlspecialchars($recaptchaSite, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                </div>
+                <div class="col-md-6">
+                    <label for="recaptcha_secret" class="form-label">Secret Key</label>
+                    <input type="password" class="form-control" id="recaptcha_secret" name="recaptcha_secret"
+                           value="<?php echo htmlspecialchars($recaptchaSecret, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                </div>
+                <div class="col-md-4">
+                    <label for="recaptcha_version" class="form-label">Version</label>
+                    <select class="form-select" id="recaptcha_version" name="recaptcha_version">
+                        <option value="v2" <?php echo $recaptchaVer === 'v2' ? 'selected' : ''; ?>>
+                            v2 (visible checkbox)
+                        </option>
+                        <option value="v3" <?php echo $recaptchaVer === 'v3' ? 'selected' : ''; ?>>
+                            v3 (invisible / score)
+                        </option>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label for="recaptcha_v3_action" class="form-label">v3 Action Name</label>
+                    <input type="text" class="form-control" id="recaptcha_v3_action" name="recaptcha_v3_action"
+                           value="<?php echo htmlspecialchars($recaptchaV3Act, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                    <div class="form-text">Default: <code>submit</code>. v3 only.</div>
+                </div>
+                <div class="col-md-4">
+                    <label for="recaptcha_v3_threshold" class="form-label">v3 Score Threshold</label>
+                    <input type="number" class="form-control" id="recaptcha_v3_threshold" name="recaptcha_v3_threshold"
+                           min="0" max="1" step="0.05"
+                           value="<?php echo htmlspecialchars($recaptchaV3Thr, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                    <div class="form-text">0.0 (allow all) to 1.0 (strict). v3 only.</div>
+                </div>
+            </div>
+            <p class="form-text mb-0">
+                Get keys at
+                <a href="https://www.google.com/recaptcha/admin" target="_blank" rel="noopener noreferrer">
+                    Google reCAPTCHA admin <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>
+                </a>.
+            </p>
+        </div>
+    </div>
+
+    <!-- 🅷 hCaptcha -->
+    <div class="card shadow-sm mb-4">
+        <div class="card-header bg-body-tertiary d-flex align-items-center">
+            <h3 class="h6 mb-0 flex-grow-1">
+                <i class="fa-solid fa-h me-2"></i>hCaptcha
+            </h3>
+            <?php echo $statusBadge($hcaptchaSite !== '' && $hcaptchaSecret !== ''); ?>
+        </div>
+        <div class="card-body">
+            <div class="row g-3">
+                <div class="col-md-6">
+                    <label for="hcaptcha_site" class="form-label">Site Key</label>
+                    <input type="text" class="form-control" id="hcaptcha_site" name="hcaptcha_site"
+                           value="<?php echo htmlspecialchars($hcaptchaSite, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                </div>
+                <div class="col-md-6">
+                    <label for="hcaptcha_secret" class="form-label">Secret Key</label>
+                    <input type="password" class="form-control" id="hcaptcha_secret" name="hcaptcha_secret"
+                           value="<?php echo htmlspecialchars($hcaptchaSecret, ENT_QUOTES, 'UTF-8'); ?>"
+                           autocomplete="off">
+                </div>
+            </div>
+            <p class="form-text mb-0">
+                Get keys at
+                <a href="https://dashboard.hcaptcha.com/" target="_blank" rel="noopener noreferrer">
+                    hCaptcha dashboard <i class="fa-solid fa-arrow-up-right-from-square fa-xs"></i>
+                </a>.
+            </p>
+        </div>
+    </div>
+
+    <button type="submit" class="btn btn-success">
+        <i class="fa-solid fa-save me-1"></i> Save Provider Keys
+    </button>
+    <a href="/admin/captcha" class="btn btn-outline-secondary">Cancel</a>
+</form>
+
+<!-- ============================================================================ -->
+<!-- 🪜 Drag-and-drop init (SortableJS via CDN with graceful no-op fallback) -->
+<!-- ============================================================================ -->
+<script src="https://cdn.jsdelivr.net/npm/sortablejs@1.15.2/Sortable.min.js"
+        crossorigin="anonymous"></script>
+<script>
+(function () {
+    var list  = document.getElementById('captchaPriorityList');
+    var field = document.getElementById('priorityField');
+    if (list === null || field === null || typeof Sortable === 'undefined') {
+        return;
+    }
+    Sortable.create(list, {
+        animation: 150,
+        handle: '.fa-grip-vertical',
+        ghostClass: 'bg-body-tertiary',
+        onSort: function () {
+            var keys = [];
+            list.querySelectorAll('[data-key]').forEach(function (li) {
+                keys.push(li.getAttribute('data-key'));
+            });
+            field.value = keys.join(',');
+        }
+    });
+})();
+</script>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/admin/captcha/save.php
+++ b/web/public_html/admin/captcha/save.php
@@ -1,0 +1,192 @@
+<?php
+// Path: public_html/admin/captcha/save.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Captcha Save Handler 💾
+ * -----------------------------------------------------------------------------
+ * POST handler for /admin/captcha. Two actions:
+ *   • action=priority  — persists the drag-and-drop ordering (single setting)
+ *   • action=keys      — persists site/secret keys + reCAPTCHA v2/v3 toggle
+ *
+ * All captcha settings are stored at siteID = NULL (global / shared across
+ * all sites in this installation).
+ *
+ * @package   Portal\Admin
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.10.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Captcha;
+use Portal\Core\Logger;
+use Portal\Core\Router;
+
+// 🛡️ Only POST
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /admin/captcha', true, 302);
+    exit();
+}
+
+// 🛡️ Admin only
+if (App::isAdmin() === false) {
+    Router::renderError(403);
+    return;
+}
+
+// 🔐 CSRF
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    $_SESSION['flash_msg']  = 'Invalid or expired form token. Please try again.';
+    $_SESSION['flash_type'] = 'danger';
+    header('Location: /admin/captcha', true, 302);
+    exit();
+}
+
+$action = (string) ($_POST['action'] ?? '');
+
+/**
+ * 🔧 Upsert a global (siteID = NULL) setting key/value.
+ *
+ * Encrypts the value first if isSensitive is true and the encrypt_setting()
+ * helper is available.
+ */
+$upsert = static function (mysqli $db, string $key, string $value, bool $isSensitive): bool {
+    if ($isSensitive === true && function_exists('encrypt_setting') === true && $value !== '') {
+        $value = encrypt_setting($value);
+    }
+    $isSensInt = $isSensitive === true ? 1 : 0;
+
+    // 🔎 Lookup existing row at global scope (siteID IS NULL)
+    $stmt = $db->prepare('SELECT settingID FROM tblSettings WHERE settingKey = ? AND siteID IS NULL LIMIT 1');
+    if ($stmt === false) {
+        return false;
+    }
+    $stmt->bind_param('s', $key);
+    $stmt->execute();
+    $stmt->bind_result($id);
+    $exists = $stmt->fetch() === true;
+    $stmt->close();
+
+    if ($exists === true) {
+        $stmt = $db->prepare(
+            'UPDATE tblSettings SET settingValue = ?, isSensitive = ?, updatedAt = NOW() '
+            . 'WHERE settingID = ?'
+        );
+        if ($stmt === false) {
+            return false;
+        }
+        $stmt->bind_param('sii', $value, $isSensInt, $id);
+        $ok = $stmt->execute();
+        $stmt->close();
+        return $ok;
+    }
+
+    $stmt = $db->prepare(
+        'INSERT INTO tblSettings (settingKey, settingValue, isSensitive, siteID, updatedAt) '
+        . 'VALUES (?, ?, ?, NULL, NOW())'
+    );
+    if ($stmt === false) {
+        return false;
+    }
+    $stmt->bind_param('ssi', $key, $value, $isSensInt);
+    $ok = $stmt->execute();
+    $stmt->close();
+    return $ok;
+};
+
+// -----------------------------------------------------------------------------
+// 🪜 Save provider priority
+// -----------------------------------------------------------------------------
+if ($action === 'priority') {
+    $rawPriority = (string) ($_POST['priority'] ?? '');
+    $clean       = Captcha::normalisePriority($rawPriority);
+
+    $ok = $upsert($mysqli, 'auth.captcha.priority', $clean, false);
+
+    if ($ok === true) {
+        Logger::activity('CaptchaPriorityUpdated', 'Set priority to: ' . $clean);
+        $_SESSION['flash_msg']  = 'Captcha priority updated.';
+        $_SESSION['flash_type'] = 'success';
+    } else {
+        Logger::errorPlatform('Settings', 'Error', 'CAPTCHA_PRIORITY_FAIL', $mysqli->error, '');
+        $_SESSION['flash_msg']  = 'Failed to save captcha priority.';
+        $_SESSION['flash_type'] = 'danger';
+    }
+
+    header('Location: /admin/captcha', true, 302);
+    exit();
+}
+
+// -----------------------------------------------------------------------------
+// 🔑 Save provider keys
+// -----------------------------------------------------------------------------
+if ($action === 'keys') {
+    $turnstileSite   = trim((string) ($_POST['turnstile_site']   ?? ''));
+    $turnstileSecret = trim((string) ($_POST['turnstile_secret'] ?? ''));
+
+    $recaptchaSite   = trim((string) ($_POST['recaptcha_site']   ?? ''));
+    $recaptchaSecret = trim((string) ($_POST['recaptcha_secret'] ?? ''));
+    $recaptchaVer    = (string) ($_POST['recaptcha_version'] ?? 'v2');
+    $recaptchaV3Act  = trim((string) ($_POST['recaptcha_v3_action']    ?? 'submit'));
+    $recaptchaV3Thr  = trim((string) ($_POST['recaptcha_v3_threshold'] ?? '0.5'));
+
+    $hcaptchaSite    = trim((string) ($_POST['hcaptcha_site']   ?? ''));
+    $hcaptchaSecret  = trim((string) ($_POST['hcaptcha_secret'] ?? ''));
+
+    // 🛡️ Normalise enum + score values
+    if ($recaptchaVer !== 'v2' && $recaptchaVer !== 'v3') {
+        $recaptchaVer = 'v2';
+    }
+    if ($recaptchaV3Act === '') {
+        $recaptchaV3Act = 'submit';
+    }
+    $thresholdFloat = (float) $recaptchaV3Thr;
+    if ($thresholdFloat < 0.0) {
+        $thresholdFloat = 0.0;
+    }
+    if ($thresholdFloat > 1.0) {
+        $thresholdFloat = 1.0;
+    }
+    $recaptchaV3Thr = (string) $thresholdFloat;
+
+    $writes = [
+        ['auth.turnstile.siteKey',         $turnstileSite,   true],
+        ['auth.turnstile.secretKey',       $turnstileSecret, true],
+        ['auth.recaptcha.siteKey',         $recaptchaSite,   true],
+        ['auth.recaptcha.secretKey',       $recaptchaSecret, true],
+        ['auth.recaptcha.version',         $recaptchaVer,    false],
+        ['auth.recaptcha.v3.action',       $recaptchaV3Act,  false],
+        ['auth.recaptcha.v3.threshold',    $recaptchaV3Thr,  false],
+        ['auth.hcaptcha.siteKey',          $hcaptchaSite,    true],
+        ['auth.hcaptcha.secretKey',        $hcaptchaSecret,  true],
+    ];
+
+    $allOk = true;
+    foreach ($writes as [$key, $value, $sensitive]) {
+        if ($upsert($mysqli, (string) $key, (string) $value, (bool) $sensitive) === false) {
+            Logger::errorPlatform('Settings', 'Error', 'CAPTCHA_KEY_FAIL', $mysqli->error, 'key=' . $key);
+            $allOk = false;
+        }
+    }
+
+    if ($allOk === true) {
+        Logger::activity('CaptchaKeysUpdated', 'Captcha provider keys updated');
+        $_SESSION['flash_msg']  = 'Captcha provider keys saved.';
+        $_SESSION['flash_type'] = 'success';
+    } else {
+        $_SESSION['flash_msg']  = 'One or more captcha settings failed to save — see error log.';
+        $_SESSION['flash_type'] = 'danger';
+    }
+
+    header('Location: /admin/captcha', true, 302);
+    exit();
+}
+
+// 🚫 Unknown action — bounce back
+header('Location: /admin/captcha', true, 302);
+exit();

--- a/web/public_html/admin/index.php
+++ b/web/public_html/admin/index.php
@@ -315,6 +315,12 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
                     <span class="small">Integrations</span>
                 </a>
             </div>
+            <div class="col-6 col-md-4 col-lg-2">
+                <a href="/admin/captcha" class="btn btn-outline-warning w-100 d-flex flex-column align-items-center gap-1 py-3">
+                    <i class="fa-solid fa-robot fa-lg"></i>
+                    <span class="small">Captcha</span>
+                </a>
+            </div>
             <?php if (App::isUmbrellaAdmin() === true): ?>
             <div class="col-6 col-md-4 col-lg-2">
                 <a href="/admin/sites" class="btn btn-outline-dark w-100 d-flex flex-column align-items-center gap-1 py-3">

--- a/web/sql/040_captcha_providers.sql
+++ b/web/sql/040_captcha_providers.sql
@@ -1,0 +1,34 @@
+-- =============================================================================
+-- 040 — Multi-provider Captcha support 🤖
+-- =============================================================================
+-- Adds:
+--   • hCaptcha as a third supported provider (site + secret keys)
+--   • reCAPTCHA v3 score / action settings
+--   • auth.captcha.priority — ordered, comma-separated provider list
+--     (admin-configurable via /admin/captcha drag-and-drop)
+--
+-- Default priority places Cloudflare Turnstile first per platform policy.
+-- =============================================================================
+
+-- 🌐 Provider priority (admin-configurable, drag-and-drop UI at /admin/captcha)
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'auth.captcha.priority', 'turnstile,recaptcha,hcaptcha', 'turnstile,recaptcha,hcaptcha', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+-- ☁️ hCaptcha provider keys
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'auth.hcaptcha.siteKey',   '', '', 1),
+    (NULL, 'auth.hcaptcha.secretKey', '', '', 1)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+-- 🎯 reCAPTCHA v3-only settings (ignored when version=v2)
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'auth.recaptcha.v3.action',    'submit', 'submit', 0),
+    (NULL, 'auth.recaptcha.v3.threshold', '0.5',    '0.5',    0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+-- 🛠️ Routes for the new admin captcha-config page
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/captcha',      'admin/captcha/index.php', 1),
+    ('admin/captcha/save', 'admin/captcha/save.php',  1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -1147,6 +1147,26 @@ INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `default
 VALUES ('auth.turnstile.secretKey', '', 1, '')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.hcaptcha.siteKey', '', 1, '')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.hcaptcha.secretKey', '', 1, '')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.recaptcha.v3.action', 'submit', 0, 'submit')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.recaptcha.v3.threshold', '0.5', 0, '0.5')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.captcha.priority', 'turnstile,recaptcha,hcaptcha', 0, 'turnstile,recaptcha,hcaptcha')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
 -- ─── Auth — Google OAuth ─────────────────────────────────────────────────────
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
 VALUES ('auth.google.clientID', '', 1, '')
@@ -1839,6 +1859,9 @@ ON DUPLICATE KEY UPDATE `filename` = `filename`;
 INSERT INTO `tblMigrations` (`filename`) VALUES ('039_prayer_requests.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('040_captcha_providers.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
 -- Seed the branding.hidePoweredBy setting (matches migration 038)
 INSERT INTO `tblSettings`
     (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`)
@@ -1912,4 +1935,10 @@ INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('prayer-requests/anonymous',      'prayer-requests/anonymous.php',       0),
     ('prayer-requests/anonymous/save', 'prayer-requests/anonymous-save.php',  0),
     ('help/prayer-requests',           'help/prayer-requests.php',            0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+-- Seed admin captcha routes (matches migration 040)
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/captcha',      'admin/captcha/index.php', 1),
+    ('admin/captcha/save', 'admin/captcha/save.php',  1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);


### PR DESCRIPTION
## Summary

The captcha layer now supports three providers and admin-configurable priority.

- **Providers**: Cloudflare Turnstile (default first), Google reCAPTCHA (v2 checkbox **or** v3 invisible / score), hCaptcha.
- **Admin UI** at `/admin/captcha` with drag-and-drop priority ordering (SortableJS) and per-provider site/secret-key inputs. reCAPTCHA gets a v2/v3 toggle plus action + threshold inputs for v3.
- **Active provider selection** is data-driven: the first provider in the priority list with **both keys configured** is used. If nothing is configured, captcha is silently skipped.
- **reCAPTCHA v3** verification enforces both action match (anti-replay) and score threshold; default action `submit`, default threshold `0.5`.

## Backwards-compatible call sites

Existing call sites — `Captcha::scriptTag()`, `Captcha::widget()`, `Captcha::verify(\$_POST)`, `Captcha::isConfigured()` — are unchanged; they internally route to the active provider. New public helpers `Captcha::activeProvider()`, `Captcha::listProviders()`, `Captcha::normalisePriority()` power the admin UI.

## Schema

Migration `web/sql/040_captcha_providers.sql` adds:

- `auth.captcha.priority`           (default `turnstile,recaptcha,hcaptcha`)
- `auth.hcaptcha.siteKey` / `auth.hcaptcha.secretKey`
- `auth.recaptcha.v3.action`        (default `submit`)
- `auth.recaptcha.v3.threshold`     (default `0.5`)
- Routes: `admin/captcha`, `admin/captcha/save`

Seeds mirrored into `web/sql/full_schema.sql`.

## Security notes

Pre-commit review checks all clean:

- All SQL uses prepared statements with `?` placeholders + `bind_param`.
- All output in admin templates passes through `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')`.
- `/admin/captcha/save` enforces CSRF + `App::isAdmin()`; non-admins get 403 via `Router::renderError(403)`.
- Sensitive provider keys are encrypted at rest via existing `encrypt_setting()` helper.
- SortableJS is loaded from jsdelivr with `crossorigin=\"anonymous\"`; SRI intentionally omitted (no verified hash bundled). Reviewer is invited to add a pinned SRI hash before merge if desired.
- reCAPTCHA v3 action match + score threshold both enforced server-side.

## Test plan

- [ ] Run migration `040_captcha_providers.sql`
- [ ] Visit `/admin/captcha` as admin — verify priority list renders, drag-drop works
- [ ] Enter only Turnstile keys → confirm \"Active\" badge moves to Turnstile, login form shows Turnstile widget
- [ ] Add reCAPTCHA keys with version=v2 → reorder via drag so reCAPTCHA is first → confirm widget switches to reCAPTCHA v2
- [ ] Switch reCAPTCHA to v3 → confirm invisible hidden input renders, verification still works on a real form
- [ ] Add hCaptcha keys → reorder → confirm hCaptcha widget renders
- [ ] Remove all keys → captcha silently skipped (graceful fallback)
- [ ] Verify non-admin gets 403 on `/admin/captcha` and `/admin/captcha/save`

🤖 Generated with [Claude Code](https://claude.com/claude-code)