### PR TITLE
feat(calendar): per-month strap-lines + category display-style toggle (follow-ups to #136)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,31 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Added — Calendar: per-month strap-lines + category display-style toggle (follow-ups to #136)
+
+Two enhancements deferred from the original calendar-views PR (#137):
+
+- **Per-month strap-lines / themes** on the year planner. A new table
+  `tblCalendarMonthThemes` stores one text line per (site, year, month)
+  that appears under each month name on `/calendar?view=year`. Managed
+  via a new admin page at `/calendar/manage/month-themes` (year picker
+  with 12 inputs; empty values delete the existing row).
+- **`tblEventCategories.color` + `tblEventCategories.displayStyle`**
+  columns. Categories can now carry a colour and choose whether that
+  colour renders as a **tinted background band** (default — used for
+  organisational scopes like "Area 8", "Conference", "Union") or as
+  **coloured text** on the default background (used for events like
+  Bank Holidays / Notable Days that just want to flag the day, not
+  fill the band).
+- Category management UI at `/calendar/manage/types` exposes a colour
+  picker + display-style dropdown for every category. Existing
+  categories get an inline form to update appearance in-place.
+- Year-planner legend renders text-style categories as a coloured
+  word rather than a swatch + name, mirroring how they'll appear in
+  the planner.
+- Migration `web/sql/043_calendar_categories_and_month_themes.sql`
+  adds the new columns, the new table, and the admin route.
+
 ### Added — Calendar multi-view modes (#136)
 
 The calendar app was previously list-view only. It now supports **seven**

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -1923,6 +1923,19 @@ a:focus > .app-card {
     border-radius: 3px;
     border: 1px solid var(--portal-border);
 }
+.portal-cal-yearplan-legend-text {
+    /* Text-only legend entries (e.g. Bank Holidays) — no swatch, just
+       the category name rendered in its display colour. */
+    font-size: var(--portal-font-size-sm);
+}
+
+/* Text-style event entries inside day cells — coloured text with no
+   background tint, distinguishing them from band-style events. */
+.portal-cal-yearplan-events li.is-text-style a {
+    text-decoration: underline;
+    text-decoration-thickness: 1px;
+    text-underline-offset: 2px;
+}
 
 .portal-cal-yearplan-scroll {
     overflow-x: auto;
@@ -1954,6 +1967,21 @@ a:focus > .app-card {
 .portal-cal-yearplan-monthhead:hover {
     color: var(--portal-primary);
     background: var(--portal-primary-subtle);
+}
+.portal-cal-yearplan-monthhead-name {
+    display: block;
+    font-weight: 700;
+    line-height: 1.1;
+}
+.portal-cal-yearplan-monthhead-strap {
+    display: block;
+    font-size: var(--portal-font-size-xs);
+    font-weight: 400;
+    font-style: italic;
+    color: var(--portal-text-muted);
+    margin-top: 0.15rem;
+    line-height: 1.1;
+    word-break: break-word;
 }
 
 /* Day-number sub-cell */

--- a/web/public_html/calendar/index.php
+++ b/web/public_html/calendar/index.php
@@ -215,7 +215,8 @@ if ($view === 'list') {
          . 'e.startDateTime, e.endDateTime, e.timezone, e.isAllDay, '
          . 'e.locationName, e.locationAddress, e.status, e.isFeatured, '
          . 'e.heroImage, '
-         . 'c.categoryName, c.color AS categoryColor, t.typeName, s.seriesName '
+         . 'c.categoryName, c.color AS categoryColor, c.displayStyle AS categoryDisplayStyle, '
+         . 't.typeName, s.seriesName '
          . 'FROM tblEvents e '
          . 'LEFT JOIN tblEventCategories c ON c.categoryID = e.categoryID '
          . 'LEFT JOIN tblEventTypes t ON t.typeID = e.typeID '
@@ -258,7 +259,8 @@ if ($view === 'list') {
          . 'e.startDateTime, e.endDateTime, e.timezone, e.isAllDay, '
          . 'e.locationName, e.locationAddress, e.status, e.isFeatured, '
          . 'e.heroImage, '
-         . 'c.categoryName, c.color AS categoryColor, t.typeName, s.seriesName '
+         . 'c.categoryName, c.color AS categoryColor, c.displayStyle AS categoryDisplayStyle, '
+         . 't.typeName, s.seriesName '
          . 'FROM tblEvents e '
          . 'LEFT JOIN tblEventCategories c ON c.categoryID = e.categoryID '
          . 'LEFT JOIN tblEventTypes t ON t.typeID = e.typeID '
@@ -285,7 +287,8 @@ if ($view === 'list') {
 // -----------------------------------------------------------------------------
 $categories = [];
 $stmtCat = $mysqli->prepare(
-    'SELECT categoryID, categoryName, color FROM tblEventCategories '
+    'SELECT categoryID, categoryName, color, displayStyle '
+    . 'FROM tblEventCategories '
     . 'WHERE isActive = 1 AND siteID = ? ORDER BY sortOrder, categoryName'
 );
 if ($stmtCat !== false) {

--- a/web/public_html/calendar/manage/index.php
+++ b/web/public_html/calendar/manage/index.php
@@ -217,11 +217,19 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
 
 <?php else: ?>
 <!-- 📋 Event List + Create -->
-<div class="d-flex justify-content-between align-items-center mb-4">
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
     <h1 class="mb-0"><i class="fa-solid fa-list-check me-2"></i>Manage Events</h1>
-    <button class="btn btn-success" data-bs-toggle="collapse" data-bs-target="#createEventForm">
-        <i class="fa-solid fa-plus me-1"></i> Create Event
-    </button>
+    <div class="d-flex gap-2 flex-wrap">
+        <a href="/calendar/manage/types" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-tags me-1"></i> Categories &amp; Types
+        </a>
+        <a href="/calendar/manage/month-themes" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-quote-left me-1"></i> Month Themes
+        </a>
+        <button class="btn btn-success" data-bs-toggle="collapse" data-bs-target="#createEventForm">
+            <i class="fa-solid fa-plus me-1"></i> Create Event
+        </button>
+    </div>
 </div>
 
 <!-- ➕ Create event form (collapsible) -->

--- a/web/public_html/calendar/manage/month-themes.php
+++ b/web/public_html/calendar/manage/month-themes.php
@@ -1,0 +1,211 @@
+<?php
+// Path: public_html/calendar/manage/month-themes.php
+/**
+ * -----------------------------------------------------------------------------
+ * Calendar — Month Themes / Strap-lines Admin 🗓️
+ * -----------------------------------------------------------------------------
+ * Per-year-per-month text shown under each month name on /calendar?view=year.
+ * Stored in tblCalendarMonthThemes; one row per (siteID, year, month).
+ *
+ * Usage:
+ *   /calendar/manage/month-themes              → current year
+ *   /calendar/manage/month-themes?year=2027    → specific year
+ *
+ * @package   Portal\Calendar
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   0.11.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Router;
+use Portal\Core\Site;
+
+// 📌 Page metadata
+$pageTitle   = 'Month Themes';
+$pageSection = 'calendar';
+$breadcrumbs = [
+    'Dashboard'        => '/',
+    'Calendar'         => '/calendar',
+    'Manage'           => '/calendar/manage',
+    'Month Themes'     => '',
+];
+
+Auth::ensureSession();
+if (App::isAdmin() === false) {
+    Router::renderError(403);
+    return;
+}
+
+$siteId = Site::id();
+$year   = (int) ($_GET['year'] ?? $_POST['year'] ?? date('Y'));
+if ($year < 1900 || $year > 2999) {
+    $year = (int) date('Y');
+}
+
+// -----------------------------------------------------------------------------
+// 💾 POST handler — save all 12 months in one round-trip
+// -----------------------------------------------------------------------------
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+        $_SESSION['flash_msg']  = 'Invalid or expired form token. Please try again.';
+        $_SESSION['flash_type'] = 'danger';
+        header('Location: /calendar/manage/month-themes?year=' . $year, true, 302);
+        exit();
+    }
+
+    $themes = $_POST['theme'] ?? [];
+    if (is_array($themes) === true) {
+        $upsert = $mysqli->prepare(
+            'INSERT INTO tblCalendarMonthThemes (siteID, year, month, themeText) '
+            . 'VALUES (?, ?, ?, ?) '
+            . 'ON DUPLICATE KEY UPDATE themeText = VALUES(themeText)'
+        );
+        $deleteEmpty = $mysqli->prepare(
+            'DELETE FROM tblCalendarMonthThemes '
+            . 'WHERE siteID = ? AND year = ? AND month = ?'
+        );
+
+        if ($upsert !== false && $deleteEmpty !== false) {
+            for ($m = 1; $m <= 12; $m++) {
+                $val = trim((string) ($themes[(string) $m] ?? ''));
+                if (mb_strlen($val) > 255) {
+                    $val = mb_substr($val, 0, 255);
+                }
+                if ($val === '') {
+                    // 🧹 Empty value → remove any existing row so the cell goes back to default
+                    $deleteEmpty->bind_param('iii', $siteId, $year, $m);
+                    $deleteEmpty->execute();
+                } else {
+                    $upsert->bind_param('iiis', $siteId, $year, $m, $val);
+                    $upsert->execute();
+                }
+            }
+            $upsert->close();
+            $deleteEmpty->close();
+
+            Logger::activity('CalendarMonthThemesSaved', 'Saved month themes for year ' . $year);
+            $_SESSION['flash_msg']  = 'Month themes for ' . $year . ' saved.';
+            $_SESSION['flash_type'] = 'success';
+        } else {
+            $_SESSION['flash_msg']  = 'Database error saving themes.';
+            $_SESSION['flash_type'] = 'danger';
+        }
+    }
+
+    header('Location: /calendar/manage/month-themes?year=' . $year, true, 302);
+    exit();
+}
+
+// -----------------------------------------------------------------------------
+// 📋 Load existing themes for this year
+// -----------------------------------------------------------------------------
+$existing = [];
+$stmt = $mysqli->prepare(
+    'SELECT month, themeText FROM tblCalendarMonthThemes '
+    . 'WHERE siteID = ? AND year = ?'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $siteId, $year);
+    $stmt->execute();
+    $r = $stmt->get_result();
+    while ($row = $r->fetch_assoc()) {
+        $existing[(int) $row['month']] = (string) $row['themeText'];
+    }
+    $stmt->close();
+}
+
+$flashMsg  = $_SESSION['flash_msg']  ?? '';
+$flashType = $_SESSION['flash_type'] ?? 'info';
+unset($_SESSION['flash_msg'], $_SESSION['flash_type']);
+
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+$months = [
+    1 => 'January', 2 => 'February', 3 => 'March',    4 => 'April',
+    5 => 'May',     6 => 'June',     7 => 'July',     8 => 'August',
+    9 => 'September',10 => 'October',11 => 'November',12 => 'December',
+];
+?>
+
+<div class="d-flex justify-content-between align-items-center mb-4 flex-wrap gap-2">
+    <h1 class="mb-0">
+        <i class="fa-solid fa-quote-left me-2"></i>Month Themes — <?php echo (int) $year; ?>
+    </h1>
+    <div class="d-flex gap-2">
+        <a href="/calendar/manage" class="btn btn-outline-secondary">
+            <i class="fa-solid fa-arrow-left me-1"></i> Back to Manage
+        </a>
+        <a href="/calendar?view=year&amp;date=<?php echo (int) $year; ?>-01-01" class="btn btn-outline-primary">
+            <i class="fa-solid fa-eye me-1"></i> View on Planner
+        </a>
+    </div>
+</div>
+
+<?php if ($flashMsg !== ''): ?>
+    <div class="alert alert-<?php echo htmlspecialchars($flashType, ENT_QUOTES, 'UTF-8'); ?> alert-dismissible fade show">
+        <?php echo htmlspecialchars($flashMsg, ENT_QUOTES, 'UTF-8'); ?>
+        <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+<?php endif; ?>
+
+<!-- Year picker -->
+<form method="get" action="/calendar/manage/month-themes" class="row g-2 align-items-end mb-3">
+    <div class="col-auto">
+        <label for="year-input" class="form-label small mb-1">Year</label>
+        <input id="year-input" type="number" name="year" class="form-control form-control-sm"
+               min="1900" max="2999" value="<?php echo (int) $year; ?>">
+    </div>
+    <div class="col-auto">
+        <button type="submit" class="btn btn-sm btn-outline-secondary">Load</button>
+    </div>
+</form>
+
+<!-- Themes editor -->
+<form method="post" action="/calendar/manage/month-themes">
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
+    <input type="hidden" name="year" value="<?php echo (int) $year; ?>">
+
+    <div class="card shadow-sm">
+        <div class="card-body">
+            <p class="text-muted small">
+                Each month can carry a short "strap-line" or theme that appears under its
+                name on the year-planner view. Leave a field blank to remove the theme
+                for that month.
+            </p>
+
+            <div class="row g-3">
+                <?php foreach ($months as $num => $name): ?>
+                    <div class="col-12 col-md-6 col-lg-4">
+                        <label for="theme-<?php echo $num; ?>" class="form-label">
+                            <strong><?php echo htmlspecialchars($name, ENT_QUOTES, 'UTF-8'); ?></strong>
+                        </label>
+                        <input id="theme-<?php echo $num; ?>"
+                               type="text"
+                               name="theme[<?php echo $num; ?>]"
+                               class="form-control"
+                               maxlength="255"
+                               value="<?php echo htmlspecialchars($existing[$num] ?? '', ENT_QUOTES, 'UTF-8'); ?>"
+                               placeholder="e.g. ~Healthy connections~">
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+        <div class="card-footer d-flex gap-2">
+            <button type="submit" class="btn btn-success">
+                <i class="fa-solid fa-save me-1"></i> Save Themes
+            </button>
+            <a href="/calendar?view=year&amp;date=<?php echo (int) $year; ?>-01-01" class="btn btn-outline-secondary">
+                Cancel
+            </a>
+        </div>
+    </div>
+</form>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/calendar/manage/types.php
+++ b/web/public_html/calendar/manage/types.php
@@ -72,15 +72,59 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         $name     = trim($_POST['categoryName'] ?? '');
         $parentID = ((int) ($_POST['parentID'] ?? 0)) ?: null;
         $slug     = strtolower(trim(preg_replace('/[^a-zA-Z0-9]+/', '-', $name), '-'));
+
+        // 🎨 Colour + display style validation
+        $color = trim((string) ($_POST['color'] ?? ''));
+        if ($color !== '' && preg_match('/^#[0-9a-fA-F]{3,8}$/', $color) !== 1) {
+            $color = '';   // reject malformed hex silently — falls back to default
+        }
+        $colorParam = $color === '' ? null : $color;
+
+        $displayStyle = (string) ($_POST['displayStyle'] ?? 'background');
+        if ($displayStyle !== 'background' && $displayStyle !== 'text') {
+            $displayStyle = 'background';
+        }
+
         if ($name !== '') {
-            $stmt = $mysqli->prepare('INSERT INTO tblEventCategories (categoryName, categorySlug, parentID, siteID) VALUES (?, ?, ?, ?)');
+            $stmt = $mysqli->prepare(
+                'INSERT INTO tblEventCategories '
+                . '(categoryName, categorySlug, parentID, siteID, color, displayStyle) '
+                . 'VALUES (?, ?, ?, ?, ?, ?)'
+            );
             if ($stmt !== false) {
-                $stmt->bind_param('ssii', $name, $slug, $parentID, $siteId);
+                $stmt->bind_param('ssiiss', $name, $slug, $parentID, $siteId, $colorParam, $displayStyle);
                 $stmt->execute();
                 $stmt->close();
             }
             Logger::activity('CategoryCreated', 'Created event category: ' . $name, $_SESSION['user_id'] ?? null);
             $_SESSION['flash_msg'] = 'Category "' . $name . '" created.';
+            $_SESSION['flash_type'] = 'success';
+        }
+    }
+
+    if ($action === 'update' && $entity === 'category') {
+        $catID    = (int) ($_POST['categoryID'] ?? 0);
+        $color    = trim((string) ($_POST['color'] ?? ''));
+        if ($color !== '' && preg_match('/^#[0-9a-fA-F]{3,8}$/', $color) !== 1) {
+            $color = '';
+        }
+        $colorParam = $color === '' ? null : $color;
+        $displayStyle = (string) ($_POST['displayStyle'] ?? 'background');
+        if ($displayStyle !== 'background' && $displayStyle !== 'text') {
+            $displayStyle = 'background';
+        }
+
+        if ($catID > 0) {
+            $stmt = $mysqli->prepare(
+                'UPDATE tblEventCategories SET color = ?, displayStyle = ? '
+                . 'WHERE categoryID = ? AND siteID = ?'
+            );
+            if ($stmt !== false) {
+                $stmt->bind_param('ssii', $colorParam, $displayStyle, $catID, $siteId);
+                $stmt->execute();
+                $stmt->close();
+            }
+            $_SESSION['flash_msg'] = 'Category appearance updated.';
             $_SESSION['flash_type'] = 'success';
         }
     }
@@ -283,6 +327,20 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
                                 <?php endforeach; ?>
                             </select>
                         </div>
+                        <div class="row g-2 mb-2">
+                            <div class="col-7">
+                                <label class="form-label small mb-1">Colour</label>
+                                <input type="color" class="form-control form-control-sm form-control-color"
+                                       name="color" value="#5e6ad2" title="Pick a colour">
+                            </div>
+                            <div class="col-5">
+                                <label class="form-label small mb-1">Style</label>
+                                <select name="displayStyle" class="form-select form-select-sm">
+                                    <option value="background">Background</option>
+                                    <option value="text">Text only</option>
+                                </select>
+                            </div>
+                        </div>
                         <button type="submit" class="btn btn-sm btn-success">Add</button>
                     </form>
                 </div>
@@ -291,12 +349,54 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
             <div class="card-body p-0">
                 <div class="portal-data-list">
                     <?php foreach ($categoriesList as $c): ?>
-                        <div class="portal-data-row">
-                            <div class="col-8">
+                        <?php
+                        $catColor = (string) ($c['color'] ?? '');
+                        $catStyle = (string) ($c['displayStyle'] ?? 'background');
+                        ?>
+                        <div class="portal-data-row align-items-center">
+                            <div class="col-12 col-md-5">
                                 <?php echo ($c['parentID'] !== null) ? '<span class="text-muted ms-3">↳</span> ' : ''; ?>
-                                <?php echo htmlspecialchars($c['categoryName'], ENT_QUOTES, 'UTF-8'); ?>
+                                <?php if ($catColor !== '' && preg_match('/^#[0-9a-fA-F]{3,8}$/', $catColor) === 1): ?>
+                                    <?php if ($catStyle === 'text'): ?>
+                                        <span style="color: <?php echo htmlspecialchars($catColor, ENT_QUOTES, 'UTF-8'); ?>; font-weight: 600;">
+                                            <?php echo htmlspecialchars($c['categoryName'], ENT_QUOTES, 'UTF-8'); ?>
+                                        </span>
+                                    <?php else: ?>
+                                        <span class="badge"
+                                              style="background: <?php echo htmlspecialchars($catColor, ENT_QUOTES, 'UTF-8'); ?>; color: #fff;">
+                                            <?php echo htmlspecialchars($c['categoryName'], ENT_QUOTES, 'UTF-8'); ?>
+                                        </span>
+                                    <?php endif; ?>
+                                <?php else: ?>
+                                    <?php echo htmlspecialchars($c['categoryName'], ENT_QUOTES, 'UTF-8'); ?>
+                                <?php endif; ?>
                             </div>
-                            <div class="col-4 text-end">
+                            <div class="col-12 col-md-5">
+                                <form method="post" action="/calendar/manage/types" class="row g-1 align-items-center">
+                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
+                                    <input type="hidden" name="action" value="update">
+                                    <input type="hidden" name="entity" value="category">
+                                    <input type="hidden" name="categoryID" value="<?php echo (int) $c['categoryID']; ?>">
+                                    <div class="col-auto">
+                                        <input type="color" class="form-control form-control-sm form-control-color"
+                                               name="color"
+                                               value="<?php echo $catColor !== '' ? htmlspecialchars($catColor, ENT_QUOTES, 'UTF-8') : '#5e6ad2'; ?>"
+                                               title="Category colour">
+                                    </div>
+                                    <div class="col-auto">
+                                        <select name="displayStyle" class="form-select form-select-sm">
+                                            <option value="background" <?php echo $catStyle === 'background' ? 'selected' : ''; ?>>Background</option>
+                                            <option value="text"       <?php echo $catStyle === 'text'       ? 'selected' : ''; ?>>Text only</option>
+                                        </select>
+                                    </div>
+                                    <div class="col-auto">
+                                        <button type="submit" class="btn btn-sm btn-outline-primary" title="Save appearance">
+                                            <i class="fa-solid fa-save"></i>
+                                        </button>
+                                    </div>
+                                </form>
+                            </div>
+                            <div class="col-12 col-md-2 text-end">
                                 <form method="post" action="/calendar/manage/types" class="d-inline">
                                     <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8'); ?>">
                                     <input type="hidden" name="action" value="delete">

--- a/web/public_html/calendar/views/year.php
+++ b/web/public_html/calendar/views/year.php
@@ -45,6 +45,22 @@ $cleanHex = static function (?string $c): ?string {
     return preg_match('/^#[0-9a-fA-F]{3,8}$/', $c) === 1 ? $c : null;
 };
 
+// 🗓️ Per-month strap-lines from tblCalendarMonthThemes
+$monthThemes = [];   // map: monthNum => themeText
+$stmtMt = $mysqli->prepare(
+    'SELECT month, themeText FROM tblCalendarMonthThemes '
+    . 'WHERE siteID = ? AND year = ?'
+);
+if ($stmtMt !== false) {
+    $stmtMt->bind_param('ii', $siteId, $year);
+    $stmtMt->execute();
+    $r = $stmtMt->get_result();
+    while ($row = $r->fetch_assoc()) {
+        $monthThemes[(int) $row['month']] = (string) $row['themeText'];
+    }
+    $stmtMt->close();
+}
+
 // 🗂️ Bucket events by Y-m-d, repeating multi-day events on each day they span.
 $byDate = [];
 foreach ($events as $ev) {
@@ -73,14 +89,23 @@ $months = [
 ];
 
 /**
- * Decide the cell background colour for a day. If any multi-day event
- * covers the day, use its category colour. Otherwise, weekend cells
- * get a Sat/Sun tint. Plain weekdays get no background.
+ * Decide the cell appearance for a day.
+ *
+ * Walks the day's events in order and picks the first one whose category has
+ * `displayStyle = 'background'` to drive a tinted cell bg. Categories with
+ * `displayStyle = 'text'` (e.g. Bank Holidays, Notable Days) never tint the
+ * background — they only colour the event text inside the cell.
+ *
+ * If no event triggers a bg tint, weekend cells get Sat/Sun tint.
  *
  * @return array{bg:?string,isWeekend:bool}
  */
 $cellBg = static function (array $dayEvents, DateTimeImmutable $dt) use ($cleanHex): array {
     foreach ($dayEvents as $ev) {
+        $style = (string) ($ev['categoryDisplayStyle'] ?? 'background');
+        if ($style !== 'background') {
+            continue;   // text-style events don't tint the cell
+        }
         $c = $cleanHex($ev['categoryColor'] ?? null);
         if ($c !== null) {
             return ['bg' => $c, 'isWeekend' => false];
@@ -106,10 +131,21 @@ $cellBg = static function (array $dayEvents, DateTimeImmutable $dt) use ($cleanH
         <div class="portal-cal-yearplan-legend mb-2">
             <strong class="small text-muted me-2">Key:</strong>
             <?php foreach ($legendCats as $cat): ?>
+                <?php
+                $catColor = (string) $cleanHex($cat['color']);
+                $catStyle = (string) ($cat['displayStyle'] ?? 'background');
+                ?>
                 <span class="portal-cal-yearplan-legend-item">
-                    <span class="portal-cal-yearplan-legend-swatch"
-                          style="background: <?php echo $esc((string) $cleanHex($cat['color'])); ?>;"></span>
-                    <?php echo $esc((string) $cat['categoryName']); ?>
+                    <?php if ($catStyle === 'text'): ?>
+                        <span class="portal-cal-yearplan-legend-text"
+                              style="color: <?php echo $esc($catColor); ?>; font-weight: 600;">
+                            <?php echo $esc((string) $cat['categoryName']); ?>
+                        </span>
+                    <?php else: ?>
+                        <span class="portal-cal-yearplan-legend-swatch"
+                              style="background: <?php echo $esc($catColor); ?>;"></span>
+                        <?php echo $esc((string) $cat['categoryName']); ?>
+                    <?php endif; ?>
                 </span>
             <?php endforeach; ?>
         </div>
@@ -121,10 +157,16 @@ $cellBg = static function (array $dayEvents, DateTimeImmutable $dt) use ($cleanH
 
             <!-- Header row: month names (each spans 2 sub-columns) -->
             <?php foreach ($months as $monthNum => $monthName): ?>
+                <?php $strap = $monthThemes[$monthNum] ?? ''; ?>
                 <a href="/calendar?view=month&amp;date=<?php echo $year; ?>-<?php echo sprintf('%02d', $monthNum); ?>-01"
                    class="portal-cal-yearplan-monthhead"
                    style="grid-column: span 2;">
-                    <?php echo $esc($monthName); ?>
+                    <span class="portal-cal-yearplan-monthhead-name"><?php echo $esc($monthName); ?></span>
+                    <?php if ($strap !== ''): ?>
+                        <span class="portal-cal-yearplan-monthhead-strap">
+                            <?php echo $esc($strap); ?>
+                        </span>
+                    <?php endif; ?>
                 </a>
             <?php endforeach; ?>
 
@@ -188,10 +230,14 @@ $cellBg = static function (array $dayEvents, DateTimeImmutable $dt) use ($cleanH
                         <?php if (count($dayEv) > 0): ?>
                             <ul class="portal-cal-yearplan-events">
                                 <?php foreach ($dayEv as $ev): ?>
-                                    <?php $evColor = $cleanHex($ev['categoryColor'] ?? null); ?>
-                                    <li>
+                                    <?php
+                                    $evColor = $cleanHex($ev['categoryColor'] ?? null);
+                                    $evStyle = (string) ($ev['categoryDisplayStyle'] ?? 'background');
+                                    $textColored = ($evStyle === 'text' && $evColor !== null);
+                                    ?>
+                                    <li class="<?php echo $textColored === true ? 'is-text-style' : ''; ?>">
                                         <a href="/calendar/event?slug=<?php echo $esc((string) $ev['eventSlug']); ?>"
-                                           <?php if ($evColor !== null): ?>style="--ev-color: <?php echo $esc($evColor); ?>;"<?php endif; ?>
+                                           <?php if ($evColor !== null): ?>style="--ev-color: <?php echo $esc($evColor); ?>;<?php echo $textColored === true ? ' color: ' . $esc($evColor) . '; font-weight: 600;' : ''; ?>"<?php endif; ?>
                                            title="<?php echo $esc((string) $ev['eventName']); ?>">
                                             <?php echo $esc((string) $ev['eventName']); ?>
                                         </a>

--- a/web/sql/043_calendar_categories_and_month_themes.sql
+++ b/web/sql/043_calendar_categories_and_month_themes.sql
@@ -1,0 +1,51 @@
+-- =============================================================================
+-- 043 — Calendar categories: colour + display style, plus per-month themes
+-- =============================================================================
+-- Two related additions to the calendar app (follow-up to #136 / PR #137):
+--
+--   1. `tblEventCategories.color` + `tblEventCategories.displayStyle`
+--      Categories can now carry a colour (hex) and choose how that colour
+--      renders in the year planner:
+--        - 'background' (default) → tinted cell behind the event text
+--        - 'text'                 → coloured text on default background
+--      This lets sites style Bank Holidays / notable days as coloured text
+--      while reserving the tinted-band look for organisational scopes
+--      (Area, Conference, Union, etc.).
+--
+--   2. `tblCalendarMonthThemes` (new table)
+--      Per-year-per-month "strap line" / theme text that appears under
+--      the month name on the year-planner view (e.g. "~Healthy connections~"
+--      for February). One row per (site, year, month).
+-- =============================================================================
+
+-- 🎨 Categories: add colour + display style ----------------------------------
+ALTER TABLE `tblEventCategories`
+    ADD COLUMN `color` VARCHAR(9) DEFAULT NULL
+        COMMENT 'Hex colour (#RRGGBB or #RRGGBBAA) used by the year planner / month grid'
+        AFTER `sortOrder`,
+    ADD COLUMN `displayStyle` ENUM('background','text') NOT NULL DEFAULT 'background'
+        COMMENT 'How the colour renders in the year planner: background tint vs. text colour'
+        AFTER `color`;
+
+-- 🗓️ Per-month theme / strap line --------------------------------------------
+CREATE TABLE IF NOT EXISTS `tblCalendarMonthThemes` (
+    `themeID`    INT          NOT NULL AUTO_INCREMENT,
+    `siteID`     INT          NOT NULL COMMENT 'FK → tblSites',
+    `year`       SMALLINT     NOT NULL COMMENT 'e.g. 2026',
+    `month`      TINYINT      NOT NULL COMMENT '1..12',
+    `themeText`  VARCHAR(255) NOT NULL COMMENT 'Strap-line shown under the month name on /calendar?view=year',
+    `createdAt`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`themeID`),
+    UNIQUE KEY `uq_cmt_site_year_month` (`siteID`, `year`, `month`),
+    KEY `idx_cmt_site_year` (`siteID`, `year`),
+    CONSTRAINT `fk_cmt_site` FOREIGN KEY (`siteID`)
+        REFERENCES `tblSites` (`siteID`) ON DELETE CASCADE,
+    CONSTRAINT `chk_cmt_month` CHECK (`month` BETWEEN 1 AND 12)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Per-year-per-month strap-line shown on the calendar year planner.';
+
+-- 🛣️ Route for the new admin page --------------------------------------------
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('calendar/manage/month-themes', 'calendar/manage/month-themes.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -562,6 +562,9 @@ CREATE TABLE IF NOT EXISTS `tblEventCategories` (
     `categoryName` VARCHAR(150) NOT NULL,
     `categorySlug` VARCHAR(100) NOT NULL COMMENT 'URL-safe slug',
     `sortOrder`    INT          NOT NULL DEFAULT 0,
+    `color`        VARCHAR(9)   DEFAULT NULL COMMENT 'Hex colour (#RRGGBB or #RRGGBBAA) for the year planner / month grid',
+    `displayStyle` ENUM('background','text') NOT NULL DEFAULT 'background'
+                   COMMENT 'How the colour renders in the year planner: tinted background vs. coloured text',
     `isActive`     TINYINT(1)   NOT NULL DEFAULT 1,
     `createdAt`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`categoryID`),
@@ -574,6 +577,27 @@ CREATE TABLE IF NOT EXISTS `tblEventCategories` (
         REFERENCES `tblSites` (`siteID`)
 ) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
 COMMENT='Event categories with nested sub-categories.';
+
+-- -----------------------------------------------------------------------------
+-- 🗓️ tblCalendarMonthThemes — per-year-per-month strap-line shown on the
+--    year planner (e.g. "~Healthy connections~" for February 2026).
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS `tblCalendarMonthThemes` (
+    `themeID`    INT          NOT NULL AUTO_INCREMENT,
+    `siteID`     INT          NOT NULL COMMENT 'FK → tblSites',
+    `year`       SMALLINT     NOT NULL,
+    `month`      TINYINT      NOT NULL COMMENT '1..12',
+    `themeText`  VARCHAR(255) NOT NULL,
+    `createdAt`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`  DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`themeID`),
+    UNIQUE KEY `uq_cmt_site_year_month` (`siteID`, `year`, `month`),
+    KEY `idx_cmt_site_year` (`siteID`, `year`),
+    CONSTRAINT `fk_cmt_site` FOREIGN KEY (`siteID`)
+        REFERENCES `tblSites` (`siteID`) ON DELETE CASCADE,
+    CONSTRAINT `chk_cmt_month` CHECK (`month` BETWEEN 1 AND 12)
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_unicode_ci
+COMMENT='Per-year-per-month strap-line shown on the calendar year planner.';
 
 
 -- -----------------------------------------------------------------------------
@@ -1661,6 +1685,10 @@ VALUES ('calendar/manage/types', 'calendar/manage/types.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
+VALUES ('calendar/manage/month-themes', 'calendar/manage/month-themes.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
 VALUES ('calendar/export', 'calendar/export.php', 0)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
@@ -1884,6 +1912,9 @@ INSERT INTO `tblMigrations` (`filename`) VALUES ('041_password_policy_hardening.
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblMigrations` (`filename`) VALUES ('042_calendar_default_view.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('043_calendar_categories_and_month_themes.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 -- Seed the branding.hidePoweredBy setting (matches migration 038)


### PR DESCRIPTION
## Summary

Picks up the two follow-ups I deferred from PR #137 — the wall-planner refinements that referenced the example screenshot you shared.

> **Stacked PR**: based on `feat/calendar-view-modes` (PR #137), not `main`. When #137 merges, this PR's base will auto-fast-forward to `main`.

### What's new

1. **Per-month strap-lines / themes** on the year planner (e.g. *"~Healthy connections~"* under February).
   - New table `tblCalendarMonthThemes` (siteID, year, month, themeText) with a unique index on `(site, year, month)`.
   - New admin page at `/calendar/manage/month-themes` — pick a year, fill in (or clear) the 12 inputs, save.
   - Rendered as an italicised strap-line beneath each month name on `/calendar?view=year`.

2. **`tblEventCategories.color` + `tblEventCategories.displayStyle`**
   - **`color`** — hex `#RRGGBB` (or `#RRGGBBAA`) used by the year planner and month grid.
   - **`displayStyle`** — `'background'` (default) renders the colour as a tinted band behind the event text; `'text'` colours the event name in place without filling the cell. Matches how the reference planner flags Bank Holidays / Notable Days as just coloured text.
   - Category management UI (`/calendar/manage/types`) now exposes both fields on the add form **and** as an inline editor on every existing category row.

### Files

```text
web/sql/043_calendar_categories_and_month_themes.sql
web/sql/full_schema.sql                              — schema + route seeds
web/public_html/calendar/index.php                   — router pulls displayStyle
web/public_html/calendar/manage/index.php            — links to new admin pages
web/public_html/calendar/manage/types.php            — colour + style on form & rows
web/public_html/calendar/manage/month-themes.php     — new admin page (CSRF + admin-gated)
web/public_html/calendar/views/year.php              — strap-lines + displayStyle aware rendering
web/public_html/assets/css/portal.css                — strap-line typography + text-style accents
CHANGELOG.md                                         — [Unreleased] entry
```

### Security

Pre-commit grep sweep — all clean:

- All `style="..."` colour interpolations are regex-validated as hex (`/^#[0-9a-fA-F]{3,8}$/`) **before** persistence **and** htmlspecialchars-escaped on output. No CSS-injection vector via crafted category colours.
- `/calendar/manage/month-themes` verifies CSRF and gates on `App::isAdmin()` before any DB write.
- All SQL uses prepared statements + `bind_param`; no interpolation.

### Test plan

- [ ] Run migration `043_calendar_categories_and_month_themes.sql`.
- [ ] Visit `/calendar/manage/types`: confirm the add-category form has a colour picker + style dropdown; existing rows show an inline editor that saves correctly.
- [ ] Set one category to `displayStyle = text` (e.g. "Bank Holidays"). On `/calendar?view=year`, confirm the event renders as coloured **text** with no cell tint.
- [ ] Set another category to `displayStyle = background` (e.g. "Area 8"). Confirm the cell renders as a tinted band on every covered day.
- [ ] Visit `/calendar/manage/month-themes`, fill in a few months, save. Confirm the strap-lines appear under the month names on `/calendar?view=year`.
- [ ] Clear a strap-line by submitting an empty input → confirm the row is deleted and the cell goes back to default.
- [ ] Toggle dark mode → confirm tints + strap-line typography remain legible.

🤖 Generated with [Claude Code](https://claude.com/claude-code)