### PR TITLE
security(debug): refuse debug mode in production (#54)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,23 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Security — Debug mode hardening in production (#54)
+
+- `Debug::isEnabled()` and `App::isDebug()` now **unconditionally refuse**
+  to enable debug mode when `PORTAL_ENV === 'prod'`, regardless of who is
+  signed in or what query parameters are present.
+- Attempts to set `?debug=true` in prod are logged once per request
+  (`DebugBlocked` activity entry with IP + request path) so probing shows
+  up in the activity log.
+- `bootstrap.php` now hardens PHP error display: in prod `display_errors`,
+  `display_startup_errors`, and `html_errors` are all forced to `0`.
+  Errors are still **reported** so they're captured by `Logger::phpError()`
+  and surface in the admin error log — they just aren't echoed into the
+  response.
+- The global exception handler already routed detailed traces through
+  `App::isDebug()`; since that now refuses prod, no stack traces / file
+  paths can leak in production even on unhandled exceptions.
+
 ### Security — Password policy hardening (#53)
 
 - **Default minimum length raised from 8 to 12** characters (configurable

--- a/web/core/App.php
+++ b/web/core/App.php
@@ -188,9 +188,10 @@ class App
 
     /**
      * Check if debug mode is active.
-     * Debug mode requires BOTH:
+     * Debug mode requires ALL THREE of:
      *   1. The URL parameter ?debug=true
-     *   2. The current user is an Admin or Root Admin
+     *   2. PORTAL_ENV is not 'prod' (production env unconditionally refuses)
+     *   3. The current user is an Admin or Root Admin
      *
      * @return bool True if debug mode is active
      */
@@ -198,6 +199,11 @@ class App
     {
         // 🔍 Check URL parameter first (quick exit if not present)
         if (isset($_GET['debug']) === false || $_GET['debug'] !== 'true') {
+            return false;
+        }
+
+        // 🛡️ Unconditionally disabled in production, regardless of role
+        if (defined('PORTAL_ENV') === true && PORTAL_ENV === 'prod') {
             return false;
         }
 

--- a/web/core/Debug.php
+++ b/web/core/Debug.php
@@ -123,22 +123,77 @@ class Debug
     }
 
     /**
-     * Check whether the debug URL parameter is present.
+     * Check whether the debug URL parameter is present AND the environment
+     * permits debug mode.
      *
-     * This method intentionally does NOT check admin status – that gate is
-     * applied only at render time in renderPanel().  This design allows data
-     * collection (logQuery, log) to proceed cheaply based solely on the URL
-     * flag; the expensive admin check happens only once when the panel is
-     * actually rendered.
+     * Debug mode is **unconditionally disabled** when `PORTAL_ENV === 'prod'`,
+     * regardless of admin status, query parameters, or cookies.  Any attempt
+     * to enable it in production is logged once per request via Logger so
+     * persistent probing shows up in the activity log.
      *
-     * @return bool True if $_GET['debug'] === 'true'
+     * The admin authorization check happens later in renderPanel() — this
+     * function only answers "is the URL flag set in an env that allows it?".
+     *
+     * @return bool True if $_GET['debug'] === 'true' AND env is not prod
      */
     public static function isEnabled(): bool
     {
-        if (isset($_GET['debug']) === true && $_GET['debug'] === 'true') {
-            return true;
+        if (isset($_GET['debug']) === false || $_GET['debug'] !== 'true') {
+            return false;
         }
-        return false;
+
+        // 🛡️ Refuse debug in production, regardless of who's asking.
+        if (self::isProd() === true) {
+            self::logProdAttemptOnce();
+            return false;
+        }
+
+        return true;
+    }
+
+    /**
+     * Returns true if the active environment is production.
+     */
+    private static function isProd(): bool
+    {
+        if (defined('PORTAL_ENV') === false) {
+            return false;
+        }
+        return PORTAL_ENV === 'prod';
+    }
+
+    /** @var bool Guard so we only log the first prod debug attempt per request */
+    private static bool $loggedProdAttempt = false;
+
+    /**
+     * Record an attempt to enable debug mode in production. Logged at most
+     * once per request so a single page that probes ?debug=true doesn't
+     * flood the activity table.
+     */
+    private static function logProdAttemptOnce(): void
+    {
+        if (self::$loggedProdAttempt === true) {
+            return;
+        }
+        self::$loggedProdAttempt = true;
+
+        $ip = $_SERVER['HTTP_CF_CONNECTING_IP']
+            ?? $_SERVER['HTTP_X_FORWARDED_FOR']
+            ?? $_SERVER['REMOTE_ADDR']
+            ?? '';
+        if (str_contains((string) $ip, ',') === true) {
+            $ip = trim(explode(',', (string) $ip)[0]);
+        }
+        $path = $_SERVER['REQUEST_URI'] ?? '';
+
+        // 🪵 Use Logger if available; never throw — this is best-effort audit only.
+        if (class_exists('\\Portal\\Core\\Logger', false) === true) {
+            try {
+                Logger::activity('DebugBlocked', 'Debug mode attempt in prod from ' . $ip . ' at ' . $path);
+            } catch (\Throwable) {
+                // 🤷 Logging failure must never break the request.
+            }
+        }
     }
 
     /**

--- a/web/core/bootstrap.php
+++ b/web/core/bootstrap.php
@@ -80,6 +80,27 @@ if ($env === false || $env === '') {
 }
 define('PORTAL_ENV', $env);
 
+// 🛡️ PHP error display hardening
+// -----------------------------------------------------------------------------
+// In production we MUST NOT echo PHP errors / warnings into the response —
+// they can leak file paths, query fragments, and credential variable names.
+// Errors are still captured by Logger / tblErrors for admin diagnosis.
+//
+// In dev / beta we surface errors at the top of the page so developers see
+// them during active work. Admin staff on beta are expected to be technical.
+//
+// See: https://www.php.net/manual/en/errorfunc.configuration.php
+if (PORTAL_ENV === 'prod') {
+    ini_set('display_errors', '0');
+    ini_set('display_startup_errors', '0');
+    ini_set('html_errors', '0');
+    // Errors are still REPORTED so PHP's logger sees them; just not DISPLAYED.
+    error_reporting(E_ALL);
+} else {
+    ini_set('display_errors', '1');
+    error_reporting(E_ALL);
+}
+
 // 🕐 Default timezone until settings load (overridden later)
 date_default_timezone_set('UTC');
 


### PR DESCRIPTION
## Summary

Closes #54.

Production now refuses debug mode at three layers, defence-in-depth:

1. **`Debug::isEnabled()`** returns `false` unconditionally when `PORTAL_ENV === 'prod'`, regardless of admin role, query params, or cookies. `Debug::renderPanel()` was already gated on `isEnabled() && App::isAdmin()`, so the panel can never render in prod.
2. **`App::isDebug()`** mirrors the same prod refusal — important because the global `set_exception_handler()` in `bootstrap.php` already routes detailed exception traces through `App::isDebug()`. With this change, no stack traces / file paths can leak in production even on unhandled exceptions.
3. **`bootstrap.php`** forces `display_errors`, `display_startup_errors`, and `html_errors` all to `'0'` in prod. `error_reporting(E_ALL)` stays on so `Logger::phpError()` continues to capture everything for the admin error log — errors are still **reported**, just not **displayed**.

## Audit log

Attempts to set `?debug=true` in production are logged once per request as a `DebugBlocked` activity entry with the source IP and request path. A static guard prevents flood-logging when a single page issues sub-requests.

## Files changed

```text
web/core/Debug.php       - isEnabled() prod refusal + logProdAttemptOnce()
web/core/App.php         - isDebug() prod refusal
web/core/bootstrap.php   - display_errors=0 in prod, still report+log
CHANGELOG.md             - [Unreleased] entry under Security
```

## Security notes

Pre-commit review (grepped the diff):

- No new SQL string interpolation.
- No new raw user-input echo.
- No dangerous functions added.
- Logger call is wrapped in try/catch so audit-log failure cannot break a request.
- The class-exists guard on `Logger` keeps this safe even if Debug is somehow used during very early bootstrap.

## Acceptance criteria (from #54)

- [x] Debug panel never renders in production environment
- [x] Debug query parameters ignored in production
- [x] No sensitive information exposed in production error responses

## Test plan

- [ ] Set `PORTAL_ENV=prod` in env, hit any page with `?debug=true` → no debug panel, no detailed error info, `DebugBlocked` row in activity log.
- [ ] Set `PORTAL_ENV=dev`, sign in as admin, hit `?debug=true` → panel renders as before.
- [ ] Trigger a deliberate PHP error in prod (e.g. divide by zero) → response is the generic error template; nothing leaks to the browser.
- [ ] Trigger same error in dev → details show at top of page as before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)