### PR TITLE
chore(deploy): dry-run dispatch input + DEV_NOTES troubleshooting (#107)

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -79,6 +79,11 @@ on:
           - alpha
           - beta
           - main
+      dry_run:
+        description: "Dry run — print what would be uploaded / DELETED on the server, without making any changes. Safe to run before structurally-significant deploys (see #107)."
+        required: false
+        type: boolean
+        default: false
 
 permissions:
   contents: read
@@ -91,6 +96,11 @@ jobs:
     # Shared lftp exclude flags. Patterns with wildcards are single-quoted in
     # YAML so they pass through the shell as literal regexes for lftp.
     env:
+      # 🧪 Dry-run mode (manual dispatch only): lftp prints what it WOULD do,
+      # including which server-side files would be DELETED by --delete, but
+      # makes no changes. Threaded into every `mirror` invocation below. See
+      # https://lftp.yar.ru/lftp-man.html → "mirror --dry-run". Issue #107.
+      LFTP_DRYRUN_FLAG: ${{ github.event.inputs.dry_run == 'true' && '--dry-run' || '' }}
       LFTP_EXCLUDES: >-
         --exclude ^\.DS_Store$
         --exclude ^Thumbs\.db$
@@ -295,11 +305,12 @@ jobs:
           REMOTE:    ${{ steps.target.outputs.remote_public }}
         run: |
           REMOTE_DIR="${REMOTE%/}/"
+          [[ -n "${LFTP_DRYRUN_FLAG}" ]] && echo "🧪 DRY RUN — no changes will be made"
           echo "Deploying web/public_html/ -> $REMOTE_DIR"
           cat > /tmp/lftp_public.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
           open sftp://${SFTP_USER}@${SFTP_HOST}:${SFTP_PORT}
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES web/public_html/ ${REMOTE_DIR}
+          mirror --reverse --delete ${LFTP_DRYRUN_FLAG} --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES web/public_html/ ${REMOTE_DIR}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_public.txt
@@ -314,10 +325,11 @@ jobs:
           REMOTE:    ${{ steps.target.outputs.remote_public }}
         run: |
           REMOTE_DIR="${REMOTE%/}/"
+          [[ -n "${LFTP_DRYRUN_FLAG}" ]] && echo "🧪 DRY RUN — no changes will be made"
           echo "Deploying web/public_html/ -> $REMOTE_DIR"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
-                mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
+                mirror --reverse --delete ${LFTP_DRYRUN_FLAG} --verbose --only-newer --no-empty-dirs \
                 $LFTP_EXCLUDES \
                 web/public_html/ ${REMOTE_DIR}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"
@@ -351,6 +363,7 @@ jobs:
           REMOTE:    ${{ steps.target.outputs.remote_shared }}
         run: |
           REMOTE_DIR="${REMOTE%/}/"
+          [[ -n "${LFTP_DRYRUN_FLAG}" ]] && echo "🧪 DRY RUN — no changes will be made (mkdir steps still execute and are harmless)"
           echo "Deploying shared web/ (core, vendor, sql, _includes, _functions, _libraries/dompdf) -> $REMOTE_DIR"
           cat > /tmp/lftp_shared.txt <<LFTP_EOF
           set sftp:connect-program "ssh -o StrictHostKeyChecking=no -i $HOME/.ssh/deploy_key -p ${SFTP_PORT}"
@@ -358,7 +371,7 @@ jobs:
           mkdir -p -f ${REMOTE_DIR}_auth_keys
           mkdir -p -f ${REMOTE_DIR}_uploads
           mkdir -p -f ${REMOTE_DIR}_backups
-          mirror --reverse --delete --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE_DIR}
+          mirror --reverse --delete ${LFTP_DRYRUN_FLAG} --verbose --only-newer --no-empty-dirs $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES web/ ${REMOTE_DIR}
           bye
           LFTP_EOF
           lftp -f /tmp/lftp_shared.txt
@@ -373,13 +386,14 @@ jobs:
           REMOTE:    ${{ steps.target.outputs.remote_shared }}
         run: |
           REMOTE_DIR="${REMOTE%/}/"
+          [[ -n "${LFTP_DRYRUN_FLAG}" ]] && echo "🧪 DRY RUN — no changes will be made (mkdir steps still execute and are harmless)"
           echo "Deploying shared web/ (core, vendor, sql, _includes, _functions, _libraries/dompdf) -> $REMOTE_DIR"
           lftp -u "${SFTP_USER},${SFTP_PASS}" \
             -e "set sftp:auto-confirm yes; set ssl:verify-certificate no; \
                 mkdir -p -f ${REMOTE_DIR}_auth_keys; \
                 mkdir -p -f ${REMOTE_DIR}_uploads; \
                 mkdir -p -f ${REMOTE_DIR}_backups; \
-                mirror --reverse --delete --verbose --only-newer --no-empty-dirs \
+                mirror --reverse --delete ${LFTP_DRYRUN_FLAG} --verbose --only-newer --no-empty-dirs \
                 $LFTP_EXCLUDES $WEB_ROOT_EXCLUDES \
                 web/ ${REMOTE_DIR}; bye" \
             "sftp://${SFTP_HOST}:${SFTP_PORT}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,21 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Changed — Deploy workflow: dry-run dispatch + DEV_NOTES troubleshooting (#107)
