### PR TITLE
security(auth): harden password policy — min length 12 + full-flow coverage (#53)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,30 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Security — Password policy hardening (#53)
+
+- **Default minimum length raised from 8 to 12** characters (configurable
+  via `auth.password.minLength`).
+- Added `auth.password.maxLength` (default `128` — defends against
+  pathological inputs; bcrypt truncates at 72 anyway).
+- Added `auth.password.requireLowercase` setting (default `true`). The
+  validator previously gated the lowercase check on the `requireUppercase`
+  flag — fixed so each case requirement is independent.
+- Server-side validation is now enforced on **every** password-set flow:
+  - Reset password (`/reset-password`) — already validated; now uses
+    the shared `Auth::passwordPolicy()` helper for hints.
+  - Account change-password — already validated; same shared helper.
+  - **Admin user create/update (`/admin/users`)** — previously unvalidated.
+  - **Installer (`/install`)** — previously only checked length ≥ 8.
+- New helper `Auth::passwordPolicy()` returns the active policy as a
+  structured array (rules list + minLength/maxLength/required flags) so
+  forms can render the policy consistently.
+- **Client-side strength meter** added to all password-set forms via
+  `data-portal-password-input` + `data-portal-password-meter` attributes
+  (Bootstrap progress bar, 5-step score). Wired into `portal.js` and a
+  self-contained inline copy for the bootstrap-free installer.
+- Migration `web/sql/041_password_policy_hardening.sql`.
+
 ## [0.11.0] - 2026-05-22
 
 ### Added — Multi-provider Captcha

--- a/web/core/Auth.php
+++ b/web/core/Auth.php
@@ -704,8 +704,10 @@ class Auth
      * Validate a password against the configurable policy stored in tblSettings.
      *
      * Settings used (all under auth.password.*):
-     *   minLength        – minimum character count (default 8)
-     *   requireUppercase – must contain A-Z and a-z (default true)
+     *   minLength        – minimum character count (default 12)
+     *   maxLength        – maximum character count (default 128 — bcrypt truncates at 72)
+     *   requireUppercase – must contain A-Z (default true)
+     *   requireLowercase – must contain a-z (default true)
      *   requireNumber    – must contain 0-9 (default true)
      *   requireSpecial   – must contain a non-alphanumeric char (default true)
      *
@@ -717,20 +719,27 @@ class Auth
     {
         $errors = [];
 
-        $minLength      = (int) (App::settings('auth.password.minLength') ?? '8');
+        $minLength      = (int) (App::settings('auth.password.minLength') ?? '12');
+        $maxLength      = (int) (App::settings('auth.password.maxLength') ?? '128');
         $requireUpper   = (App::settings('auth.password.requireUppercase') ?? 'true') === 'true';
+        $requireLower   = (App::settings('auth.password.requireLowercase') ?? 'true') === 'true';
         $requireNumber  = (App::settings('auth.password.requireNumber') ?? 'true') === 'true';
         $requireSpecial = (App::settings('auth.password.requireSpecial') ?? 'true') === 'true';
 
-        if (strlen($password) < $minLength) {
+        // 🔢 Length checks — use byte length (strlen) because that's what bcrypt sees.
+        $length = strlen($password);
+        if ($length < $minLength) {
             $errors[] = 'Password must be at least ' . $minLength . ' characters.';
+        }
+        if ($maxLength > 0 && $length > $maxLength) {
+            $errors[] = 'Password must be no more than ' . $maxLength . ' characters.';
         }
 
         if ($requireUpper === true && preg_match('/[A-Z]/', $password) !== 1) {
             $errors[] = 'Password must contain at least one uppercase letter.';
         }
 
-        if ($requireUpper === true && preg_match('/[a-z]/', $password) !== 1) {
+        if ($requireLower === true && preg_match('/[a-z]/', $password) !== 1) {
             $errors[] = 'Password must contain at least one lowercase letter.';
         }
 
@@ -743,6 +752,46 @@ class Auth
         }
 
         return ['valid' => (count($errors) === 0), 'errors' => $errors];
+    }
+
+    /**
+     * Return the active password policy as a structured array suitable for
+     * rendering on password-set forms (so users see the requirements upfront).
+     *
+     * @return array{minLength:int, maxLength:int, requireUppercase:bool, requireLowercase:bool, requireNumber:bool, requireSpecial:bool, rules:list<string>}
+     */
+    public static function passwordPolicy(): array
+    {
+        $minLength      = (int) (App::settings('auth.password.minLength') ?? '12');
+        $maxLength      = (int) (App::settings('auth.password.maxLength') ?? '128');
+        $requireUpper   = (App::settings('auth.password.requireUppercase') ?? 'true') === 'true';
+        $requireLower   = (App::settings('auth.password.requireLowercase') ?? 'true') === 'true';
+        $requireNumber  = (App::settings('auth.password.requireNumber') ?? 'true') === 'true';
+        $requireSpecial = (App::settings('auth.password.requireSpecial') ?? 'true') === 'true';
+
+        $rules = ['At least ' . $minLength . ' characters'];
+        if ($requireUpper === true) {
+            $rules[] = 'At least one uppercase letter (A-Z)';
+        }
+        if ($requireLower === true) {
+            $rules[] = 'At least one lowercase letter (a-z)';
+        }
+        if ($requireNumber === true) {
+            $rules[] = 'At least one number (0-9)';
+        }
+        if ($requireSpecial === true) {
+            $rules[] = 'At least one special character (e.g. !@#$%^&*)';
+        }
+
+        return [
+            'minLength'        => $minLength,
+            'maxLength'        => $maxLength,
+            'requireUppercase' => $requireUpper,
+            'requireLowercase' => $requireLower,
+            'requireNumber'    => $requireNumber,
+            'requireSpecial'   => $requireSpecial,
+            'rules'            => $rules,
+        ];
     }
 
     /* ====================================================================== */

--- a/web/install/index.php
+++ b/web/install/index.php
@@ -197,14 +197,36 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $adminPass  = $_POST['admin_pass'] ?? '';
         $adminPass2 = $_POST['admin_pass2'] ?? '';
 
+        // 🛡️ Self-contained password policy — mirrors Auth::validatePassword() defaults
+        // (the installer runs before bootstrap.php is available).
+        $pwErrors = [];
+        if (strlen($adminPass) < 12) {
+            $pwErrors[] = 'Password must be at least 12 characters.';
+        }
+        if (strlen($adminPass) > 128) {
+            $pwErrors[] = 'Password must be no more than 128 characters.';
+        }
+        if (preg_match('/[A-Z]/', $adminPass) !== 1) {
+            $pwErrors[] = 'Password must contain at least one uppercase letter.';
+        }
+        if (preg_match('/[a-z]/', $adminPass) !== 1) {
+            $pwErrors[] = 'Password must contain at least one lowercase letter.';
+        }
+        if (preg_match('/[0-9]/', $adminPass) !== 1) {
+            $pwErrors[] = 'Password must contain at least one number.';
+        }
+        if (preg_match('/[^a-zA-Z0-9]/', $adminPass) !== 1) {
+            $pwErrors[] = 'Password must contain at least one special character.';
+        }
+
         if ($adminName === '' || $adminEmail === '' || $adminPass === '') {
             $error = 'All fields are required.';
             $step = 4;
         } elseif (filter_var($adminEmail, FILTER_VALIDATE_EMAIL) === false) {
             $error = 'Please enter a valid email address.';
             $step = 4;
-        } elseif (strlen($adminPass) < 8) {
-            $error = 'Password must be at least 8 characters.';
+        } elseif (count($pwErrors) > 0) {
+            $error = 'Password does not meet policy: ' . implode(' ', $pwErrors);
             $step = 4;
         } elseif ($adminPass !== $adminPass2) {
             $error = 'Passwords do not match.';
@@ -1108,13 +1130,31 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
                 <div class="row">
                     <div class="col-md-6 mb-3">
                         <label for="admin_pass" class="form-label">Password</label>
-                        <input type="password" class="form-control" id="admin_pass" name="admin_pass" required minlength="8">
-                        <div class="form-text">Minimum 8 characters.</div>
+                        <input type="password" class="form-control" id="admin_pass" name="admin_pass"
+                               required minlength="12" maxlength="128"
+                               data-portal-password-input>
+                        <div class="portal-password-strength mt-2" data-portal-password-meter hidden>
+                            <div class="progress" style="height:6px;">
+                                <div class="progress-bar" role="progressbar" style="width:0%"></div>
+                            </div>
+                            <small class="form-text" data-portal-password-meter-label>Password strength</small>
+                        </div>
                     </div>
                     <div class="col-md-6 mb-3">
                         <label for="admin_pass2" class="form-label">Confirm Password</label>
-                        <input type="password" class="form-control" id="admin_pass2" name="admin_pass2" required minlength="8">
+                        <input type="password" class="form-control" id="admin_pass2" name="admin_pass2"
+                               required minlength="12" maxlength="128">
                     </div>
+                </div>
+                <div class="alert alert-light border small mb-3">
+                    <strong>Password must include:</strong>
+                    <ul class="mb-0 ps-3">
+                        <li>At least 12 characters</li>
+                        <li>At least one uppercase letter (A-Z)</li>
+                        <li>At least one lowercase letter (a-z)</li>
+                        <li>At least one number (0-9)</li>
+                        <li>At least one special character (e.g. !@#$%^&amp;*)</li>
+                    </ul>
                 </div>
 
                 <div class="d-flex justify-content-between">
@@ -1260,6 +1300,57 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
     // Initial state — FOUC script already applied the data-* attrs; just sync the icons/titles.
     updateThemeBtn(savedTheme());
     applyCb(savedCb());
+})();
+</script>
+
+<script>
+// Password strength meter for the installer (standalone — doesn't load portal.js)
+(function () {
+    function score(value, minLength) {
+        if (!value) { return 0; }
+        var s = 0;
+        if (value.length >= minLength)  { s += 1; }
+        if (/[a-z]/.test(value))        { s += 1; }
+        if (/[A-Z]/.test(value))        { s += 1; }
+        if (/[0-9]/.test(value))        { s += 1; }
+        if (/[^a-zA-Z0-9]/.test(value)) { s += 1; }
+        return s;
+    }
+    function labelFor(s) {
+        if (s <= 1)  { return ['bg-danger',  'Very weak']; }
+        if (s === 2) { return ['bg-danger',  'Weak']; }
+        if (s === 3) { return ['bg-warning', 'Fair']; }
+        if (s === 4) { return ['bg-info',    'Strong']; }
+        return ['bg-success', 'Very strong'];
+    }
+    document.querySelectorAll('input[data-portal-password-input]').forEach(function (input) {
+        var scope = input.closest('.col-md-6, .mb-3, form') || input.parentNode;
+        var meter = scope ? scope.querySelector('[data-portal-password-meter]') : null;
+        if (!meter) { return; }
+        var bar = meter.querySelector('.progress-bar');
+        var lbl = meter.querySelector('[data-portal-password-meter-label]');
+        if (!bar) { return; }
+        var minLength = parseInt(input.getAttribute('minlength'), 10);
+        if (!minLength || minLength < 1) { minLength = 12; }
+        input.addEventListener('input', function () {
+            var v = input.value || '';
+            if (v === '') {
+                meter.hidden = true;
+                bar.style.width = '0%';
+                bar.className = 'progress-bar';
+                if (lbl) { lbl.textContent = 'Password strength'; }
+                return;
+            }
+            meter.hidden = false;
+            var sc = score(v, minLength);
+            var pct = Math.round((sc / 5) * 100);
+            var sl = labelFor(sc);
+            bar.style.width = pct + '%';
+            bar.className = 'progress-bar ' + sl[0];
+            bar.setAttribute('aria-valuenow', String(pct));
+            if (lbl) { lbl.textContent = 'Password strength: ' + sl[1]; }
+        });
+    });
 })();
 </script>
 

--- a/web/public_html/admin/users/index.php
+++ b/web/public_html/admin/users/index.php
@@ -144,6 +144,9 @@ $flashMsg  = $_SESSION['flash_msg']  ?? '';
 $flashType = $_SESSION['flash_type'] ?? 'info';
 unset($_SESSION['flash_msg'], $_SESSION['flash_type']);
 
+// 🔐 Password policy for inline hints + strength meter
+$policy = Auth::passwordPolicy();
+
 // 📄 Include shared header template
 require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
 ?>
@@ -364,11 +367,29 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
                         </div>
                         <div class="col-12 col-md-6">
                             <label class="form-label">Password</label>
-                            <input type="password" class="form-control" name="password" placeholder="Required if username is set">
+                            <input type="password" class="form-control" name="password"
+                                   placeholder="Required if username is set"
+                                   minlength="<?php echo (int) $policy['minLength']; ?>"
+                                   maxlength="<?php echo (int) $policy['maxLength']; ?>"
+                                   data-portal-password-input>
+                            <div class="portal-password-strength mt-2" data-portal-password-meter hidden>
+                                <div class="progress" style="height:6px;">
+                                    <div class="progress-bar" role="progressbar" style="width:0%"></div>
+                                </div>
+                                <small class="form-text" data-portal-password-meter-label>Password strength</small>
+                            </div>
                         </div>
                         <div class="col-12 col-md-6">
                             <label class="form-label">Confirm Password</label>
-                            <input type="password" class="form-control" name="password_confirm">
+                            <input type="password" class="form-control" name="password_confirm"
+                                   minlength="<?php echo (int) $policy['minLength']; ?>"
+                                   maxlength="<?php echo (int) $policy['maxLength']; ?>">
+                        </div>
+                        <div class="col-12">
+                            <div class="small text-muted">
+                                Password policy:
+                                <?php echo htmlspecialchars(implode(' • ', $policy['rules']), ENT_QUOTES, 'UTF-8'); ?>
+                            </div>
                         </div>
                         <div class="col-12">
                             <div class="form-check form-check-inline">
@@ -425,7 +446,20 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
                         </div>
                         <div class="col-12 col-md-6">
                             <label class="form-label">New Password</label>
-                            <input type="password" class="form-control" name="password" placeholder="Leave blank to keep current">
+                            <input type="password" class="form-control" name="password"
+                                   placeholder="Leave blank to keep current"
+                                   minlength="<?php echo (int) $policy['minLength']; ?>"
+                                   maxlength="<?php echo (int) $policy['maxLength']; ?>"
+                                   data-portal-password-input>
+                            <div class="portal-password-strength mt-2" data-portal-password-meter hidden>
+                                <div class="progress" style="height:6px;">
+                                    <div class="progress-bar" role="progressbar" style="width:0%"></div>
+                                </div>
+                                <small class="form-text" data-portal-password-meter-label>Password strength</small>
+                            </div>
+                            <div class="small text-muted mt-1">
+                                Policy: <?php echo htmlspecialchars(implode(' • ', $policy['rules']), ENT_QUOTES, 'UTF-8'); ?>
+                            </div>
                         </div>
                         <div class="col-12">
                             <div class="form-check form-check-inline">

--- a/web/public_html/admin/users/save.php
+++ b/web/public_html/admin/users/save.php
@@ -97,6 +97,17 @@ if ($action === 'create') {
         exit();
     }
 
+    // 🛡️ Enforce password policy when a password was supplied
+    if ($password !== '') {
+        $check = Auth::validatePassword($password);
+        if ($check['valid'] === false) {
+            $_SESSION['flash_msg']  = 'Password does not meet policy: ' . implode(' ', $check['errors']);
+            $_SESSION['flash_type'] = 'danger';
+            header('Location: /admin/users');
+            exit();
+        }
+    }
+
     // 🔄 Wrap multi-table insert in a transaction for atomicity
     App::beginTransaction();
 
@@ -212,6 +223,15 @@ if ($action === 'update') {
 
     // 🔑 Update password if provided
     if ($password !== '') {
+        // 🛡️ Enforce password policy before hashing
+        $check = Auth::validatePassword($password);
+        if ($check['valid'] === false) {
+            $_SESSION['flash_msg']  = 'Password does not meet policy: ' . implode(' ', $check['errors']);
+            $_SESSION['flash_type'] = 'danger';
+            header('Location: /admin/users');
+            exit();
+        }
+
         $hash = password_hash($password, PASSWORD_DEFAULT);
         // Check if local account exists
         $stmt = $mysqli->prepare('SELECT localID FROM tblLocalAccounts WHERE userID = ? LIMIT 1');

--- a/web/public_html/assets/js/portal.js
+++ b/web/public_html/assets/js/portal.js
@@ -348,6 +348,82 @@
     }
 
     /* ========================================================================
+       4b. Password Strength Meter
+       ------------------------------------------------------------------------
+       Attaches to any <input type="password" data-portal-password-input>.
+       A sibling [data-portal-password-meter] element receives the live
+       strength score (0-5) as a Bootstrap progress bar + label.
+
+       Scoring (mirrors Auth::passwordPolicy on the server):
+         +1 length >= minLength (from input minlength, fallback 12)
+         +1 contains lowercase
+         +1 contains uppercase
+         +1 contains digit
+         +1 contains symbol
+       Range 0-5 -> mapped to {0,20,40,60,80,100}% bar.
+       ======================================================================== */
+    function scorePassword(value, minLength) {
+        if (!value) {
+            return 0;
+        }
+        var s = 0;
+        if (value.length >= minLength) { s += 1; }
+        if (/[a-z]/.test(value))        { s += 1; }
+        if (/[A-Z]/.test(value))        { s += 1; }
+        if (/[0-9]/.test(value))        { s += 1; }
+        if (/[^a-zA-Z0-9]/.test(value)) { s += 1; }
+        return s;
+    }
+
+    function strengthClassAndLabel(score) {
+        if (score <= 1) { return ['bg-danger',  'Very weak']; }
+        if (score === 2) { return ['bg-danger',  'Weak']; }
+        if (score === 3) { return ['bg-warning', 'Fair']; }
+        if (score === 4) { return ['bg-info',    'Strong']; }
+        return ['bg-success', 'Very strong'];
+    }
+
+    function initPasswordMeters() {
+        var inputs = document.querySelectorAll('input[data-portal-password-input]');
+        inputs.forEach(function (input) {
+            // Find the closest container that also holds the meter element
+            var meter = null;
+            var scope = input.closest('.mb-3, .col-md-6, form') || input.parentNode;
+            if (scope) {
+                meter = scope.querySelector('[data-portal-password-meter]');
+            }
+            if (!meter) {
+                return;
+            }
+            var bar = meter.querySelector('.progress-bar');
+            var lbl = meter.querySelector('[data-portal-password-meter-label]');
+            if (!bar) { return; }
+
+            var minLength = parseInt(input.getAttribute('minlength'), 10);
+            if (!minLength || minLength < 1) { minLength = 12; }
+
+            input.addEventListener('input', function () {
+                var value = input.value || '';
+                if (value === '') {
+                    meter.hidden = true;
+                    bar.style.width = '0%';
+                    bar.className = 'progress-bar';
+                    if (lbl) { lbl.textContent = 'Password strength'; }
+                    return;
+                }
+                meter.hidden = false;
+                var score = scorePassword(value, minLength);
+                var pct = Math.round((score / 5) * 100);
+                var sl = strengthClassAndLabel(score);
+                bar.style.width = pct + '%';
+                bar.className = 'progress-bar ' + sl[0];
+                bar.setAttribute('aria-valuenow', String(pct));
+                if (lbl) { lbl.textContent = 'Password strength: ' + sl[1]; }
+            });
+        });
+    }
+
+    /* ========================================================================
        5. Initialisation
        ======================================================================== */
 
@@ -357,11 +433,13 @@
             initThemeToggle();
             initCbToggle();
             initDropzones();
+            initPasswordMeters();
         });
     } else {
         initThemeToggle();
         initCbToggle();
         initDropzones();
+        initPasswordMeters();
     }
 
     // Expose public API on window.Portal

