### PR TITLE
feat(calendar): seven view modes — day / week / weekdays / weekend / month / year / list (#136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Added — Calendar multi-view modes (#136)
+
+The calendar app was previously list-view only. It now supports **seven**
+view modes that the spec originally called for:
+
+- **Day** — single day, vertical hour timeline.
+- **Week** — full 7-day grid (Mon → Sun), hour timeline.
+- **Weekdays** — 5-column grid (Mon → Fri).
+- **Weekend** — 2-column grid (Sat → Sun).
+- **Month** — 7×5/6 calendar grid; up to 3 event pills per day, "+ N more"
+  link to the day view for busier days.
+- **Year** — 12-column wall-planner grid (months across, days down).
+  Cells show day-of-week initial + up to 3 colour-coded category dots.
+- **List** — the original card-grid layout, refactored into the new shell.
+
+Implementation:
+
+- `web/public_html/calendar/index.php` is now a thin view router that
+  validates `?view=`, resolves the visible date range, fetches events in
+  one query, and delegates rendering to a per-view partial under
+  `web/public_html/calendar/views/`.
+- Day / Week / Weekdays / Weekend share a single hour-timeline renderer
+  (`views/_day_columns.php`) parametrised by column count.
+- Shared header (`views/_shared_header.php`) provides date navigation,
+  view-switcher buttons, filters (category / type / show-past).
+- Last-used view persists in `localStorage` (`portal-calendar-view`); a
+  new admin setting `calendar.defaultView` controls the first-visit
+  landing view (default: `month`).
+- Events colour-code by `tblEventCategories.color` via an `--ev-color`
+  CSS custom property; falls back to `--portal-primary`.
+- Mobile-responsive: hour timelines scroll horizontally; month cells
+  shrink; pill names hide below 640px.
+- Migration `web/sql/042_calendar_default_view.sql` seeds
+  `calendar.defaultView`.
+
 ### Fixed — Anchor colour falling back to browser default in dark mode
 
 - `portal.css` now binds `--portal-link` (and its hover / RGB variants) to

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -1880,94 +1880,194 @@ a:focus > .app-card {
     text-decoration: underline;
 }
 
-/* ---------- Year planner ---------- */
+/* ---------- Year planner (wall-planner layout) ----------
+   Modelled on traditional printed wall planners. 12 month columns across
+   the top, each split into a "day-number" sub-column and a "content"
+   sub-column. 31 day rows down; blank cells fill where months are shorter.
+   Weekend tints (Sat/Sun) come from --portal-cal-sat / --portal-cal-sun.
+   Event-band colours come from --ev-color set inline per cell. */
 
-.portal-cal-year {
-    background: var(--portal-surface);
-    border: 1px solid var(--portal-border);
-    border-radius: var(--portal-radius-md);
-    overflow-x: auto;
-    padding: var(--portal-spacing-md);
+:root {
+    /* Weekend tints — kept on theme tokens so they auto-adjust for dark mode */
+    --portal-cal-sat: #fff8e1;   /* cream */
+    --portal-cal-sun: #fde2e4;   /* peach */
 }
-.portal-cal-year-grid {
-    display: grid;
-    grid-template-columns: 32px repeat(12, minmax(56px, 1fr));
-    gap: 1px;
-    background: var(--portal-border);
-    min-width: 880px;
+[data-bs-theme="dark"] {
+    --portal-cal-sat: #2c2818;
+    --portal-cal-sun: #2c1f23;
 }
-.portal-cal-year-cornercell,
-.portal-cal-year-daynum,
-.portal-cal-year-monthhead,
-.portal-cal-year-cell {
-    background: var(--portal-surface);
-    padding: 0.2rem;
-    font-size: var(--portal-font-size-xs);
-    line-height: 1.1;
+
+.portal-cal-yearplan {
+    /* Container — legend + scroll wrapper live here */
 }
-.portal-cal-year-monthhead {
-    text-align: center;
-    font-weight: 600;
-    text-transform: uppercase;
-    padding: 0.35rem 0.2rem;
-    background: var(--portal-surface-elevated);
-}
-.portal-cal-year-monthhead a {
-    color: var(--portal-text);
-    text-decoration: none;
-}
-.portal-cal-year-monthhead a:hover {
-    color: var(--portal-primary);
-}
-.portal-cal-year-daynum {
-    text-align: right;
-    font-weight: 600;
-    color: var(--portal-text-muted);
-    background: var(--portal-surface-elevated);
-}
-.portal-cal-year-cell {
+.portal-cal-yearplan-legend {
     display: flex;
+    flex-wrap: wrap;
+    gap: 0.5rem 0.75rem;
     align-items: center;
-    justify-content: space-between;
-    text-decoration: none;
-    color: var(--portal-text);
-    min-height: 22px;
-    transition: background var(--portal-transition-fast);
+    padding: 0.5rem 0.75rem;
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-sm);
+    background: var(--portal-surface);
 }
-.portal-cal-year-cell:hover {
-    background: var(--portal-surface-hover);
-}
-.portal-cal-year-cell.is-weekend {
-    background: var(--portal-surface-hover);
-}
-.portal-cal-year-cell.is-today {
-    outline: 2px solid var(--portal-primary);
-    outline-offset: -2px;
-    background: var(--portal-primary-subtle);
-}
-.portal-cal-year-cell.is-blank {
-    background: transparent;
-    pointer-events: none;
-}
-.portal-cal-year-cell-dow {
-    color: var(--portal-text-subtle);
-    font-size: 0.65rem;
-}
-.portal-cal-year-dots {
+.portal-cal-yearplan-legend-item {
     display: inline-flex;
     align-items: center;
-    gap: 2px;
+    gap: 0.35rem;
+    font-size: var(--portal-font-size-sm);
 }
-.portal-cal-year-dot {
+.portal-cal-yearplan-legend-swatch {
     display: inline-block;
-    width: 6px;
-    height: 6px;
-    border-radius: 50%;
+    width: 14px;
+    height: 14px;
+    border-radius: 3px;
+    border: 1px solid var(--portal-border);
 }
-.portal-cal-year-dot-more {
-    font-size: 0.6rem;
+
+.portal-cal-yearplan-scroll {
+    overflow-x: auto;
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-md);
+    background: var(--portal-surface);
+}
+.portal-cal-yearplan-grid {
+    display: grid;
+    grid-template-columns: repeat(24, minmax(0, 1fr));
+    /* 24 cols = 12 months × (day-num + content). Min-width keeps cells legible
+       on small screens; container scrolls horizontally beyond that. */
+    min-width: 1800px;
+    gap: 0;
+    background: var(--portal-border);
+}
+
+/* Header row: month name spans 2 cols (one for day-num, one for content) */
+.portal-cal-yearplan-monthhead {
+    grid-column: span 2;
+    background: var(--portal-surface-elevated);
+    padding: 0.4rem 0.5rem;
+    font-weight: 700;
+    text-align: center;
+    color: var(--portal-text);
+    text-decoration: none;
+    border-right: 1px solid var(--portal-border);
+}
+.portal-cal-yearplan-monthhead:hover {
+    color: var(--portal-primary);
+    background: var(--portal-primary-subtle);
+}
+
+/* Day-number sub-cell */
+.portal-cal-yearplan-num {
+    background: var(--portal-surface-elevated);
+    padding: 0.15rem 0.35rem;
+    border-right: 1px solid var(--portal-border);
+    border-top: 1px solid var(--portal-border);
+    color: var(--portal-text);
+    text-decoration: none;
+    font-size: var(--portal-font-size-xs);
+    line-height: 1.15;
+    display: flex;
+    flex-direction: row;
+    align-items: center;
+    gap: 0.35rem;
+    min-height: 24px;
+    white-space: nowrap;
+}
+.portal-cal-yearplan-num:hover {
+    background: var(--portal-surface-hover);
+}
+.portal-cal-yearplan-num-day {
+    font-weight: 700;
+    min-width: 1.5em;
+}
+.portal-cal-yearplan-num-dow {
     color: var(--portal-text-muted);
-    margin-left: 2px;
+    text-transform: capitalize;
+}
+
+/* Content sub-cell */
+.portal-cal-yearplan-content {
+    background: var(--portal-surface);
+    padding: 0.15rem 0.35rem;
+    border-right: 1px solid var(--portal-border);
+    border-top: 1px solid var(--portal-border);
+    font-size: var(--portal-font-size-xs);
+    line-height: 1.15;
+    min-height: 24px;
+    overflow: hidden;
+    /* The --ev-color inline custom property drives a left accent border
+       when the cell is part of an event band. */
+}
+.portal-cal-yearplan-content.has-event {
+    border-left: 3px solid var(--ev-color, var(--portal-primary));
+    padding-left: calc(0.35rem - 3px);
+}
+
+/* Weekend tints — only when the cell has no event background */
+.portal-cal-yearplan-num.is-saturday,
+.portal-cal-yearplan-content.is-saturday:not(.has-event) {
+    background: var(--portal-cal-sat);
+}
+.portal-cal-yearplan-num.is-sunday,
+.portal-cal-yearplan-content.is-sunday:not(.has-event) {
+    background: var(--portal-cal-sun);
+}
+
+/* Today highlight — a thick outline so it survives over event backgrounds */
+.portal-cal-yearplan-num.is-today,
+.portal-cal-yearplan-content.is-today {
+    outline: 2px solid var(--portal-primary);
+    outline-offset: -2px;
+    position: relative;
+    z-index: 1;
+}
+
+/* Blank cells (e.g. Feb 30, 31) — hide bg / borders, no interaction */
+.portal-cal-yearplan-num.is-blank,
+.portal-cal-yearplan-content.is-blank {
+    background: var(--portal-surface-hover);
+    pointer-events: none;
+    opacity: 0.35;
+}
+
+/* Event list inside a content cell */
+.portal-cal-yearplan-events {
+    list-style: none;
+    margin: 0;
+    padding: 0;
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+}
+.portal-cal-yearplan-events li {
+    overflow: hidden;
+}
+.portal-cal-yearplan-events a {
+    color: var(--portal-text);
+    text-decoration: none;
+    font-size: var(--portal-font-size-xs);
+    line-height: 1.2;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.portal-cal-yearplan-events a:hover {
+    text-decoration: underline;
+    color: var(--ev-color, var(--portal-primary));
+}
+
+/* Compact when the grid is squeezed horizontally — content text wraps less */
+@media (max-width: 1100px) {
+    .portal-cal-yearplan-grid {
+        font-size: 11px;
+    }
+    .portal-cal-yearplan-events a {
+        -webkit-line-clamp: 1;
+        line-clamp: 1;
+    }
 }
 
 /* ---------- Mobile: collapse grid views to a friendlier layout ---------- */

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -1620,3 +1620,372 @@ a:focus > .app-card {
     border-top-left-radius: var(--portal-radius-lg);
     border-top-right-radius: var(--portal-radius-lg);
 }
+
+/* ============================================================================
+   Calendar — multi-view grids (issue #136)
+
+   Shared between:
+     • day, week, weekdays, weekend  → .portal-cal-grid (hour timeline)
+     • month                         → .portal-cal-month (date grid)
+     • year                          → .portal-cal-year (wall planner)
+
+   Each event gets a --ev-color inline custom property pulled from
+   tblEventCategories.color; falls back to --portal-primary if absent.
+   ============================================================================ */
+
+.portal-calendar-controls {
+    background: var(--portal-surface);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-md);
+    padding: var(--portal-spacing-md);
+}
+
+/* ---------- Hour-timeline grid (day / week / weekdays / weekend) ---------- */
+
+.portal-cal-grid {
+    background: var(--portal-surface);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-md);
+    overflow: hidden;
+}
+
+.portal-cal-headrow {
+    display: grid;
+    grid-template-columns: 56px repeat(var(--cal-cols, 7), minmax(0, 1fr));
+    border-bottom: 1px solid var(--portal-border);
+    background: var(--portal-surface-elevated);
+}
+
+.portal-cal-gutter {
+    border-right: 1px solid var(--portal-border);
+}
+
+.portal-cal-dayhead {
+    padding: 0.5rem 0.75rem;
+    text-align: center;
+    border-right: 1px solid var(--portal-border);
+}
+.portal-cal-dayhead:last-child { border-right: none; }
+.portal-cal-dayhead.is-today {
+    background: var(--portal-primary-subtle);
+    color: var(--portal-primary);
+    font-weight: 600;
+}
+
+.portal-cal-allday {
+    display: grid;
+    grid-template-columns: 56px repeat(var(--cal-cols, 7), minmax(0, 1fr));
+    border-bottom: 1px solid var(--portal-border);
+    background: var(--portal-surface);
+}
+.portal-cal-allday .portal-cal-gutter {
+    padding: 0.5rem;
+    display: flex;
+    align-items: center;
+    justify-content: flex-end;
+}
+.portal-cal-allday-cell {
+    padding: 0.25rem;
+    border-right: 1px solid var(--portal-border);
+    min-height: 2.25rem;
+    display: flex;
+    flex-direction: column;
+    gap: 0.25rem;
+}
+.portal-cal-allday-cell:last-child { border-right: none; }
+
+.portal-cal-timeline {
+    display: grid;
+    grid-template-columns: 56px repeat(var(--cal-cols, 7), minmax(0, 1fr));
+    position: relative;
+    /* Cap at ~70vh so a 24-hour grid stays usable on small screens */
+    max-height: 70vh;
+    overflow-y: auto;
+}
+
+.portal-cal-hours {
+    display: flex;
+    flex-direction: column;
+}
+.portal-cal-hour {
+    height: var(--portal-cal-px-per-hour, 48px);
+    padding: 0 0.25rem;
+    border-bottom: 1px solid var(--portal-border);
+    display: flex;
+    align-items: flex-start;
+    justify-content: flex-end;
+}
+.portal-cal-col {
+    position: relative;
+    border-right: 1px solid var(--portal-border);
+}
+.portal-cal-col:last-child { border-right: none; }
+.portal-cal-hourline {
+    height: var(--portal-cal-px-per-hour, 48px);
+    border-bottom: 1px solid var(--portal-border);
+}
+
+/* Events (pill blocks) — coloured by --ev-color from category */
+.portal-cal-event {
+    --ev-color: var(--portal-primary);
+    display: block;
+    text-decoration: none;
+    border-radius: var(--portal-radius-sm);
+    padding: 0.25rem 0.4rem;
+    color: var(--portal-text);
+    background: color-mix(in srgb, var(--ev-color) 18%, var(--portal-surface));
+    border-left: 3px solid var(--ev-color);
+    overflow: hidden;
+    transition: filter var(--portal-transition-fast),
+                box-shadow var(--portal-transition-fast);
+}
+.portal-cal-event:hover {
+    filter: brightness(1.05);
+    box-shadow: var(--portal-shadow-xs);
+}
+.portal-cal-event.is-featured {
+    box-shadow: 0 0 0 2px var(--portal-warning);
+}
+.portal-cal-event-timed {
+    position: absolute;
+    left: 4px;
+    right: 4px;
+    z-index: 1;
+    font-size: var(--portal-font-size-sm);
+    line-height: 1.2;
+}
+.portal-cal-event-time {
+    font-weight: 600;
+    color: var(--ev-color);
+    margin-bottom: 0.125rem;
+}
+.portal-cal-event-title {
+    font-weight: 500;
+}
+.portal-cal-event-loc {
+    color: var(--portal-text-muted);
+    overflow: hidden;
+    text-overflow: ellipsis;
+    white-space: nowrap;
+}
+.portal-cal-event-allday {
+    font-size: var(--portal-font-size-sm);
+    line-height: 1.2;
+    white-space: nowrap;
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+
+/* Fallback: when color-mix is unsupported, use a tinted background via opacity */
+@supports not (background: color-mix(in srgb, red, blue)) {
+    .portal-cal-event {
+        background: var(--ev-color);
+        opacity: 0.85;
+        color: #fff;
+    }
+}
+
+/* ---------- Month grid ---------- */
+
+.portal-cal-month {
+    background: var(--portal-surface);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-md);
+    overflow: hidden;
+}
+.portal-cal-month-head {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+    background: var(--portal-surface-elevated);
+    border-bottom: 1px solid var(--portal-border);
+}
+.portal-cal-month-headcell {
+    padding: 0.5rem 0.75rem;
+    text-align: center;
+    font-weight: 600;
+    color: var(--portal-text-muted);
+    text-transform: uppercase;
+    font-size: var(--portal-font-size-xs);
+    border-right: 1px solid var(--portal-border);
+}
+.portal-cal-month-headcell:last-child { border-right: none; }
+
+.portal-cal-month-grid {
+    display: grid;
+    grid-template-columns: repeat(7, minmax(0, 1fr));
+}
+.portal-cal-month-cell {
+    min-height: 96px;
+    padding: 0.375rem;
+    border-right: 1px solid var(--portal-border);
+    border-bottom: 1px solid var(--portal-border);
+    display: flex;
+    flex-direction: column;
+    gap: 0.2rem;
+    background: var(--portal-surface);
+}
+.portal-cal-month-cell:nth-child(7n) { border-right: none; }
+.portal-cal-month-cell.is-outside {
+    background: var(--portal-surface-hover);
+    color: var(--portal-text-subtle);
+}
+.portal-cal-month-cell.is-today {
+    background: var(--portal-primary-subtle);
+}
+.portal-cal-month-cell-head {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    margin-bottom: 0.1rem;
+}
+.portal-cal-month-cell-date {
+    font-weight: 600;
+    text-decoration: none;
+    color: var(--portal-text);
+}
+.portal-cal-month-pill {
+    --ev-color: var(--portal-primary);
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    padding: 0.125rem 0.35rem;
+    border-radius: var(--portal-radius-sm);
+    text-decoration: none;
+    color: var(--portal-text);
+    background: color-mix(in srgb, var(--ev-color) 16%, var(--portal-surface));
+    border-left: 2px solid var(--ev-color);
+    font-size: var(--portal-font-size-xs);
+    line-height: 1.2;
+    overflow: hidden;
+    white-space: nowrap;
+    text-overflow: ellipsis;
+}
+.portal-cal-month-pill:hover {
+    filter: brightness(1.05);
+}
+.portal-cal-month-pill-time {
+    font-weight: 600;
+    color: var(--ev-color);
+}
+.portal-cal-month-pill-name {
+    overflow: hidden;
+    text-overflow: ellipsis;
+}
+.portal-cal-month-more {
+    color: var(--portal-primary);
+    text-decoration: none;
+    margin-top: 0.1rem;
+}
+.portal-cal-month-more:hover {
+    text-decoration: underline;
+}
+
+/* ---------- Year planner ---------- */
+
+.portal-cal-year {
+    background: var(--portal-surface);
+    border: 1px solid var(--portal-border);
+    border-radius: var(--portal-radius-md);
+    overflow-x: auto;
+    padding: var(--portal-spacing-md);
+}
+.portal-cal-year-grid {
+    display: grid;
+    grid-template-columns: 32px repeat(12, minmax(56px, 1fr));
+    gap: 1px;
+    background: var(--portal-border);
+    min-width: 880px;
+}
+.portal-cal-year-cornercell,
+.portal-cal-year-daynum,
+.portal-cal-year-monthhead,
+.portal-cal-year-cell {
+    background: var(--portal-surface);
+    padding: 0.2rem;
+    font-size: var(--portal-font-size-xs);
+    line-height: 1.1;
+}
+.portal-cal-year-monthhead {
+    text-align: center;
+    font-weight: 600;
+    text-transform: uppercase;
+    padding: 0.35rem 0.2rem;
+    background: var(--portal-surface-elevated);
+}
+.portal-cal-year-monthhead a {
+    color: var(--portal-text);
+    text-decoration: none;
+}
+.portal-cal-year-monthhead a:hover {
+    color: var(--portal-primary);
+}
+.portal-cal-year-daynum {
+    text-align: right;
+    font-weight: 600;
+    color: var(--portal-text-muted);
+    background: var(--portal-surface-elevated);
+}
+.portal-cal-year-cell {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    text-decoration: none;
+    color: var(--portal-text);
+    min-height: 22px;
+    transition: background var(--portal-transition-fast);
+}
+.portal-cal-year-cell:hover {
+    background: var(--portal-surface-hover);
+}
+.portal-cal-year-cell.is-weekend {
+    background: var(--portal-surface-hover);
+}
+.portal-cal-year-cell.is-today {
+    outline: 2px solid var(--portal-primary);
+    outline-offset: -2px;
+    background: var(--portal-primary-subtle);
+}
+.portal-cal-year-cell.is-blank {
+    background: transparent;
+    pointer-events: none;
+}
+.portal-cal-year-cell-dow {
+    color: var(--portal-text-subtle);
+    font-size: 0.65rem;
+}
+.portal-cal-year-dots {
+    display: inline-flex;
+    align-items: center;
+    gap: 2px;
+}
+.portal-cal-year-dot {
+    display: inline-block;
+    width: 6px;
+    height: 6px;
+    border-radius: 50%;
+}
+.portal-cal-year-dot-more {
+    font-size: 0.6rem;
+    color: var(--portal-text-muted);
+    margin-left: 2px;
+}
+
+/* ---------- Mobile: collapse grid views to a friendlier layout ---------- */
+
+@media (max-width: 640px) {
+    /* Hour-timeline grids stay scrollable horizontally so the week view
+       doesn't get squashed past readability. */
+    .portal-cal-timeline,
+    .portal-cal-headrow,
+    .portal-cal-allday {
+        overflow-x: auto;
+    }
+    /* Month cells shrink to fit but stay readable */
+    .portal-cal-month-cell {
+        min-height: 64px;
+        font-size: var(--portal-font-size-xs);
+    }
+    .portal-cal-month-pill-name {
+        display: none;
+    }
+}

--- a/web/public_html/calendar/index.php
+++ b/web/public_html/calendar/index.php
@@ -2,19 +2,44 @@
 // Path: public_html/calendar/index.php
 /**
  * -----------------------------------------------------------------------------
- * Calendar — Public Event Listing 📅
+ * Calendar — View Router 📅
  * -----------------------------------------------------------------------------
- * Public-facing calendar page showing upcoming and past events. Supports:
- *   - List view (default) with filters by category, type, and date range
- *   - Toggle to show past events
- *   - Pagination
- *   - Links to individual event pages and admin management (if admin)
+ * Routes between the seven calendar view modes (issue #136):
+ *
+ *   ?view=day        – single day, hour timeline
+ *   ?view=week       – 7-day grid (Mon-Sun)
+ *   ?view=weekdays   – 5-day grid (Mon-Fri)
+ *   ?view=weekend    – 2-day grid (Sat-Sun)
+ *   ?view=month      – calendar grid (5-6 rows)
+ *   ?view=year       – 12-month wall planner
+ *   ?view=list       – chronological card list (legacy default)
+ *
+ * Defaults:
+ *   - URL  ?view=…           ← takes top priority
+ *   - localStorage           ← remembered last view per device
+ *   - setting calendar.defaultView (admin-set, falls back to "month")
+ *
+ * Date cursor:
+ *   ?date=YYYY-MM-DD         (interpreted by view: day uses date,
+ *                            week uses containing week, month uses
+ *                            year-month, year uses year part)
+ *
+ * Filters (applied to every view):
+ *   ?category=N              category ID
+ *   ?type=N                  type ID
+ *   ?past=1                  list-view-only: also show past events
+ *
+ * Each view partial under views/ receives the resolved $events array
+ * plus the shared filter / range variables and emits the inner panel
+ * markup only (the shared header and template chrome are emitted by
+ * this router).
  *
  * @package   Portal\Calendar
  * @author    MWBM Partners Ltd (t/a MWservices)
  * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
  * @license   All Rights Reserved
- * @version   0.3.0
+ * @version   0.11.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/136
  * -----------------------------------------------------------------------------
  */
 
@@ -33,26 +58,128 @@ $breadcrumbs = ['Dashboard' => '/', 'Calendar' => ''];
 Auth::ensureSession();
 
 // -----------------------------------------------------------------------------
-// 🔍 Filter parameters
+// 🔀 Resolve active view
 // -----------------------------------------------------------------------------
-$filterCategory = trim($_GET['category'] ?? '');
-$filterType     = trim($_GET['type'] ?? '');
-$showPast       = ($_GET['past'] ?? '') === '1';
-$page           = max(1, (int) ($_GET['page'] ?? 1));
-$perPage        = 20;
-$offset         = ($page - 1) * $perPage;
+$validViews = ['day', 'week', 'weekdays', 'weekend', 'month', 'year', 'list'];
 
-// 🌐 Multi-site scope
+$defaultView = (string) (App::settings('calendar.defaultView') ?? 'month');
+if (in_array($defaultView, $validViews, true) === false) {
+    $defaultView = 'month';
+}
+
+$view = (string) ($_GET['view'] ?? $defaultView);
+if (in_array($view, $validViews, true) === false) {
+    $view = $defaultView;
+}
+
+// -----------------------------------------------------------------------------
+// 📅 Resolve the date cursor — interpreted per view below
+// -----------------------------------------------------------------------------
+$rawDate = trim((string) ($_GET['date'] ?? ''));
+$cursor  = null;
+if ($rawDate !== '') {
+    // Accept YYYY-MM-DD, YYYY-MM, or YYYY — fall back to today if malformed
+    try {
+        if (preg_match('/^\d{4}$/', $rawDate) === 1) {
+            $cursor = new DateTimeImmutable($rawDate . '-01-01');
+        } elseif (preg_match('/^\d{4}-\d{2}$/', $rawDate) === 1) {
+            $cursor = new DateTimeImmutable($rawDate . '-01');
+        } else {
+            $cursor = new DateTimeImmutable($rawDate);
+        }
+    } catch (\Throwable) {
+        $cursor = null;
+    }
+}
+if ($cursor === null) {
+    $cursor = new DateTimeImmutable('today');
+}
+
+// -----------------------------------------------------------------------------
+// 🔍 Common filter parameters
+// -----------------------------------------------------------------------------
+$filterCategory = trim((string) ($_GET['category'] ?? ''));
+$filterType     = trim((string) ($_GET['type'] ?? ''));
+$showPast       = ($_GET['past'] ?? '') === '1';   // list-view only
+
 $siteId = Site::id();
 
-// 📊 Build WHERE clause
+// -----------------------------------------------------------------------------
+// 📊 Compute the date range visible in the chosen view.
+//
+// Returned as [DateTimeImmutable $rangeStart (00:00:00),
+//              DateTimeImmutable $rangeEnd  (last second of the range)].
+//
+// Used both for the SQL filter (grid views) and the title shown in the
+// shared header. List view ignores the range and uses pagination instead.
+// -----------------------------------------------------------------------------
+$rangeStart = $cursor;
+$rangeEnd   = $cursor;
+
+switch ($view) {
+    case 'day':
+        $rangeStart = $cursor->setTime(0, 0, 0);
+        $rangeEnd   = $cursor->setTime(23, 59, 59);
+        break;
+
+    case 'week':
+        // Week runs Monday → Sunday for civil/ISO convenience.
+        $dow        = (int) $cursor->format('N');           // 1..7, Mon..Sun
+        $rangeStart = $cursor->modify('-' . ($dow - 1) . ' days')->setTime(0, 0, 0);
+        $rangeEnd   = $rangeStart->modify('+6 days')->setTime(23, 59, 59);
+        break;
+
+    case 'weekdays':
+        $dow        = (int) $cursor->format('N');
+        $rangeStart = $cursor->modify('-' . ($dow - 1) . ' days')->setTime(0, 0, 0);
+        $rangeEnd   = $rangeStart->modify('+4 days')->setTime(23, 59, 59); // Mon..Fri
+        break;
+
+    case 'weekend':
+        // Anchor on the Saturday of the containing week. If the cursor is
+        // Mon-Fri we look forward to the upcoming Sat; if it's Sat/Sun we
+        // use the same weekend.
+        $dow = (int) $cursor->format('N');
+        if ($dow <= 5) {
+            $rangeStart = $cursor->modify('+' . (6 - $dow) . ' days')->setTime(0, 0, 0);
+        } else {
+            // Sat (6) → today; Sun (7) → yesterday (start of weekend)
+            $rangeStart = $cursor->modify('-' . ($dow - 6) . ' days')->setTime(0, 0, 0);
+        }
+        $rangeEnd = $rangeStart->modify('+1 day')->setTime(23, 59, 59);
+        break;
+
+    case 'month':
+        $rangeStart = $cursor->modify('first day of this month')->setTime(0, 0, 0);
+        $rangeEnd   = $cursor->modify('last day of this month')->setTime(23, 59, 59);
+        break;
+
+    case 'year':
+        $rangeStart = $cursor->setDate((int) $cursor->format('Y'), 1, 1)->setTime(0, 0, 0);
+        $rangeEnd   = $cursor->setDate((int) $cursor->format('Y'), 12, 31)->setTime(23, 59, 59);
+        break;
+
+    case 'list':
+    default:
+        $rangeStart = null;
+        $rangeEnd   = null;
+        break;
+}
+
+// -----------------------------------------------------------------------------
+// 🗄️ Fetch events. List view keeps its pagination; grid views pull the
+// full visible-range set in one query (no pagination — grids show the
+// whole window).
+// -----------------------------------------------------------------------------
+$events      = [];
+$totalRows   = 0;
+$totalPages  = 1;
+$page        = max(1, (int) ($_GET['page'] ?? 1));
+$perPage     = 20;
+
 $conditions = ["e.isDeleted = 0", "e.status = 'published'", "e.isPublic = 1", "e.siteID = ?"];
 $params     = [$siteId];
 $types      = 'i';
-
-if ($showPast === false) {
-    $conditions[] = 'e.startDateTime >= NOW()';
-}
 
 if ($filterCategory !== '') {
     $conditions[] = 'e.categoryID = ?';
@@ -65,13 +192,14 @@ if ($filterType !== '') {
     $types       .= 'i';
 }
 
-$where = 'WHERE ' . implode(' AND ', $conditions);
+if ($view === 'list') {
+    if ($showPast === false) {
+        $conditions[] = 'e.startDateTime >= NOW()';
+    }
+    $where = 'WHERE ' . implode(' AND ', $conditions);
 
-// 📋 Count total rows
-$countSql  = 'SELECT COUNT(*) AS cnt FROM tblEvents e ' . $where;
-$totalRows = 0;
-if (count($params) > 0) {
-    $stmt = $mysqli->prepare($countSql);
+    // 📋 Count
+    $stmt = $mysqli->prepare('SELECT COUNT(*) AS cnt FROM tblEvents e ' . $where);
     if ($stmt !== false) {
         $stmt->bind_param($types, ...$params);
         $stmt->execute();
@@ -79,48 +207,87 @@ if (count($params) > 0) {
         $totalRows = (int) ($row['cnt'] ?? 0);
         $stmt->close();
     }
+    $totalPages = max(1, (int) ceil($totalRows / $perPage));
+    $offset     = ($page - 1) * $perPage;
+
+    $orderDir = $showPast === true ? 'DESC' : 'ASC';
+    $sql = 'SELECT e.eventID, e.eventName, e.eventSlug, e.description, '
+         . 'e.startDateTime, e.endDateTime, e.timezone, e.isAllDay, '
+         . 'e.locationName, e.locationAddress, e.status, e.isFeatured, '
+         . 'e.heroImage, '
+         . 'c.categoryName, c.color AS categoryColor, t.typeName, s.seriesName '
+         . 'FROM tblEvents e '
+         . 'LEFT JOIN tblEventCategories c ON c.categoryID = e.categoryID '
+         . 'LEFT JOIN tblEventTypes t ON t.typeID = e.typeID '
+         . 'LEFT JOIN tblEventSeries s ON s.seriesID = e.seriesID '
+         . $where . ' '
+         . 'ORDER BY e.startDateTime ' . $orderDir . ' '
+         . 'LIMIT ? OFFSET ?';
+
+    $fetchTypes  = $types . 'ii';
+    $fetchParams = array_merge($params, [$perPage, $offset]);
+
+    $stmt = $mysqli->prepare($sql);
+    if ($stmt !== false) {
+        $stmt->bind_param($fetchTypes, ...$fetchParams);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($r = $result->fetch_assoc()) {
+            $events[] = $r;
+        }
+        $stmt->close();
+    }
 } else {
-    $result = $mysqli->query($countSql);
-    if ($result !== false) {
-        $row = $result->fetch_assoc();
-        $totalRows = (int) ($row['cnt'] ?? 0);
+    // Grid views: fetch every event overlapping the visible range.
+    // An event overlaps if it starts BEFORE the range ends AND
+    // (it has no end date OR it ends AFTER the range starts).
+    $startStr = $rangeStart->format('Y-m-d H:i:s');
+    $endStr   = $rangeEnd->format('Y-m-d H:i:s');
+
+    $conditions[] = 'e.startDateTime <= ?';
+    $params[]     = $endStr;
+    $types       .= 's';
+
+    $conditions[] = '(e.endDateTime IS NULL OR e.endDateTime >= ?)';
+    $params[]     = $startStr;
+    $types       .= 's';
+
+    $where = 'WHERE ' . implode(' AND ', $conditions);
+
+    $sql = 'SELECT e.eventID, e.eventName, e.eventSlug, e.description, '
+         . 'e.startDateTime, e.endDateTime, e.timezone, e.isAllDay, '
+         . 'e.locationName, e.locationAddress, e.status, e.isFeatured, '
+         . 'e.heroImage, '
+         . 'c.categoryName, c.color AS categoryColor, t.typeName, s.seriesName '
+         . 'FROM tblEvents e '
+         . 'LEFT JOIN tblEventCategories c ON c.categoryID = e.categoryID '
+         . 'LEFT JOIN tblEventTypes t ON t.typeID = e.typeID '
+         . 'LEFT JOIN tblEventSeries s ON s.seriesID = e.seriesID '
+         . $where . ' '
+         . 'ORDER BY e.startDateTime ASC';
+
+    $stmt = $mysqli->prepare($sql);
+    if ($stmt !== false) {
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($r = $result->fetch_assoc()) {
+            $events[] = $r;
+        }
+        $stmt->close();
     }
-}
-$totalPages = max(1, (int) ceil($totalRows / $perPage));
-
-// 📋 Fetch events
-$orderDir = $showPast === true ? 'DESC' : 'ASC';
-$sql = 'SELECT e.eventID, e.eventName, e.eventSlug, e.description, '
-     . 'e.startDateTime, e.endDateTime, e.timezone, e.isAllDay, '
-     . 'e.locationName, e.locationAddress, e.status, e.isFeatured, '
-     . 'e.heroImage, '
-     . 'c.categoryName, t.typeName, s.seriesName '
-     . 'FROM tblEvents e '
-     . 'LEFT JOIN tblEventCategories c ON c.categoryID = e.categoryID '
-     . 'LEFT JOIN tblEventTypes t ON t.typeID = e.typeID '
-     . 'LEFT JOIN tblEventSeries s ON s.seriesID = e.seriesID '
-     . $where . ' '
-     . 'ORDER BY e.startDateTime ' . $orderDir . ' '
-     . 'LIMIT ? OFFSET ?';
-
-$fetchTypes  = $types . 'ii';
-$fetchParams = array_merge($params, [$perPage, $offset]);
-
-$events = [];
-$stmt = $mysqli->prepare($sql);
-if ($stmt !== false) {
-    $stmt->bind_param($fetchTypes, ...$fetchParams);
-    $stmt->execute();
-    $result = $stmt->get_result();
-    while ($r = $result->fetch_assoc()) {
-        $events[] = $r;
-    }
-    $stmt->close();
+    $totalRows  = count($events);
+    $totalPages = 1;
 }
 
-// 📊 Fetch categories and types for filter dropdowns
+// -----------------------------------------------------------------------------
+// 🏷️ Categories + types — for filter dropdowns AND for colour-coding events
+// -----------------------------------------------------------------------------
 $categories = [];
-$stmtCat = $mysqli->prepare('SELECT categoryID, categoryName FROM tblEventCategories WHERE isActive = 1 AND siteID = ? ORDER BY sortOrder, categoryName');
+$stmtCat = $mysqli->prepare(
+    'SELECT categoryID, categoryName, color FROM tblEventCategories '
+    . 'WHERE isActive = 1 AND siteID = ? ORDER BY sortOrder, categoryName'
+);
 if ($stmtCat !== false) {
     $stmtCat->bind_param('i', $siteId);
     $stmtCat->execute();
@@ -132,7 +299,11 @@ if ($stmtCat !== false) {
 }
 
 $eventTypes = [];
-$stmtType = $mysqli->prepare('SELECT typeID, typeName FROM tblEventTypes WHERE isActive = 1 AND parentID IS NULL AND siteID = ? ORDER BY sortOrder, typeName');
+$stmtType = $mysqli->prepare(
+    'SELECT typeID, typeName FROM tblEventTypes '
+    . 'WHERE isActive = 1 AND parentID IS NULL AND siteID = ? '
+    . 'ORDER BY sortOrder, typeName'
+);
 if ($stmtType !== false) {
     $stmtType->bind_param('i', $siteId);
     $stmtType->execute();
@@ -147,8 +318,8 @@ if ($stmtType !== false) {
 require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
 ?>
 
-<!-- 📅 Calendar Listing -->
-<div class="d-flex justify-content-between align-items-center mb-4">
+<!-- 📅 Calendar shell -->
+<div class="d-flex justify-content-between align-items-center mb-3 flex-wrap gap-2">
     <h1 class="mb-0"><i class="fa-solid fa-calendar-days me-2"></i>Calendar</h1>
     <div class="d-flex gap-2">
         <?php if (App::isAdmin() === true): ?>
@@ -159,146 +330,18 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
     </div>
 </div>
 
-<!-- 🔍 Filters -->
-<form method="get" action="/calendar" class="row g-2 mb-4">
-    <div class="col-12 col-md-3">
-        <select name="category" class="form-select form-select-sm">
-            <option value="">All Categories</option>
-            <?php foreach ($categories as $cat): ?>
-                <option value="<?php echo (int) $cat['categoryID']; ?>"
-                    <?php echo ($filterCategory === (string) $cat['categoryID']) ? 'selected' : ''; ?>>
-                    <?php echo htmlspecialchars($cat['categoryName'], ENT_QUOTES, 'UTF-8'); ?>
-                </option>
-            <?php endforeach; ?>
-        </select>
-    </div>
-    <div class="col-12 col-md-3">
-        <select name="type" class="form-select form-select-sm">
-            <option value="">All Types</option>
-            <?php foreach ($eventTypes as $et): ?>
-                <option value="<?php echo (int) $et['typeID']; ?>"
-                    <?php echo ($filterType === (string) $et['typeID']) ? 'selected' : ''; ?>>
-                    <?php echo htmlspecialchars($et['typeName'], ENT_QUOTES, 'UTF-8'); ?>
-                </option>
-            <?php endforeach; ?>
-        </select>
-    </div>
-    <div class="col-12 col-md-3">
-        <div class="form-check form-switch mt-2">
-            <input class="form-check-input" type="checkbox" name="past" value="1" id="showPast"
-                   <?php echo $showPast === true ? 'checked' : ''; ?>>
-            <label class="form-check-label" for="showPast">Show past events</label>
-        </div>
-    </div>
-    <div class="col-12 col-md-3">
-        <button type="submit" class="btn btn-sm btn-outline-primary w-100">
-            <i class="fa-solid fa-filter me-1"></i> Filter
-        </button>
-    </div>
-</form>
+<?php require __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . '_shared_header.php'; ?>
 
-<!-- 📋 Events list -->
-<?php if (count($events) === 0): ?>
-    <div class="alert alert-info">
-        <i class="fa-solid fa-circle-info me-1"></i>
-        <?php echo $showPast === true ? 'No events found matching your filters.' : 'No upcoming events. Check back soon!'; ?>
-    </div>
-<?php else: ?>
-    <div class="row g-4">
-        <?php foreach ($events as $event): ?>
-            <?php
-            $startDt = new DateTime($event['startDateTime']);
-            $isToday = $startDt->format('Y-m-d') === date('Y-m-d');
-            $isPast  = $startDt < new DateTime();
-            ?>
-            <div class="col-12 col-md-6 col-lg-4">
-                <div class="card h-100 <?php echo $event['isFeatured'] === '1' ? 'border-warning' : ''; ?> <?php echo $isPast === true ? 'opacity-75' : ''; ?>">
-                    <?php if ($event['heroImage'] !== null && $event['heroImage'] !== ''): ?>
-                        <img src="/assets/uploads/calendar/<?php echo htmlspecialchars($event['heroImage'], ENT_QUOTES, 'UTF-8'); ?>"
-                             class="card-img-top" alt="" style="height:180px;object-fit:cover;">
-                    <?php endif; ?>
-                    <div class="card-body">
-                        <?php if ($event['isFeatured'] === '1'): ?>
-                            <span class="badge bg-warning text-dark mb-2"><i class="fa-solid fa-star me-1"></i>Featured</span>
-                        <?php endif; ?>
-
-                        <h5 class="card-title">
-                            <a href="/calendar/event?slug=<?php echo htmlspecialchars($event['eventSlug'], ENT_QUOTES, 'UTF-8'); ?>" class="text-decoration-none">
-                                <?php echo htmlspecialchars($event['eventName'], ENT_QUOTES, 'UTF-8'); ?>
-                            </a>
-                        </h5>
-
-                        <!-- 📅 Date/Time -->
-                        <p class="card-text mb-1">
-                            <i class="fa-regular fa-calendar me-1 text-primary"></i>
-                            <strong><?php echo htmlspecialchars(\Portal\Core\I18n::formatDate($startDt->format('Y-m-d H:i:s'), 'long'), ENT_QUOTES, 'UTF-8'); ?></strong>
-                            <?php if ($event['isAllDay'] !== '1' && (int) $event['isAllDay'] !== 1): ?>
-                                <span class="text-muted ms-1"><?php echo htmlspecialchars($startDt->format('g:i A'), ENT_QUOTES, 'UTF-8'); ?></span>
-                            <?php else: ?>
-                                <span class="badge bg-light text-dark ms-1">All Day</span>
-                            <?php endif; ?>
-                            <?php if ($isToday === true): ?>
-                                <span class="badge bg-success ms-1">Today</span>
-                            <?php endif; ?>
-                        </p>
-
-                        <!-- 📍 Location -->
-                        <?php if ($event['locationName'] !== null && $event['locationName'] !== ''): ?>
-                            <p class="card-text mb-1 small text-muted">
-                                <i class="fa-solid fa-location-dot me-1"></i>
-                                <?php echo htmlspecialchars($event['locationName'], ENT_QUOTES, 'UTF-8'); ?>
-                            </p>
-                        <?php endif; ?>
-
-                        <!-- 🏷️ Category / Type badges -->
-                        <div class="mt-2">
-                            <?php if ($event['categoryName'] !== null): ?>
-                                <span class="badge bg-primary me-1"><?php echo htmlspecialchars($event['categoryName'], ENT_QUOTES, 'UTF-8'); ?></span>
-                            <?php endif; ?>
-                            <?php if ($event['typeName'] !== null): ?>
-                                <span class="badge bg-secondary me-1"><?php echo htmlspecialchars($event['typeName'], ENT_QUOTES, 'UTF-8'); ?></span>
-                            <?php endif; ?>
-                            <?php if ($event['seriesName'] !== null): ?>
-                                <span class="badge bg-info me-1"><?php echo htmlspecialchars($event['seriesName'], ENT_QUOTES, 'UTF-8'); ?></span>
-                            <?php endif; ?>
-                        </div>
-                    </div>
-                </div>
-            </div>
-        <?php endforeach; ?>
-    </div>
-
-    <!-- 📖 Pagination -->
-    <?php if ($totalPages > 1): ?>
-        <nav aria-label="Calendar pagination" class="mt-4">
-            <ul class="pagination justify-content-center">
-                <?php
-                $baseUrl = '/calendar?' . http_build_query(array_filter([
-                    'category' => $filterCategory,
-                    'type'     => $filterType,
-                    'past'     => $showPast ? '1' : '',
-                ]));
-                $sep = '&';
-                ?>
-                <li class="page-item <?php echo ($page <= 1) ? 'disabled' : ''; ?>">
-                    <a class="page-link" href="<?php echo htmlspecialchars($baseUrl . $sep . 'page=' . ($page - 1), ENT_QUOTES, 'UTF-8'); ?>">&laquo;</a>
-                </li>
-                <?php for ($i = 1; $i <= $totalPages; $i++): ?>
-                    <?php if ($i <= 3 || $i >= $totalPages - 2 || abs($i - $page) <= 1): ?>
-                        <li class="page-item <?php echo ($i === $page) ? 'active' : ''; ?>">
-                            <a class="page-link" href="<?php echo htmlspecialchars($baseUrl . $sep . 'page=' . $i, ENT_QUOTES, 'UTF-8'); ?>"><?php echo $i; ?></a>
-                        </li>
-                    <?php elseif ($i === 4 || $i === $totalPages - 3): ?>
-                        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
-                    <?php endif; ?>
-                <?php endfor; ?>
-                <li class="page-item <?php echo ($page >= $totalPages) ? 'disabled' : ''; ?>">
-                    <a class="page-link" href="<?php echo htmlspecialchars($baseUrl . $sep . 'page=' . ($page + 1), ENT_QUOTES, 'UTF-8'); ?>">&raquo;</a>
-                </li>
-            </ul>
-        </nav>
-    <?php endif; ?>
-<?php endif; ?>
+<?php
+// 🚦 Dispatch to the active view's partial
+$partial = __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . $view . '.php';
+if (is_file($partial) === true) {
+    require $partial;
+} else {
+    // 🛟 Should never happen — $view is whitelisted above.
+    require __DIR__ . DIRECTORY_SEPARATOR . 'views' . DIRECTORY_SEPARATOR . 'list.php';
+}
+?>
 
 <?php
 // 📄 Include shared footer template

--- a/web/public_html/calendar/views/_day_columns.php
+++ b/web/public_html/calendar/views/_day_columns.php
@@ -1,0 +1,212 @@
+<?php
+// Path: public_html/calendar/views/_day_columns.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Hour-timeline grid renderer 🕒
+ * -----------------------------------------------------------------------------
+ * Shared by day / week / weekdays / weekend views. Renders a vertical hour
+ * timeline (00:00 → 24:00) with one column per day; events are positioned
+ * absolutely inside their column at the correct hour and span their duration.
+ *
+ * All-day events render in a separate strip above the timeline so they don't
+ * fight for space with timed events.
+ *
+ * Usage:
+ *   require __DIR__ . '/_day_columns.php';
+ *   echo render_day_columns($days, $events);
+ *
+ * where:
+ *   $days   list<DateTimeImmutable>  — midnights of the days to render
+ *   $events list<array>              — already-fetched event rows
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+if (function_exists('render_day_columns') === false) {
+
+    /**
+     * Render the hour-timeline grid.
+     *
+     * @param list<DateTimeImmutable> $days
+     * @param list<array<string,mixed>> $events
+     *
+     * @return string HTML
+     */
+    function render_day_columns(array $days, array $events): string
+    {
+        if (count($days) === 0) {
+            return '<div class="alert alert-info">No days to display.</div>';
+        }
+
+        // 🕔 Hour range. Show full 24 hours for completeness; CSS makes
+        // the grid scrollable so the user can focus on working hours.
+        $startHour = 0;
+        $endHour   = 24;
+        $hourSlots = $endHour - $startHour;
+        $pxPerHour = 48;  // matches the CSS .portal-cal-hour height
+
+        // 🗂️ Bucket events by which day-column they belong to.
+        // For multi-day events we split them across columns and clip
+        // the time range to each column's [00:00, 24:00] window.
+        $byDay = [];           // map: YYYY-MM-DD => list<eventRow>
+        $allDayByDay = [];     // map: YYYY-MM-DD => list<eventRow>
+        $dayKeys = [];
+        foreach ($days as $d) {
+            $k = $d->format('Y-m-d');
+            $byDay[$k] = [];
+            $allDayByDay[$k] = [];
+            $dayKeys[] = $k;
+        }
+
+        foreach ($events as $ev) {
+            $start = new DateTimeImmutable((string) $ev['startDateTime']);
+            $end   = isset($ev['endDateTime']) === true && $ev['endDateTime'] !== null
+                ? new DateTimeImmutable((string) $ev['endDateTime'])
+                : $start->modify('+1 hour');
+            $isAllDay = (int) ($ev['isAllDay'] ?? 0) === 1;
+
+            foreach ($days as $d) {
+                $dStart = $d->setTime(0, 0, 0);
+                $dEnd   = $d->setTime(23, 59, 59);
+                // overlap test
+                if ($start <= $dEnd && $end >= $dStart) {
+                    $k = $d->format('Y-m-d');
+                    if ($isAllDay === true) {
+                        $allDayByDay[$k][] = $ev;
+                    } else {
+                        $byDay[$k][] = $ev;
+                    }
+                }
+            }
+        }
+
+        // 🎨 Helpers
+        $esc = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+
+        $eventColor = static function (array $ev): string {
+            $c = (string) ($ev['categoryColor'] ?? '');
+            // 🛡️ Only allow safe hex / rgb tokens through to inline CSS.
+            if (preg_match('/^#[0-9a-fA-F]{3,8}$/', $c) === 1) {
+                return $c;
+            }
+            return 'var(--portal-primary)';
+        };
+
+        ob_start();
+        ?>
+        <div class="portal-cal-grid">
+
+            <!-- 📌 Header row: weekday + date per column -->
+            <div class="portal-cal-headrow" style="--cal-cols: <?php echo count($days); ?>;">
+                <div class="portal-cal-gutter" aria-hidden="true"></div>
+                <?php foreach ($days as $d): ?>
+                    <?php $isToday = $d->format('Y-m-d') === date('Y-m-d'); ?>
+                    <div class="portal-cal-dayhead <?php echo $isToday === true ? 'is-today' : ''; ?>">
+                        <div class="small text-muted text-uppercase"><?php echo $esc($d->format('D')); ?></div>
+                        <div class="h6 mb-0"><?php echo $esc($d->format('j M')); ?></div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+
+            <!-- 🌅 All-day events strip -->
+            <?php
+            $hasAllDay = false;
+            foreach ($allDayByDay as $list) {
+                if (count($list) > 0) {
+                    $hasAllDay = true;
+                    break;
+                }
+            }
+            ?>
+            <?php if ($hasAllDay === true): ?>
+                <div class="portal-cal-allday" style="--cal-cols: <?php echo count($days); ?>;">
+                    <div class="portal-cal-gutter small text-muted">all-day</div>
+                    <?php foreach ($dayKeys as $k): ?>
+                        <div class="portal-cal-allday-cell">
+                            <?php foreach ($allDayByDay[$k] as $ev): ?>
+                                <a class="portal-cal-event portal-cal-event-allday"
+                                   href="/calendar/event?slug=<?php echo $esc((string) $ev['eventSlug']); ?>"
+                                   style="--ev-color: <?php echo $esc($eventColor($ev)); ?>;"
+                                   title="<?php echo $esc((string) $ev['eventName']); ?>">
+                                    <?php echo $esc((string) $ev['eventName']); ?>
+                                </a>
+                            <?php endforeach; ?>
+                        </div>
+                    <?php endforeach; ?>
+                </div>
+            <?php endif; ?>
+
+            <!-- 🕐 Hour timeline -->
+            <div class="portal-cal-timeline" style="--cal-cols: <?php echo count($days); ?>; --cal-hours: <?php echo $hourSlots; ?>; --cal-px-per-hour: <?php echo $pxPerHour; ?>px;">
+
+                <!-- Hour gutter -->
+                <div class="portal-cal-gutter portal-cal-hours">
+                    <?php for ($h = $startHour; $h < $endHour; $h++): ?>
+                        <div class="portal-cal-hour">
+                            <span class="small text-muted"><?php echo sprintf('%02d:00', $h); ?></span>
+                        </div>
+                    <?php endfor; ?>
+                </div>
+
+                <!-- Day columns -->
+                <?php foreach ($dayKeys as $k): ?>
+                    <div class="portal-cal-col" data-date="<?php echo $esc($k); ?>">
+                        <!-- Hour grid lines -->
+                        <?php for ($h = $startHour; $h < $endHour; $h++): ?>
+                            <div class="portal-cal-hourline"></div>
+                        <?php endfor; ?>
+
+                        <!-- Events absolutely positioned -->
+                        <?php foreach ($byDay[$k] as $ev): ?>
+                            <?php
+                            $colDate = new DateTimeImmutable($k);
+                            $colStart = $colDate->setTime(0, 0, 0);
+                            $colEnd   = $colDate->setTime(23, 59, 59);
+                            $evStart  = new DateTimeImmutable((string) $ev['startDateTime']);
+                            $evEnd    = $ev['endDateTime'] !== null
+                                ? new DateTimeImmutable((string) $ev['endDateTime'])
+                                : $evStart->modify('+1 hour');
+
+                            // Clip to the visible column window
+                            $visStart = $evStart < $colStart ? $colStart : $evStart;
+                            $visEnd   = $evEnd   > $colEnd   ? $colEnd   : $evEnd;
+
+                            $startMins = ((int) $visStart->format('H')) * 60 + (int) $visStart->format('i');
+                            $endMins   = ((int) $visEnd->format('H'))   * 60 + (int) $visEnd->format('i');
+                            $duration  = max(15, $endMins - $startMins);  // never less than 15min visible
+
+                            // Convert to pixel offsets via the per-hour height
+                            $top    = ($startMins / 60) * $pxPerHour;
+                            $height = ($duration  / 60) * $pxPerHour;
+                            ?>
+                            <a class="portal-cal-event portal-cal-event-timed <?php echo (int) ($ev['isFeatured'] ?? 0) === 1 ? 'is-featured' : ''; ?>"
+                               href="/calendar/event?slug=<?php echo $esc((string) $ev['eventSlug']); ?>"
+                               style="top: <?php echo (int) round($top); ?>px; height: <?php echo (int) round($height); ?>px; --ev-color: <?php echo $esc($eventColor($ev)); ?>;"
+                               title="<?php echo $esc($evStart->format('H:i') . ' – ' . $evEnd->format('H:i') . ' · ' . (string) $ev['eventName']); ?>">
+                                <div class="portal-cal-event-time small">
+                                    <?php echo $esc($evStart->format('H:i')); ?>
+                                </div>
+                                <div class="portal-cal-event-title">
+                                    <?php echo $esc((string) $ev['eventName']); ?>
+                                </div>
+                                <?php if ($ev['locationName'] !== null && $ev['locationName'] !== ''): ?>
+                                    <div class="portal-cal-event-loc small">
+                                        <i class="fa-solid fa-location-dot me-1"></i>
+                                        <?php echo $esc((string) $ev['locationName']); ?>
+                                    </div>
+                                <?php endif; ?>
+                            </a>
+                        <?php endforeach; ?>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <?php
+        return (string) ob_get_clean();
+    }
+}

--- a/web/public_html/calendar/views/_shared_header.php
+++ b/web/public_html/calendar/views/_shared_header.php
@@ -1,0 +1,231 @@
+<?php
+// Path: public_html/calendar/views/_shared_header.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Shared View Header 🧭
+ * -----------------------------------------------------------------------------
+ * Renders the controls common to every view mode:
+ *   • View-switcher (Day / Week / Mon-Fri / Sat-Sun / Month / Year / List)
+ *   • Date navigation (◀ Today ▶ + date input) — hidden for List
+ *   • Range title (e.g. "May 2026", "Mon 19 — Sun 25 May 2026")
+ *   • Filters (category / type / show-past)
+ *
+ * Receives from index.php:
+ *   $view, $cursor, $rangeStart, $rangeEnd,
+ *   $filterCategory, $filterType, $showPast,
+ *   $categories, $eventTypes
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+// 🏷️ Build a human-readable range title per view
+$rangeTitle = '';
+switch ($view) {
+    case 'day':
+        $rangeTitle = $cursor->format('l, j F Y');
+        break;
+    case 'week':
+    case 'weekdays':
+    case 'weekend':
+        $rangeTitle = $rangeStart->format('j M') . ' &ndash; ' . $rangeEnd->format('j M Y');
+        break;
+    case 'month':
+        $rangeTitle = $cursor->format('F Y');
+        break;
+    case 'year':
+        $rangeTitle = $cursor->format('Y');
+        break;
+    case 'list':
+    default:
+        $rangeTitle = '';
+        break;
+}
+
+/**
+ * 🔧 Helper — build a URL preserving the current filter state and replacing
+ * the listed query-string parts.
+ */
+$urlFor = static function (array $overrides) use ($view, $cursor, $filterCategory, $filterType, $showPast): string {
+    $params = array_filter([
+        'view'     => $view,
+        'date'     => $cursor->format('Y-m-d'),
+        'category' => $filterCategory,
+        'type'     => $filterType,
+        'past'     => $showPast ? '1' : '',
+    ], static fn ($v) => $v !== '' && $v !== null);
+    foreach ($overrides as $k => $v) {
+        if ($v === null || $v === '') {
+            unset($params[$k]);
+        } else {
+            $params[$k] = $v;
+        }
+    }
+    return '/calendar?' . http_build_query($params);
+};
+
+// 📆 Compute prev/next cursors per view (used by the date-nav arrows)
+$prevCursor = $cursor;
+$nextCursor = $cursor;
+switch ($view) {
+    case 'day':
+        $prevCursor = $cursor->modify('-1 day');
+        $nextCursor = $cursor->modify('+1 day');
+        break;
+    case 'week':
+    case 'weekdays':
+    case 'weekend':
+        $prevCursor = $cursor->modify('-1 week');
+        $nextCursor = $cursor->modify('+1 week');
+        break;
+    case 'month':
+        $prevCursor = $cursor->modify('first day of last month');
+        $nextCursor = $cursor->modify('first day of next month');
+        break;
+    case 'year':
+        $prevCursor = $cursor->modify('-1 year');
+        $nextCursor = $cursor->modify('+1 year');
+        break;
+}
+
+// 🪪 View-switcher metadata — order matters for the rendered button row
+$viewMeta = [
+    'day'      => ['label' => 'Day',     'icon' => 'fa-calendar-day'],
+    'week'     => ['label' => 'Week',    'icon' => 'fa-calendar-week'],
+    'weekdays' => ['label' => 'Mon-Fri', 'icon' => 'fa-briefcase'],
+    'weekend'  => ['label' => 'Sat-Sun', 'icon' => 'fa-couch'],
+    'month'    => ['label' => 'Month',   'icon' => 'fa-calendar'],
+    'year'     => ['label' => 'Year',    'icon' => 'fa-calendar-days'],
+    'list'     => ['label' => 'List',    'icon' => 'fa-list'],
+];
+?>
+
+<!-- 🧭 Calendar view controls -->
+<div class="portal-calendar-controls mb-3">
+
+    <!-- Top row: range title + date navigation (hidden for list) -->
+    <?php if ($view !== 'list'): ?>
+        <div class="d-flex flex-wrap justify-content-between align-items-center gap-2 mb-2">
+            <div class="d-flex align-items-center gap-2 flex-wrap">
+                <a href="<?php echo htmlspecialchars($urlFor(['date' => $prevCursor->format('Y-m-d')]), ENT_QUOTES, 'UTF-8'); ?>"
+                   class="btn btn-sm btn-outline-secondary" title="Previous">
+                    <i class="fa-solid fa-chevron-left"></i>
+                </a>
+                <a href="<?php echo htmlspecialchars($urlFor(['date' => date('Y-m-d')]), ENT_QUOTES, 'UTF-8'); ?>"
+                   class="btn btn-sm btn-outline-secondary">Today</a>
+                <a href="<?php echo htmlspecialchars($urlFor(['date' => $nextCursor->format('Y-m-d')]), ENT_QUOTES, 'UTF-8'); ?>"
+                   class="btn btn-sm btn-outline-secondary" title="Next">
+                    <i class="fa-solid fa-chevron-right"></i>
+                </a>
+                <h2 class="h5 mb-0 ms-2"><?php echo $rangeTitle; /* contains a literal &ndash; — safe */ ?></h2>
+            </div>
+
+            <form method="get" action="/calendar" class="d-flex align-items-center gap-2">
+                <input type="hidden" name="view" value="<?php echo htmlspecialchars($view, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php if ($filterCategory !== ''): ?>
+                    <input type="hidden" name="category" value="<?php echo htmlspecialchars($filterCategory, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php endif; ?>
+                <?php if ($filterType !== ''): ?>
+                    <input type="hidden" name="type" value="<?php echo htmlspecialchars($filterType, ENT_QUOTES, 'UTF-8'); ?>">
+                <?php endif; ?>
+                <label for="cal-date-jump" class="form-label small mb-0">Jump to:</label>
+                <input id="cal-date-jump" type="date" name="date" class="form-control form-control-sm"
+                       value="<?php echo htmlspecialchars($cursor->format('Y-m-d'), ENT_QUOTES, 'UTF-8'); ?>"
+                       onchange="this.form.submit()">
+            </form>
+        </div>
+    <?php endif; ?>
+
+    <!-- View switcher row -->
+    <div class="d-flex flex-wrap gap-2 align-items-center mb-2">
+        <div class="btn-group btn-group-sm" role="group" aria-label="Calendar view">
+            <?php foreach ($viewMeta as $key => $meta): ?>
+                <a href="<?php echo htmlspecialchars($urlFor(['view' => $key]), ENT_QUOTES, 'UTF-8'); ?>"
+                   class="btn btn-outline-primary <?php echo $key === $view ? 'active' : ''; ?>"
+                   data-portal-calendar-view="<?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?>"
+                   title="<?php echo htmlspecialchars($meta['label'], ENT_QUOTES, 'UTF-8'); ?> view">
+                    <i class="fa-solid <?php echo htmlspecialchars($meta['icon'], ENT_QUOTES, 'UTF-8'); ?> me-1"></i>
+                    <span class="d-none d-sm-inline"><?php echo htmlspecialchars($meta['label'], ENT_QUOTES, 'UTF-8'); ?></span>
+                </a>
+            <?php endforeach; ?>
+        </div>
+    </div>
+
+    <!-- Filters row -->
+    <form method="get" action="/calendar" class="row g-2 align-items-end">
+        <input type="hidden" name="view" value="<?php echo htmlspecialchars($view, ENT_QUOTES, 'UTF-8'); ?>">
+        <?php if ($view !== 'list'): ?>
+            <input type="hidden" name="date" value="<?php echo htmlspecialchars($cursor->format('Y-m-d'), ENT_QUOTES, 'UTF-8'); ?>">
+        <?php endif; ?>
+        <div class="col-12 col-md-3">
+            <label for="cal-cat" class="form-label small mb-0">Category</label>
+            <select id="cal-cat" name="category" class="form-select form-select-sm">
+                <option value="">All Categories</option>
+                <?php foreach ($categories as $cat): ?>
+                    <option value="<?php echo (int) $cat['categoryID']; ?>"
+                        <?php echo ($filterCategory === (string) $cat['categoryID']) ? 'selected' : ''; ?>>
+                        <?php echo htmlspecialchars($cat['categoryName'], ENT_QUOTES, 'UTF-8'); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <div class="col-12 col-md-3">
+            <label for="cal-type" class="form-label small mb-0">Type</label>
+            <select id="cal-type" name="type" class="form-select form-select-sm">
+                <option value="">All Types</option>
+                <?php foreach ($eventTypes as $et): ?>
+                    <option value="<?php echo (int) $et['typeID']; ?>"
+                        <?php echo ($filterType === (string) $et['typeID']) ? 'selected' : ''; ?>>
+                        <?php echo htmlspecialchars($et['typeName'], ENT_QUOTES, 'UTF-8'); ?>
+                    </option>
+                <?php endforeach; ?>
+            </select>
+        </div>
+        <?php if ($view === 'list'): ?>
+            <div class="col-12 col-md-3">
+                <div class="form-check form-switch mt-2">
+                    <input class="form-check-input" type="checkbox" name="past" value="1" id="showPast"
+                           <?php echo $showPast === true ? 'checked' : ''; ?>>
+                    <label class="form-check-label" for="showPast">Show past events</label>
+                </div>
+            </div>
+        <?php endif; ?>
+        <div class="col-12 col-md-3">
+            <button type="submit" class="btn btn-sm btn-outline-primary w-100">
+                <i class="fa-solid fa-filter me-1"></i> Apply filters
+            </button>
+        </div>
+    </form>
+</div>
+
+<!-- 💾 Persist last-used view in localStorage (progressive enhancement) -->
+<script>
+(function () {
+    try {
+        // When user clicks a view-switcher button, remember the choice
+        document.querySelectorAll('[data-portal-calendar-view]').forEach(function (a) {
+            a.addEventListener('click', function () {
+                localStorage.setItem('portal-calendar-view', a.getAttribute('data-portal-calendar-view'));
+            });
+        });
+        // On the first paint of /calendar with no explicit ?view= we honour
+        // the remembered value via a soft redirect — this never triggers
+        // when ?view= is already set explicitly.
+        var url = new URL(window.location.href);
+        var hasView = url.searchParams.has('view');
+        if (hasView === false) {
+            var remembered = localStorage.getItem('portal-calendar-view');
+            if (remembered && remembered !== <?php echo json_encode($view); ?>) {
+                url.searchParams.set('view', remembered);
+                window.location.replace(url.toString());
+            }
+        }
+    } catch (e) {
+        // localStorage unavailable (private mode etc.) — silently no-op
+    }
+})();
+</script>

--- a/web/public_html/calendar/views/day.php
+++ b/web/public_html/calendar/views/day.php
@@ -1,0 +1,24 @@
+<?php
+// Path: public_html/calendar/views/day.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Day View Partial 🗓️
+ * -----------------------------------------------------------------------------
+ * Renders one day's events on a 24-hour vertical timeline. Each event is
+ * positioned by start time and visually spans its duration. All-day events
+ * appear in a dedicated strip above the timeline.
+ *
+ * Reuses the same data-shape produced by the day/week/weekdays/weekend
+ * router branch — receives $events and $rangeStart from the router scope.
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+$day = $rangeStart;  // already set to 00:00 of the chosen date
+require __DIR__ . DIRECTORY_SEPARATOR . '_day_columns.php';
+echo render_day_columns([$day], $events);

--- a/web/public_html/calendar/views/list.php
+++ b/web/public_html/calendar/views/list.php
@@ -1,0 +1,120 @@
+<?php
+// Path: public_html/calendar/views/list.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — List View Partial 📋
+ * -----------------------------------------------------------------------------
+ * Card-grid presentation of upcoming (or past) events with optional category /
+ * type filtering. Rendered as a partial under the new calendar view router
+ * (index.php) which provides:
+ *   $events, $totalRows, $totalPages, $page,
+ *   $filterCategory, $filterType, $showPast
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+?>
+<?php if (count($events) === 0): ?>
+    <div class="alert alert-info">
+        <i class="fa-solid fa-circle-info me-1"></i>
+        <?php echo $showPast === true ? 'No events found matching your filters.' : 'No upcoming events. Check back soon!'; ?>
+    </div>
+<?php else: ?>
+    <div class="row g-4">
+        <?php foreach ($events as $event): ?>
+            <?php
+            $startDt = new DateTime($event['startDateTime']);
+            $isToday = $startDt->format('Y-m-d') === date('Y-m-d');
+            $isPast  = $startDt < new DateTime();
+            ?>
+            <div class="col-12 col-md-6 col-lg-4">
+                <div class="card h-100 <?php echo $event['isFeatured'] === '1' ? 'border-warning' : ''; ?> <?php echo $isPast === true ? 'opacity-75' : ''; ?>">
+                    <?php if ($event['heroImage'] !== null && $event['heroImage'] !== ''): ?>
+                        <img src="/assets/uploads/calendar/<?php echo htmlspecialchars($event['heroImage'], ENT_QUOTES, 'UTF-8'); ?>"
+                             class="card-img-top" alt="" style="height:180px;object-fit:cover;">
+                    <?php endif; ?>
+                    <div class="card-body">
+                        <?php if ($event['isFeatured'] === '1'): ?>
+                            <span class="badge bg-warning text-dark mb-2"><i class="fa-solid fa-star me-1"></i>Featured</span>
+                        <?php endif; ?>
+
+                        <h5 class="card-title">
+                            <a href="/calendar/event?slug=<?php echo htmlspecialchars($event['eventSlug'], ENT_QUOTES, 'UTF-8'); ?>" class="text-decoration-none">
+                                <?php echo htmlspecialchars($event['eventName'], ENT_QUOTES, 'UTF-8'); ?>
+                            </a>
+                        </h5>
+
+                        <p class="card-text mb-1">
+                            <i class="fa-regular fa-calendar me-1 text-primary"></i>
+                            <strong><?php echo htmlspecialchars(\Portal\Core\I18n::formatDate($startDt->format('Y-m-d H:i:s'), 'long'), ENT_QUOTES, 'UTF-8'); ?></strong>
+                            <?php if ($event['isAllDay'] !== '1' && (int) $event['isAllDay'] !== 1): ?>
+                                <span class="text-muted ms-1"><?php echo htmlspecialchars($startDt->format('g:i A'), ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php else: ?>
+                                <span class="badge bg-light text-dark ms-1">All Day</span>
+                            <?php endif; ?>
+                            <?php if ($isToday === true): ?>
+                                <span class="badge bg-success ms-1">Today</span>
+                            <?php endif; ?>
+                        </p>
+
+                        <?php if ($event['locationName'] !== null && $event['locationName'] !== ''): ?>
+                            <p class="card-text mb-1 small text-muted">
+                                <i class="fa-solid fa-location-dot me-1"></i>
+                                <?php echo htmlspecialchars($event['locationName'], ENT_QUOTES, 'UTF-8'); ?>
+                            </p>
+                        <?php endif; ?>
+
+                        <div class="mt-2">
+                            <?php if ($event['categoryName'] !== null): ?>
+                                <span class="badge bg-primary me-1"><?php echo htmlspecialchars($event['categoryName'], ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php endif; ?>
+                            <?php if ($event['typeName'] !== null): ?>
+                                <span class="badge bg-secondary me-1"><?php echo htmlspecialchars($event['typeName'], ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php endif; ?>
+                            <?php if ($event['seriesName'] !== null): ?>
+                                <span class="badge bg-info me-1"><?php echo htmlspecialchars($event['seriesName'], ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+
+    <!-- 📖 Pagination -->
+    <?php if (($totalPages ?? 1) > 1): ?>
+        <nav aria-label="Calendar pagination" class="mt-4">
+            <ul class="pagination justify-content-center">
+                <?php
+                $baseUrl = '/calendar?' . http_build_query(array_filter([
+                    'view'     => 'list',
+                    'category' => $filterCategory,
+                    'type'     => $filterType,
+                    'past'     => $showPast ? '1' : '',
+                ]));
+                $sep = '&';
+                ?>
+                <li class="page-item <?php echo ($page <= 1) ? 'disabled' : ''; ?>">
+                    <a class="page-link" href="<?php echo htmlspecialchars($baseUrl . $sep . 'page=' . ($page - 1), ENT_QUOTES, 'UTF-8'); ?>">&laquo;</a>
+                </li>
+                <?php for ($i = 1; $i <= $totalPages; $i++): ?>
+                    <?php if ($i <= 3 || $i >= $totalPages - 2 || abs($i - $page) <= 1): ?>
+                        <li class="page-item <?php echo ($i === $page) ? 'active' : ''; ?>">
+                            <a class="page-link" href="<?php echo htmlspecialchars($baseUrl . $sep . 'page=' . $i, ENT_QUOTES, 'UTF-8'); ?>"><?php echo $i; ?></a>
+                        </li>
+                    <?php elseif ($i === 4 || $i === $totalPages - 3): ?>
+                        <li class="page-item disabled"><span class="page-link">&hellip;</span></li>
+                    <?php endif; ?>
+                <?php endfor; ?>
+                <li class="page-item <?php echo ($page >= $totalPages) ? 'disabled' : ''; ?>">
+                    <a class="page-link" href="<?php echo htmlspecialchars($baseUrl . $sep . 'page=' . ($page + 1), ENT_QUOTES, 'UTF-8'); ?>">&raquo;</a>
+                </li>
+            </ul>
+        </nav>
+    <?php endif; ?>
+<?php endif; ?>

--- a/web/public_html/calendar/views/month.php
+++ b/web/public_html/calendar/views/month.php
@@ -1,0 +1,141 @@
+<?php
+// Path: public_html/calendar/views/month.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Month View Partial 📅
+ * -----------------------------------------------------------------------------
+ * Standard 7-column calendar grid for the cursor's month. Each cell shows
+ * the date number, an optional "today" badge, and up to N event pills.
+ * Days outside the active month are dimmed but still rendered so the grid
+ * is always a clean 5 or 6 rows.
+ *
+ * Receives from the router:
+ *   $events, $cursor, $rangeStart, $rangeEnd
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+$esc = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+
+// 🗂️ Index events by their start date so we can place them in cells
+$byDate = [];
+foreach ($events as $ev) {
+    $start = new DateTimeImmutable((string) $ev['startDateTime']);
+    $end   = $ev['endDateTime'] !== null
+        ? new DateTimeImmutable((string) $ev['endDateTime'])
+        : $start;
+
+    // Multi-day events appear on every day they overlap with the visible month
+    $current = $start;
+    while ($current <= $end) {
+        $k = $current->format('Y-m-d');
+        if (isset($byDate[$k]) === false) {
+            $byDate[$k] = [];
+        }
+        $byDate[$k][] = $ev;
+        $current = $current->modify('+1 day');
+        // Safety: don't loop past the month's visible range
+        if ($current->format('Y-m') > $cursor->format('Y-m')
+            && $current->format('Y-m') !== $cursor->modify('+1 month')->format('Y-m')
+        ) {
+            break;
+        }
+    }
+}
+
+// 🗓️ Compute grid bounds: pad to the previous Monday and the following Sunday
+$firstOfMonth = $cursor->modify('first day of this month')->setTime(0, 0, 0);
+$lastOfMonth  = $cursor->modify('last day of this month')->setTime(0, 0, 0);
+
+$leadDays = ((int) $firstOfMonth->format('N')) - 1;   // Mon=0..Sun=6
+$gridStart = $firstOfMonth->modify('-' . $leadDays . ' days');
+
+$trailDays = 7 - ((int) $lastOfMonth->format('N'));
+$gridEnd   = $lastOfMonth->modify('+' . $trailDays . ' days');
+
+$totalCells = (int) (($gridEnd->getTimestamp() - $gridStart->getTimestamp()) / 86400) + 1;
+
+$weekdayHeader = ['Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat', 'Sun'];
+
+$eventColor = static function (array $ev): string {
+    $c = (string) ($ev['categoryColor'] ?? '');
+    if (preg_match('/^#[0-9a-fA-F]{3,8}$/', $c) === 1) {
+        return $c;
+    }
+    return 'var(--portal-primary)';
+};
+
+$today = (new DateTimeImmutable('today'))->format('Y-m-d');
+?>
+
+<div class="portal-cal-month">
+    <div class="portal-cal-month-head">
+        <?php foreach ($weekdayHeader as $w): ?>
+            <div class="portal-cal-month-headcell"><?php echo $esc($w); ?></div>
+        <?php endforeach; ?>
+    </div>
+
+    <div class="portal-cal-month-grid">
+        <?php
+        $d = $gridStart;
+        for ($i = 0; $i < $totalCells; $i++) {
+            $k = $d->format('Y-m-d');
+            $inMonth   = $d->format('Y-m') === $cursor->format('Y-m');
+            $isToday   = $k === $today;
+            $dayEvents = $byDate[$k] ?? [];
+            $classes   = ['portal-cal-month-cell'];
+            if ($inMonth === false) { $classes[] = 'is-outside'; }
+            if ($isToday === true)  { $classes[] = 'is-today'; }
+        ?>
+            <div class="<?php echo implode(' ', $classes); ?>">
+                <div class="portal-cal-month-cell-head">
+                    <a class="portal-cal-month-cell-date"
+                       href="/calendar?view=day&amp;date=<?php echo $esc($k); ?>"
+                       title="View this day">
+                        <?php echo $esc($d->format('j')); ?>
+                    </a>
+                    <?php if ($isToday === true): ?>
+                        <span class="badge bg-primary ms-1">Today</span>
+                    <?php endif; ?>
+                </div>
+
+                <?php
+                // Show up to 3 events, then a "+ N more" link to the day view.
+                $maxEvents = 3;
+                $count = count($dayEvents);
+                $shown = array_slice($dayEvents, 0, $maxEvents);
+                foreach ($shown as $ev):
+                    $evStart = new DateTimeImmutable((string) $ev['startDateTime']);
+                    $isAllDay = (int) ($ev['isAllDay'] ?? 0) === 1;
+                    ?>
+                    <a class="portal-cal-month-pill"
+                       href="/calendar/event?slug=<?php echo $esc((string) $ev['eventSlug']); ?>"
+                       style="--ev-color: <?php echo $esc($eventColor($ev)); ?>;"
+                       title="<?php echo $esc((string) $ev['eventName']); ?>">
+                        <?php if ($isAllDay === false): ?>
+                            <span class="portal-cal-month-pill-time"><?php echo $esc($evStart->format('H:i')); ?></span>
+                        <?php endif; ?>
+                        <span class="portal-cal-month-pill-name">
+                            <?php echo $esc((string) $ev['eventName']); ?>
+                        </span>
+                    </a>
+                <?php endforeach; ?>
+
+                <?php if ($count > $maxEvents): ?>
+                    <a class="portal-cal-month-more small"
+                       href="/calendar?view=day&amp;date=<?php echo $esc($k); ?>">
+                        + <?php echo (int) ($count - $maxEvents); ?> more
+                    </a>
+                <?php endif; ?>
+            </div>
+        <?php
+            $d = $d->modify('+1 day');
+        }
+        ?>
+    </div>
+</div>

--- a/web/public_html/calendar/views/week.php
+++ b/web/public_html/calendar/views/week.php
@@ -1,0 +1,24 @@
+<?php
+// Path: public_html/calendar/views/week.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Week View Partial 📆
+ * -----------------------------------------------------------------------------
+ * Full 7-day grid (Monday → Sunday). Reuses _day_columns.php.
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . DIRECTORY_SEPARATOR . '_day_columns.php';
+
+$days = [];
+for ($i = 0; $i < 7; $i++) {
+    $days[] = $rangeStart->modify('+' . $i . ' days');
+}
+
+echo render_day_columns($days, $events);

--- a/web/public_html/calendar/views/weekdays.php
+++ b/web/public_html/calendar/views/weekdays.php
@@ -1,0 +1,24 @@
+<?php
+// Path: public_html/calendar/views/weekdays.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Weekdays View Partial 💼
+ * -----------------------------------------------------------------------------
+ * Monday → Friday only. Reuses _day_columns.php with 5 columns.
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . DIRECTORY_SEPARATOR . '_day_columns.php';
+
+$days = [];
+for ($i = 0; $i < 5; $i++) {
+    $days[] = $rangeStart->modify('+' . $i . ' days');
+}
+
+echo render_day_columns($days, $events);

--- a/web/public_html/calendar/views/weekend.php
+++ b/web/public_html/calendar/views/weekend.php
@@ -1,0 +1,24 @@
+<?php
+// Path: public_html/calendar/views/weekend.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Weekend View Partial 🛋️
+ * -----------------------------------------------------------------------------
+ * Saturday + Sunday only. Reuses _day_columns.php with 2 columns.
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+require __DIR__ . DIRECTORY_SEPARATOR . '_day_columns.php';
+
+$days = [
+    $rangeStart,
+    $rangeStart->modify('+1 day'),
+];
+
+echo render_day_columns($days, $events);

--- a/web/public_html/calendar/views/year.php
+++ b/web/public_html/calendar/views/year.php
@@ -2,30 +2,50 @@
 // Path: public_html/calendar/views/year.php
 /**
  * -----------------------------------------------------------------------------
- * Calendar — Year Planner View Partial 🗓️
+ * Calendar — Year Planner View Partial (Wall-Planner Layout) 🗓️
  * -----------------------------------------------------------------------------
- * 12-column wall-planner layout: months as columns (left to right), days as
- * rows (1..31 top to bottom). Each cell shows day-of-week initial and any
- * events as small coloured dots.
+ * Wall-planner style year overview modelled on traditional printed planners.
  *
- * Designed to print landscape and to give a one-page overview of the whole
- * year — modelled on traditional wall-planner posters.
+ * Layout:
+ *   • 12 month columns across the top, each split into TWO sub-columns:
+ *       – Day number + day-of-week initial
+ *       – Event content (bulleted list of all events on that day)
+ *   • 31 day rows top-to-bottom. Days that don't exist for a given month
+ *     (e.g. Feb 30/31) render as blank cells so the grid stays aligned.
+ *   • Weekend cells get a tinted background (Sat = cream, Sun = peach).
+ *   • Multi-day events show on every day they cover — same background
+ *     colour, producing a continuous "band" effect down the column.
+ *   • Category colours drive cell backgrounds via --ev-color, sourced from
+ *     tblEventCategories.color (regex-validated, falls back to primary).
+ *   • Legend at the top lists every active category with its swatch.
  *
  * Receives from the router:
- *   $events, $cursor, $rangeStart, $rangeEnd
+ *   $events, $cursor, $rangeStart, $rangeEnd, $categories
  *
  * @package   Portal\Calendar
  * @license   All Rights Reserved
  * @version   0.11.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/136
  * -----------------------------------------------------------------------------
  */
 
 declare(strict_types=1);
 
-$esc = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+$esc  = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
 $year = (int) $cursor->format('Y');
 
-// 🗂️ Bucket events by Y-m-d (multi-day events show on each spanned day)
+/**
+ * Whitelist a hex colour for inline-CSS injection. Returns the cleaned
+ * value or null if the input is not a safe hex token.
+ */
+$cleanHex = static function (?string $c): ?string {
+    if ($c === null || $c === '') {
+        return null;
+    }
+    return preg_match('/^#[0-9a-fA-F]{3,8}$/', $c) === 1 ? $c : null;
+};
+
+// 🗂️ Bucket events by Y-m-d, repeating multi-day events on each day they span.
 $byDate = [];
 foreach ($events as $ev) {
     $start = new DateTimeImmutable((string) $ev['startDateTime']);
@@ -45,76 +65,148 @@ foreach ($events as $ev) {
     }
 }
 
-$eventColor = static function (array $ev): string {
-    $c = (string) ($ev['categoryColor'] ?? '');
-    if (preg_match('/^#[0-9a-fA-F]{3,8}$/', $c) === 1) {
-        return $c;
-    }
-    return 'var(--portal-primary)';
-};
+$today  = (new DateTimeImmutable('today'))->format('Y-m-d');
+$months = [
+    1  => 'January',  2  => 'February', 3  => 'March',    4  => 'April',
+    5  => 'May',      6  => 'June',     7  => 'July',     8  => 'August',
+    9  => 'September',10 => 'October',  11 => 'November', 12 => 'December',
+];
 
-$today = (new DateTimeImmutable('today'))->format('Y-m-d');
-$months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+/**
+ * Decide the cell background colour for a day. If any multi-day event
+ * covers the day, use its category colour. Otherwise, weekend cells
+ * get a Sat/Sun tint. Plain weekdays get no background.
+ *
+ * @return array{bg:?string,isWeekend:bool}
+ */
+$cellBg = static function (array $dayEvents, DateTimeImmutable $dt) use ($cleanHex): array {
+    foreach ($dayEvents as $ev) {
+        $c = $cleanHex($ev['categoryColor'] ?? null);
+        if ($c !== null) {
+            return ['bg' => $c, 'isWeekend' => false];
+        }
+    }
+    $dow = (int) $dt->format('N');
+    if ($dow >= 6) {
+        return ['bg' => null, 'isWeekend' => true];
+    }
+    return ['bg' => null, 'isWeekend' => false];
+};
 ?>
 
-<div class="portal-cal-year">
-    <div class="portal-cal-year-grid">
-        <!-- Header row: month labels -->
-        <div class="portal-cal-year-cornercell" aria-hidden="true"></div>
-        <?php foreach ($months as $idx => $m): ?>
-            <div class="portal-cal-year-monthhead">
-                <a href="/calendar?view=month&amp;date=<?php echo $year; ?>-<?php echo sprintf('%02d', $idx + 1); ?>-01">
-                    <?php echo $esc($m); ?>
-                </a>
-            </div>
-        <?php endforeach; ?>
+<div class="portal-cal-yearplan">
 
-        <!-- 31 rows × 12 columns of day cells, with a day-number gutter -->
-        <?php for ($day = 1; $day <= 31; $day++): ?>
-            <div class="portal-cal-year-daynum"><?php echo $day; ?></div>
-            <?php for ($month = 1; $month <= 12; $month++): ?>
-                <?php
-                $daysInMonth = (int) (new DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month)))->format('t');
-                if ($day > $daysInMonth) {
-                    echo '<div class="portal-cal-year-cell is-blank" aria-hidden="true"></div>';
-                    continue;
-                }
-                $cellDate = sprintf('%04d-%02d-%02d', $year, $month, $day);
-                $dt        = new DateTimeImmutable($cellDate);
-                $isWeekend = (int) $dt->format('N') >= 6;
-                $isToday   = $cellDate === $today;
-                $dayEv     = $byDate[$cellDate] ?? [];
+    <!-- 🎨 Legend — colour key for the categories in use on this site -->
+    <?php
+    $legendCats = array_filter($categories, static function ($c) use ($cleanHex) {
+        return $cleanHex($c['color'] ?? null) !== null;
+    });
+    ?>
+    <?php if (count($legendCats) > 0): ?>
+        <div class="portal-cal-yearplan-legend mb-2">
+            <strong class="small text-muted me-2">Key:</strong>
+            <?php foreach ($legendCats as $cat): ?>
+                <span class="portal-cal-yearplan-legend-item">
+                    <span class="portal-cal-yearplan-legend-swatch"
+                          style="background: <?php echo $esc((string) $cleanHex($cat['color'])); ?>;"></span>
+                    <?php echo $esc((string) $cat['categoryName']); ?>
+                </span>
+            <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
 
-                $classes = ['portal-cal-year-cell'];
-                if ($isWeekend === true) { $classes[] = 'is-weekend'; }
-                if ($isToday === true)   { $classes[] = 'is-today'; }
-                if (count($dayEv) > 0)   { $classes[] = 'has-events'; }
-                ?>
-                <a class="<?php echo implode(' ', $classes); ?>"
-                   href="/calendar?view=day&amp;date=<?php echo $esc($cellDate); ?>"
-                   title="<?php echo $esc($dt->format('l, j F Y')); ?><?php echo count($dayEv) > 0 ? ' — ' . count($dayEv) . ' event(s)' : ''; ?>">
-                    <span class="portal-cal-year-cell-dow"><?php echo $esc(substr($dt->format('D'), 0, 1)); ?></span>
-                    <?php if (count($dayEv) > 0): ?>
-                        <span class="portal-cal-year-dots">
-                            <?php
-                            // 🎨 Up to 3 colour dots so a busy day shows pattern, not clutter.
-                            foreach (array_slice($dayEv, 0, 3) as $ev):
-                                ?>
-                                <span class="portal-cal-year-dot"
-                                      style="background: <?php echo $esc($eventColor($ev)); ?>;"></span>
-                            <?php endforeach; ?>
-                            <?php if (count($dayEv) > 3): ?>
-                                <span class="portal-cal-year-dot-more">+<?php echo count($dayEv) - 3; ?></span>
-                            <?php endif; ?>
-                        </span>
-                    <?php endif; ?>
+    <!-- 🖼️ Wall-planner grid: scrollable horizontally on narrow viewports -->
+    <div class="portal-cal-yearplan-scroll">
+        <div class="portal-cal-yearplan-grid">
+
+            <!-- Header row: month names (each spans 2 sub-columns) -->
+            <?php foreach ($months as $monthNum => $monthName): ?>
+                <a href="/calendar?view=month&amp;date=<?php echo $year; ?>-<?php echo sprintf('%02d', $monthNum); ?>-01"
+                   class="portal-cal-yearplan-monthhead"
+                   style="grid-column: span 2;">
+                    <?php echo $esc($monthName); ?>
                 </a>
+            <?php endforeach; ?>
+
+            <!-- 31 day rows × (12 months × 2 sub-columns) = 31 × 24 cells -->
+            <?php for ($day = 1; $day <= 31; $day++): ?>
+                <?php for ($month = 1; $month <= 12; $month++): ?>
+                    <?php
+                    $daysInMonth = (int) (new DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month)))->format('t');
+                    if ($day > $daysInMonth) {
+                        // Blank pair of cells so the grid stays aligned
+                        echo '<div class="portal-cal-yearplan-num is-blank" aria-hidden="true"></div>';
+                        echo '<div class="portal-cal-yearplan-content is-blank" aria-hidden="true"></div>';
+                        continue;
+                    }
+                    $cellDate = sprintf('%04d-%02d-%02d', $year, $month, $day);
+                    $dt       = new DateTimeImmutable($cellDate);
+                    $isToday  = $cellDate === $today;
+                    $dow      = (int) $dt->format('N');   // 1..7 Mon..Sun
+                    $dowInit  = substr($dt->format('D'), 0, 2);  // "Mo", "Tu", "We", "Th", "Fr", "Sa", "Su"
+                    $dayEv    = $byDate[$cellDate] ?? [];
+
+                    $info       = $cellBg($dayEv, $dt);
+                    $bgHex      = $info['bg'];
+                    $isWeekend  = $info['isWeekend'];
+
+                    // Style attrs
+                    $cellStyle = '';
+                    if ($bgHex !== null) {
+                        // Use a lightened tint of the category colour so the day
+                        // text stays readable. The category swatch + a left-border
+                        // accent at full saturation make the band still obvious.
+                        $cellStyle = 'style="background: color-mix(in srgb, '
+                                   . $esc($bgHex) . ' 28%, var(--portal-surface));'
+                                   . ' --ev-color: ' . $esc($bgHex) . ';"';
+                    }
+
+                    $contentClasses = ['portal-cal-yearplan-content'];
+                    if ($isToday === true)  { $contentClasses[] = 'is-today'; }
+                    if ($isWeekend === true) {
+                        $contentClasses[] = $dow === 6 ? 'is-saturday' : 'is-sunday';
+                    }
+                    if ($bgHex !== null) { $contentClasses[] = 'has-event'; }
+
+                    $numClasses = ['portal-cal-yearplan-num'];
+                    if ($isToday === true)  { $numClasses[] = 'is-today'; }
+                    if ($isWeekend === true) {
+                        $numClasses[] = $dow === 6 ? 'is-saturday' : 'is-sunday';
+                    }
+                    ?>
+
+                    <!-- Day number + day-of-week initial -->
+                    <a class="<?php echo implode(' ', $numClasses); ?>"
+                       href="/calendar?view=day&amp;date=<?php echo $esc($cellDate); ?>"
+                       title="<?php echo $esc($dt->format('l, j F Y')); ?>">
+                        <span class="portal-cal-yearplan-num-day"><?php echo sprintf('%02d', $day); ?></span>
+                        <span class="portal-cal-yearplan-num-dow"><?php echo $esc($dowInit); ?></span>
+                    </a>
+
+                    <!-- Event content cell -->
+                    <div class="<?php echo implode(' ', $contentClasses); ?>" <?php echo $cellStyle; ?>>
+                        <?php if (count($dayEv) > 0): ?>
+                            <ul class="portal-cal-yearplan-events">
+                                <?php foreach ($dayEv as $ev): ?>
+                                    <?php $evColor = $cleanHex($ev['categoryColor'] ?? null); ?>
+                                    <li>
+                                        <a href="/calendar/event?slug=<?php echo $esc((string) $ev['eventSlug']); ?>"
+                                           <?php if ($evColor !== null): ?>style="--ev-color: <?php echo $esc($evColor); ?>;"<?php endif; ?>
+                                           title="<?php echo $esc((string) $ev['eventName']); ?>">
+                                            <?php echo $esc((string) $ev['eventName']); ?>
+                                        </a>
+                                    </li>
+                                <?php endforeach; ?>
+                            </ul>
+                        <?php endif; ?>
+                    </div>
+                <?php endfor; ?>
             <?php endfor; ?>
-        <?php endfor; ?>
+        </div>
     </div>
 
     <p class="text-muted small mt-3 mb-0">
-        Click any day to open the day view; click a month name to jump to the month view.
-        Dots are colour-coded by category.
+        Click a month name to jump to the month view; click a day number to jump to that day.
+        Multi-day events repeat on every day they cover and share their category colour, producing a continuous band.
     </p>
 </div>

--- a/web/public_html/calendar/views/year.php
+++ b/web/public_html/calendar/views/year.php
@@ -1,0 +1,120 @@
+<?php
+// Path: public_html/calendar/views/year.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Year Planner View Partial 🗓️
+ * -----------------------------------------------------------------------------
+ * 12-column wall-planner layout: months as columns (left to right), days as
+ * rows (1..31 top to bottom). Each cell shows day-of-week initial and any
+ * events as small coloured dots.
+ *
+ * Designed to print landscape and to give a one-page overview of the whole
+ * year — modelled on traditional wall-planner posters.
+ *
+ * Receives from the router:
+ *   $events, $cursor, $rangeStart, $rangeEnd
+ *
+ * @package   Portal\Calendar
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+$esc = static fn (string $s): string => htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+$year = (int) $cursor->format('Y');
+
+// 🗂️ Bucket events by Y-m-d (multi-day events show on each spanned day)
+$byDate = [];
+foreach ($events as $ev) {
+    $start = new DateTimeImmutable((string) $ev['startDateTime']);
+    $end   = $ev['endDateTime'] !== null
+        ? new DateTimeImmutable((string) $ev['endDateTime'])
+        : $start;
+    $cur = $start;
+    while ($cur <= $end) {
+        if ((int) $cur->format('Y') === $year) {
+            $k = $cur->format('Y-m-d');
+            if (isset($byDate[$k]) === false) {
+                $byDate[$k] = [];
+            }
+            $byDate[$k][] = $ev;
+        }
+        $cur = $cur->modify('+1 day');
+    }
+}
+
+$eventColor = static function (array $ev): string {
+    $c = (string) ($ev['categoryColor'] ?? '');
+    if (preg_match('/^#[0-9a-fA-F]{3,8}$/', $c) === 1) {
+        return $c;
+    }
+    return 'var(--portal-primary)';
+};
+
+$today = (new DateTimeImmutable('today'))->format('Y-m-d');
+$months = ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'];
+?>
+
+<div class="portal-cal-year">
+    <div class="portal-cal-year-grid">
+        <!-- Header row: month labels -->
+        <div class="portal-cal-year-cornercell" aria-hidden="true"></div>
+        <?php foreach ($months as $idx => $m): ?>
+            <div class="portal-cal-year-monthhead">
+                <a href="/calendar?view=month&amp;date=<?php echo $year; ?>-<?php echo sprintf('%02d', $idx + 1); ?>-01">
+                    <?php echo $esc($m); ?>
+                </a>
+            </div>
+        <?php endforeach; ?>
+
+        <!-- 31 rows × 12 columns of day cells, with a day-number gutter -->
+        <?php for ($day = 1; $day <= 31; $day++): ?>
+            <div class="portal-cal-year-daynum"><?php echo $day; ?></div>
+            <?php for ($month = 1; $month <= 12; $month++): ?>
+                <?php
+                $daysInMonth = (int) (new DateTimeImmutable(sprintf('%04d-%02d-01', $year, $month)))->format('t');
+                if ($day > $daysInMonth) {
+                    echo '<div class="portal-cal-year-cell is-blank" aria-hidden="true"></div>';
+                    continue;
+                }
+                $cellDate = sprintf('%04d-%02d-%02d', $year, $month, $day);
+                $dt        = new DateTimeImmutable($cellDate);
+                $isWeekend = (int) $dt->format('N') >= 6;
+                $isToday   = $cellDate === $today;
+                $dayEv     = $byDate[$cellDate] ?? [];
+
+                $classes = ['portal-cal-year-cell'];
+                if ($isWeekend === true) { $classes[] = 'is-weekend'; }
+                if ($isToday === true)   { $classes[] = 'is-today'; }
+                if (count($dayEv) > 0)   { $classes[] = 'has-events'; }
+                ?>
+                <a class="<?php echo implode(' ', $classes); ?>"
+                   href="/calendar?view=day&amp;date=<?php echo $esc($cellDate); ?>"
+                   title="<?php echo $esc($dt->format('l, j F Y')); ?><?php echo count($dayEv) > 0 ? ' — ' . count($dayEv) . ' event(s)' : ''; ?>">
+                    <span class="portal-cal-year-cell-dow"><?php echo $esc(substr($dt->format('D'), 0, 1)); ?></span>
+                    <?php if (count($dayEv) > 0): ?>
+                        <span class="portal-cal-year-dots">
+                            <?php
+                            // 🎨 Up to 3 colour dots so a busy day shows pattern, not clutter.
+                            foreach (array_slice($dayEv, 0, 3) as $ev):
+                                ?>
+                                <span class="portal-cal-year-dot"
+                                      style="background: <?php echo $esc($eventColor($ev)); ?>;"></span>
+                            <?php endforeach; ?>
+                            <?php if (count($dayEv) > 3): ?>
+                                <span class="portal-cal-year-dot-more">+<?php echo count($dayEv) - 3; ?></span>
+                            <?php endif; ?>
+                        </span>
+                    <?php endif; ?>
+                </a>
+            <?php endfor; ?>
+        <?php endfor; ?>
+    </div>
+
+    <p class="text-muted small mt-3 mb-0">
+        Click any day to open the day view; click a month name to jump to the month view.
+        Dots are colour-coded by category.
+    </p>
+</div>

--- a/web/sql/042_calendar_default_view.sql
+++ b/web/sql/042_calendar_default_view.sql
@@ -1,0 +1,14 @@
+-- =============================================================================
+-- 042 — Calendar default view setting 📅
+-- =============================================================================
+-- Adds `calendar.defaultView` so admins can set the landing view on /calendar
+-- when the user has no per-device preference yet (no localStorage value).
+--
+-- Valid values: day | week | weekdays | weekend | month | year | list
+-- Default: month  — most-used overview for a typical calendar landing.
+--
+-- See: web/public_html/calendar/index.php (issue #136)
+-- =============================================================================
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'calendar.defaultView', 'month', 'month', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -1396,6 +1396,12 @@ INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `default
 VALUES ('calendar.brandColor', '#0d6efd', 0, '#0d6efd')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
+-- Default calendar view (matches migration 042 — issue #136).
+-- Valid values: day | week | weekdays | weekend | month | year | list
+INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
+VALUES ('calendar.defaultView', 'month', 0, 'month')
+ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
+
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
 VALUES ('leadership.enabled', 'false', 0, 'false')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
@@ -1871,6 +1877,9 @@ INSERT INTO `tblMigrations` (`filename`) VALUES ('040_captcha_providers.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblMigrations` (`filename`) VALUES ('041_password_policy_hardening.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('042_calendar_default_view.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 -- Seed the branding.hidePoweredBy setting (matches migration 038)


### PR DESCRIPTION
## Summary

Closes #136.

The calendar app was previously **list-view only** — the seven view modes originally specified had never been implemented. This PR fills in the gap with a single cohesive refactor.

| View | URL | What it renders |
| --- | --- | --- |
| Day | `?view=day&date=YYYY-MM-DD` | Vertical hour timeline (00–24h) for one day, events positioned by start time. |
| Week | `?view=week` | 7-day grid (Mon → Sun) sharing the same hour timeline. |
| Weekdays | `?view=weekdays` | Mon → Fri only. |
| Weekend | `?view=weekend` | Sat → Sun only. |
| Month | `?view=month&date=YYYY-MM-DD` | 7-column 5/6-row calendar grid, up to 3 event pills per cell + "+ N more". |
| Year | `?view=year&date=YYYY` | 12-column wall-planner (months across, days 1–31 down) with colour-coded category dots per day. |
| List | `?view=list&past=1` | The original card-grid layout, refactored into the new shell. |

## Architecture

- `index.php` is now a thin view router. Validates `?view=` against a whitelist, resolves the visible date range per view, fetches all events overlapping that range in one query, then delegates to a per-view partial under `views/`.
- `views/_shared_header.php` — date navigation (◀ Today ▶ + date picker), view-switcher buttons, filters.
- `views/_day_columns.php` — **one** hour-timeline renderer reused by day / week / weekdays / weekend, parametrised by column count. Events position absolutely by start time and clip to each column's window.
- `views/month.php` — standard calendar grid; up to 3 event pills per cell.
- `views/year.php` — wall-planner layout, dots colour-coded by category.
- `views/list.php` — extracted from the old `index.php` essentially verbatim, just adapted to render as a partial.

## Behaviour

- **Last-used view** persists in `localStorage` (`portal-calendar-view`) for a per-device default.
- **`calendar.defaultView`** admin setting (default `month`) controls the first-visit landing view.
- URL `?view=` always wins over both.
- Events carry an `--ev-color` CSS custom property pulled from `tblEventCategories.color` (hex-validated server-side), so each category's colour propagates everywhere. Falls back to `--portal-primary`.
- Mobile (≤640px): hour timelines scroll horizontally; month cells shrink; pill names hide.

## Schema

- New migration `web/sql/042_calendar_default_view.sql` adds `calendar.defaultView` (default `month`).
- `web/sql/full_schema.sql` mirrors the seed and the migration record.

## Year-planner style

The original ask referenced an attached example screenshot for the yearly planner, but no image came through with the message. I went with a traditional wall-planner layout — 12 columns × 31 rows, day-of-week initial + coloured dots per day. If you wanted a different style (timeline strip per month, compact month cards, etc.) say the word and we can iterate in a follow-up PR.

## Security notes

Pre-commit review (grepped the diff):

- All SQL uses prepared statements + `bind_param`; the new date range parameters (`startStr` / `endStr`) are bound, not interpolated.
- All output escaped via `htmlspecialchars(..., ENT_QUOTES, 'UTF-8')`.
- The `--ev-color` inline CSS is **regex-validated** server-side (`/^#[0-9a-fA-F]{3,8}$/`) before being injected into a `style=""` attribute, blocking CSS injection via crafted category colours.
- `?view=` is whitelisted; unknown values fall back to the default.
- `?date=` is parsed via `DateTimeImmutable` inside a try/catch; malformed input falls back to today.

## Test plan

- [ ] Visit `/calendar` — confirm month view loads as default.
- [ ] Switch to each view (Day, Week, Mon-Fri, Sat-Sun, Month, Year, List) and confirm events render correctly.
- [ ] Use ◀ Today ▶ navigation — confirm date cursor moves per view (1 day / 1 week / 1 month / 1 year).
- [ ] Jump-to-date input — confirm the cursor lands on the chosen date.
- [ ] Filter by category and type — confirm filter applies across all views.
- [ ] Click a month name in year view — confirm jump to month view of that month.
- [ ] Click a day cell in month or year — confirm jump to day view of that date.
- [ ] Toggle dark mode — confirm the grids stay legible.
- [ ] Switch view via the buttons, refresh the page — confirm the previously-selected view is remembered (localStorage).
- [ ] Mobile / narrow viewport — confirm the views remain usable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)