+
+- `deploy.yml` now accepts a `dry_run` `workflow_dispatch` input. When
+  set to `true`, lftp `--dry-run` is threaded into every `mirror`
+  invocation (both per-branch `public_html/` and the `--delete` shared
+  upload). The run prints exactly what would be uploaded **and what would
+  be deleted** on the server, without making any changes — useful before
+  structurally-significant deploys (renamed/moved files in `core/`,
+  `vendor/`, `sql/`).
+- `DEV_NOTES.md → Troubleshooting` gains a "file disappeared from the
+  server after deploy" entry documenting the `--delete` mirror semantics
+  and the survival rules for `_auth_keys/` / `_uploads/` / `_backups/`.
+- Debug-panel troubleshooting note updated to mention the new prod
+  refusal (cross-references #54).
+
 ### Security — Debug mode hardening in production (#54)
 
 - `Debug::isEnabled()` and `App::isDebug()` now **unconditionally refuse**

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1051,9 +1051,43 @@ Your user account lacks dev access. Either:
 
 ### Debug panel not showing
 
-Append `?debug=true` to the URL. Only visible to admin users.
-Check that `isAdmin=1` or `isRootAdmin=1` on your user record.
+Append `?debug=true` to the URL. Only visible to admin users in **non-prod**
+environments. Debug mode is unconditionally refused when `PORTAL_ENV=prod`
+(any attempt is logged as a `DebugBlocked` activity entry). See issue #54.
+
+### A file disappeared from the server after deploy
+
+Almost certainly because **it isn't in the `web/` tree in the repo**. The
+deploy workflow mirrors with `--delete` on the shared dirs, so any file
+present on the server but absent from `web/` will be removed on the next
+push.
+
+Affected (mirrored) trees on the server:
+
+```text
+<base>/core/
+<base>/vendor/
+<base>/sql/
+<base>/_includes/
+<base>/_functions/
+<base>/_libraries/
+```
+
+What survives:
+
+- `<base>/_auth_keys/` — server-only (credentials, encryption key)
+- `<base>/_uploads/` — user uploads
+- `<base>/_backups/` — server-managed snapshots
+
+If you need a quick patch on the server during an incident, **commit + push**
+instead of SCP'ing the file — manual edits to mirrored dirs vanish on the
+next deploy. If a library or vendored asset must live on the server but
+not in the repo, add it to `WEB_ROOT_EXCLUDES` in `.github/workflows/deploy.yml`.
+
+Use the workflow_dispatch **dry-run** input on `deploy.yml` to preview what
+a deploy would change (and crucially, what it would delete) before pushing.
+See issue #107 for the full rationale and mitigation list.
 
 ---
 
-Last updated: March 2026
+Last updated: May 2026


### PR DESCRIPTION
## Summary

Addresses two of the actionable items from #107:

1. **`deploy.yml` — new `dry_run` workflow_dispatch input.** When set to `true`, `--dry-run` is threaded into every `lftp mirror` invocation. The run prints what *would* be uploaded **and what would be DELETED** on the server, but makes no changes. Recommended before structurally-significant deploys (renames / moves in `core/`, `vendor/`, `sql/`).
2. **`DEV_NOTES.md` Troubleshooting section** — adds a "file disappeared from the server after deploy" entry documenting the `--delete` mirror semantics and the survival rules for `_auth_keys/` / `_uploads/` / `_backups/`. Existing debug-panel note updated to flag the prod refusal landed in #54.

The four `lftp mirror` invocations (per-branch `public_html/` + shared `web/`, each in SSH-key and password-auth variants) now all carry `${LFTP_DRYRUN_FLAG}`. The flag is computed once at the job-level `env:` from `github.event.inputs.dry_run`.

## What's NOT in this PR (deliberately)

The #107 checklist lists a few server-side items that need operator action, not code:

- **Pre-merge audit of `<base>/_libraries/`** — needs SSH access, can't be done from a PR. Suggest doing this before next deploy, separately.
- **Server-side weekly snapshot cron** — needs cron config on the host.
- **Atomic-deploy directory swaps** — long-term refactor; only worth it if deploy cadence rises.

Those remain on #107 if you decide to act on them.

## Files changed

```text
.github/workflows/deploy.yml  — dry_run input + LFTP_DRYRUN_FLAG threading
DEV_NOTES.md                  — Troubleshooting entry + debug note refresh
CHANGELOG.md                  — [Unreleased] entry under Changed
```

## Test plan

- [ ] On GitHub Actions → Deploy → "Run workflow" → set `dry_run = true` and run from `main`. Confirm the logs show "🧪 DRY RUN" and the mirror output includes `would upload` / `would remove` lines but the server is unchanged.
- [ ] Re-run with `dry_run = false` (or via push) and confirm normal deploy behaviour.
- [ ] DEV_NOTES.md renders cleanly on GitHub (no broken anchors).

🤖 Generated with [Claude Code](https://claude.com/claude-code)