--- a/web/public_html/auth/account/index.php
+++ b/web/public_html/auth/account/index.php
@@ -147,25 +147,11 @@ if ($npStmt !== false) {
 }
 
 // -----------------------------------------------------------------------------
-// 3. 📋 Build password policy description
+// 3. 📋 Resolve password policy for display + the strength meter
 // -----------------------------------------------------------------------------
 
-$minLength      = (int) (App::settings('auth.password.minLength') ?? '8');
-$requireUpper   = (App::settings('auth.password.requireUppercase') ?? 'true') === 'true';
-$requireNumber  = (App::settings('auth.password.requireNumber') ?? 'true') === 'true';
-$requireSpecial = (App::settings('auth.password.requireSpecial') ?? 'true') === 'true';
-
-$policyItems = [];
-$policyItems[] = 'At least ' . $minLength . ' characters';
-if ($requireUpper === true) {
-    $policyItems[] = 'Upper and lowercase letters';
-}
-if ($requireNumber === true) {
-    $policyItems[] = 'At least one number';
-}
-if ($requireSpecial === true) {
-    $policyItems[] = 'At least one special character';
-}
+$policy      = Auth::passwordPolicy();
+$policyItems = $policy['rules'];
 
 // -----------------------------------------------------------------------------
 // 4. 📨 Flash messages from save handlers
