### PR TITLE
chore: prep release v0.11.0 — version bump + CHANGELOG stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+## [0.11.0] - 2026-05-22
+
 ### Added — Multi-provider Captcha
 
 The captcha layer now supports three providers and admin-configurable priority:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebMS Intra
 
-> **Version:** 0.10.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
+> **Version:** 0.11.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
 
 A modular internal portal platform for organisations, providing centralised access to internal tools, expense management, leadership directory, multi-site support, and more.
 

--- a/web/core/App.php
+++ b/web/core/App.php
@@ -53,7 +53,7 @@ class App
     private static bool $userLoaded = false;
 
     /** @var string Portal version number */
-    private static string $version = '0.10.0';
+    private static string $version = '0.11.0';
 
     /**
      * Initialise the App registry. Called from bootstrap.php after DB and settings are ready.


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.11.0**. Bumps the version + stamps the CHANGELOG so a subsequent `git tag v0.11.0` picks up clean release notes via `release.yml`.

## Why v0.11.0

Two non-breaking feature additions have landed on `main` since v0.10.0:

- **#129** — Prayer Requests app (logged-in + anonymous public submission, full moderation lifecycle).
- **#130** — Multi-provider Captcha (Cloudflare Turnstile, Google reCAPTCHA v2+v3, hCaptcha) with admin-configurable priority via drag-and-drop.

Per semver these are MINOR additions, so `0.11.0` is the correct cut.

## Files

```text
web/core/App.php   ($version '0.10.0' → '0.11.0' — fallback value)
README.md          (banner "Version: 0.10.0" → "Version: 0.11.0")
CHANGELOG.md       (new [0.11.0] - 2026-05-22 heading wrapping the
                    captcha + prayer-requests Unreleased entries)
```

## After merge

Once this lands on main, tag the release:

```bash
git fetch origin
git checkout main
git pull --ff-only
git tag -a v0.11.0 -m "v0.11.0 — Prayer Requests app + multi-provider Captcha"
git push origin v0.11.0
```

Pushing the tag fires `release.yml`, which:
- Detects the `v*` tag pattern
- Extracts release notes from the `[0.11.0]` section of CHANGELOG.md
- Creates a GitHub Release with those notes
- Tagged as non-prerelease (no `-beta` / `-rc` suffix)

> Note: v0.10.0 was prepped (PR #125) but never tagged. If you want a clean release history, you can also retroactively tag v0.10.0 at commit `826a1f9` before pushing v0.11.0.

## Test plan

- [ ] PR Security Checks pass
- [ ] After merge: `App::version()` returns `"0.11.0"` (or whatever `tblSettings.portal.version` is set to, if any)
- [ ] After tagging: GitHub Releases page shows v0.11.0 with the prayer-requests + captcha content as the release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)