@@ -316,13 +302,24 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
                     <div class="mb-3">
                         <label for="new_password" class="form-label">New Password</label>
                         <input type="password" class="form-control" id="new_password" name="new_password"
-                               autocomplete="new-password" required>
+                               autocomplete="new-password" required
+                               minlength="<?php echo (int) $policy['minLength']; ?>"
+                               maxlength="<?php echo (int) $policy['maxLength']; ?>"
+                               data-portal-password-input>
+                        <div class="portal-password-strength mt-2" data-portal-password-meter hidden>
+                            <div class="progress" style="height:6px;">
+                                <div class="progress-bar" role="progressbar" style="width:0%"></div>
+                            </div>
+                            <small class="form-text" data-portal-password-meter-label>Password strength</small>
+                        </div>
                     </div>
 
                     <div class="mb-2">
                         <label for="new_password_confirm" class="form-label">Confirm New Password</label>
                         <input type="password" class="form-control" id="new_password_confirm" name="new_password_confirm"
-                               autocomplete="new-password" required>
+                               autocomplete="new-password" required
+                               minlength="<?php echo (int) $policy['minLength']; ?>"
+                               maxlength="<?php echo (int) $policy['maxLength']; ?>">
                     </div>
 
                     <!-- 📋 Password requirements -->

--- a/web/public_html/auth/reset-password/index.php
+++ b/web/public_html/auth/reset-password/index.php
@@ -22,7 +22,6 @@ declare(strict_types=1);
 
 require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
-use Portal\Core\App;
 use Portal\Core\Asset;
 use Portal\Core\Auth;
 use Portal\Core\Captcha;
@@ -76,25 +75,11 @@ if ($plaintextToken === '') {
 }
 
 // -----------------------------------------------------------------------------
-// 3. 📋 Build password policy description for the user
+// 3. 📋 Resolve password policy for display + the strength meter
 // -----------------------------------------------------------------------------
 
-$minLength      = (int) (App::settings('auth.password.minLength') ?? '8');
-$requireUpper   = (App::settings('auth.password.requireUppercase') ?? 'true') === 'true';
-$requireNumber  = (App::settings('auth.password.requireNumber') ?? 'true') === 'true';
-$requireSpecial = (App::settings('auth.password.requireSpecial') ?? 'true') === 'true';
-
-$policyItems = [];
-$policyItems[] = 'At least ' . $minLength . ' characters';
-if ($requireUpper === true) {
-    $policyItems[] = 'Upper and lowercase letters';
-}
-if ($requireNumber === true) {
-    $policyItems[] = 'At least one number';
-}
-if ($requireSpecial === true) {
-    $policyItems[] = 'At least one special character';
-}
+$policy      = Auth::passwordPolicy();
+$policyItems = $policy['rules'];
 
 // -----------------------------------------------------------------------------
 // 4. 🎨 Render page
@@ -158,13 +143,24 @@ if ($requireSpecial === true) {
             <div class="mb-3">
                 <label for="password" class="form-label">New Password</label>
                 <input type="password" class="form-control" id="password" name="password"
-                       autocomplete="new-password" required autofocus>
+                       autocomplete="new-password" required autofocus
+                       minlength="<?php echo (int) $policy['minLength']; ?>"
+                       maxlength="<?php echo (int) $policy['maxLength']; ?>"
+                       data-portal-password-input>
+                <div class="portal-password-strength mt-2" data-portal-password-meter hidden>
+                    <div class="progress" style="height:6px;">
+                        <div class="progress-bar" role="progressbar" style="width:0%"></div>
+                    </div>
+                    <small class="form-text" data-portal-password-meter-label>Password strength</small>
+                </div>
             </div>
 
             <div class="mb-2">
                 <label for="password_confirm" class="form-label">Confirm New Password</label>
                 <input type="password" class="form-control" id="password_confirm" name="password_confirm"
-                       autocomplete="new-password" required>
+                       autocomplete="new-password" required
+                       minlength="<?php echo (int) $policy['minLength']; ?>"
+                       maxlength="<?php echo (int) $policy['maxLength']; ?>">
             </div>
 
             <!-- 📋 Password requirements -->
@@ -193,6 +189,7 @@ if ($requireSpecial === true) {
 
 <!-- 📦 JavaScript (CDN with local fallback) -->
 <?php echo Asset::bootstrapJs(); ?>
+<?php echo Asset::portalJs(); ?>
 
 </body>
 </html>

--- a/web/sql/041_password_policy_hardening.sql
+++ b/web/sql/041_password_policy_hardening.sql
@@ -1,0 +1,27 @@
+-- =============================================================================
+-- 041 — Password policy hardening 🔐
+-- =============================================================================
+-- - Bumps default `auth.password.minLength` from 8 to 12 to align with OWASP
+--   ASVS L1 guidance (existing values are preserved by ON DUPLICATE KEY).
+-- - Adds two new policy settings:
+--     auth.password.maxLength       — defence against pathological inputs
+--                                     (bcrypt truncates at 72 bytes; 128 leaves
+--                                     headroom for emoji-rich passphrases).
+--     auth.password.requireLowercase — was previously implicit in the validator
+--                                     (bug: tied to requireUppercase flag).
+--
+-- See: web/core/Auth.php → validatePassword() / passwordPolicy()
+-- =============================================================================
+
+-- 🔄 Raise the default minimum length to 12 (default-value column only; existing
+-- siteValues are preserved).
+UPDATE `tblSettings`
+   SET `defaultValue` = '12'
+ WHERE `settingKey` = 'auth.password.minLength'
+   AND `defaultValue` = '8';
+
+-- 🆕 Add the new settings (NULL siteID = global default)
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'auth.password.maxLength',        '128',  '128',  0),
+    (NULL, 'auth.password.requireLowercase', 'true', 'true', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -1064,13 +1064,21 @@ INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `default
 VALUES ('auth.rateLimit.windowMinutes', '15', 0, '15')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
--- ─── Auth — password policy (from migration 006) ────────────────────────────
+-- ─── Auth — password policy (from migrations 006 + 041) ─────────────────────
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
-VALUES ('auth.password.minLength', '8', 0, '8')
+VALUES ('auth.password.minLength', '12', 0, '12')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.password.maxLength', '128', 0, '128')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
 VALUES ('auth.password.requireUppercase', 'true', 0, 'true')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('auth.password.requireLowercase', 'true', 0, 'true')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
@@ -1860,6 +1868,9 @@ INSERT INTO `tblMigrations` (`filename`) VALUES ('039_prayer_requests.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblMigrations` (`filename`) VALUES ('040_captcha_providers.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('041_password_policy_hardening.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 -- Seed the branding.hidePoweredBy setting (matches migration 038)


### PR DESCRIPTION
## Summary

Closes #53.

- **Default minimum length** raised from `8` → `12` characters (still configurable via `auth.password.minLength`).
- **New `auth.password.maxLength`** setting (default `128` — bcrypt truncates at 72, so this is just defence against pathological inputs).
- **New `auth.password.requireLowercase`** setting (default `true`). The validator previously gated the lowercase check on the `requireUppercase` flag — fixed so each case requirement is independent.
- **Server-side validation enforced on every password-set flow.** Previously gaps existed in:
  - `web/public_html/admin/users/save.php` — create AND update branches now call `Auth::validatePassword()`.
  - `web/install/index.php` — only checked length ≥ 8; now runs a self-contained validator (the installer pre-dates `bootstrap.php`, so it can't use the helper directly; defaults mirror `Auth::passwordPolicy()`).
- **New helper `Auth::passwordPolicy()`** returns the active policy as a structured array so forms render the policy consistently (rules list + `minLength` / `maxLength` / required flags).
- **Client-side strength meter** (5-step score) wired up via `data-portal-password-input` + `data-portal-password-meter` attributes:
  - `portal.js` picks up the attribute on logged-in pages.
  - The installer ships a self-contained inline copy.

## Schema

Migration `web/sql/041_password_policy_hardening.sql`:
- `UPDATE tblSettings SET defaultValue='12' WHERE settingKey='auth.password.minLength' AND defaultValue='8'` (preserves any site-customised values).
- `INSERT ... ON DUPLICATE KEY` for `auth.password.maxLength` and `auth.password.requireLowercase`.

Mirrored into `web/sql/full_schema.sql` so fresh installs are wired up out of the box.

## Forms touched

| Form | Server-side validate | Client-side meter | Policy hint |
| ---- | -------------------- | ----------------- | ----------- |
| `/reset-password` | already | added | already (now via helper) |
| `/account` change-password | already | added | already (now via helper) |
| `/admin/users` create modal | **added** | added | **added** |
| `/admin/users` edit modal | **added** | added | **added** |
| `/install` admin account | **added** | added | **added** |

## Security notes

Pre-commit review (grepped the diff) — all clean:

- No new SQL string interpolation; all queries use `?` + `bind_param`.
- No new raw user-input echo; every output is `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')`.
- No dangerous functions added.
- No secrets in diff (grep matches are all `password` policy code references, not credentials).
- CSRF coverage on all existing POST handlers unchanged.

## Acceptance criteria (from #53)

- [x] Password strength validated server-side on all password-setting flows
- [x] Minimum length enforced (configurable, default 12)
- [x] Complexity requirements enforced when enabled
- [x] Clear error messages when password doesn't meet requirements
- [x] Client-side strength indicator (JS-enhanced, degrades gracefully)

## Test plan

- [ ] Run migration `041_password_policy_hardening.sql`
- [ ] Try resetting a password with length 8 → confirm rejection with clear error.
- [ ] Change account password to `Abcdefgh12345!` (14 chars, mixed) → succeeds.
- [ ] Admin → create user with weak password → rejected with policy message.
- [ ] Installer admin step: type a weak password → strength meter shows red.
- [ ] Verify meter degrades gracefully when JS disabled (form still submits + server validates).

🤖 Generated with [Claude Code](https://claude.com/claude-code)