### PR TITLE
docs: comprehensive sweep — FEATURES.md + README/DEV_NOTES/CLAUDE.md + in-app help + wiki

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -4,34 +4,58 @@
 
 Internal portal platform (PHP 8.5, backward-compatible with 8.4, MySQL 8.0, Bootstrap 5.3.3) hosted on DreamHost shared hosting. No CLI, no Composer.
 
-- **Version:** 0.9.0
+- **Version:** 0.11.0 (on `main`)
 - **Licence:** All Rights Reserved — MWBM Partners Ltd (t/a MWservices)
 - **Repo:** github.com/MWBMPartners/WebMS-Intra
 - **Server:** portal.millrdsdacambridge.uk
 - **Full brief:** `.claude/ProjectBrief_Chat.claude`
+- **Living feature inventory:** [FEATURES.md](../FEATURES.md) (always check this first)
+- **Chronological history:** [CHANGELOG.md](../CHANGELOG.md)
+- **Dev-facing technical notes:** [DEV_NOTES.md](../DEV_NOTES.md)
 
 ## Directory Layout
 
 ```
 repo root/          <- NOT deployed (docs, CI/CD only)
-web/                <- ALL deployable files (synced to server via FTP)
-  core/             <- Framework classes (Portal\Core namespace)
-  vendor/           <- Vendored libs (simplejwt)
-  sql/              <- Numbered SQL migrations
+web/                <- ALL deployable files (synced to server via SFTP)
+  core/             <- Framework classes (Portal\Core namespace, 26 classes)
+  vendor/simplejwt/ <- Vendored RS256 JWT verifier
+  sql/              <- Numbered SQL migrations (000-043 + full_schema.sql)
+  lang/             <- I18n translation files (en.php, cy.php, …)
   public_html/      <- Web root: front controller + assets + app controllers
     index.php, .htaccess, assets/
-    auth/           <- Login, forgot/reset password, account
-    dashboard/      <- Portal home
-    expenses/       <- Expense claim lifecycle
-    help/           <- Help centre
-    settings/       <- Admin settings
+  public_html_dev/  <- Dev web root (Gatekeeper-protected)
+  public_html_beta/ <- Beta web root
+  private_html/, public_html_landing/, public_html_redir/  <- non-app server dirs
+  _auth_keys/       <- Credentials + encryption key (gitignored, server-managed)
+  _uploads/         <- User file uploads (gitignored, server-managed)
+  _backups/         <- Server snapshots (gitignored, server-managed)
+  _libraries/       <- Server-managed libs incl. dompdf 3.1.5
+install/            <- Standalone 6-step installation wizard (bootstrap-free)
 ```
 
-## Apps
+## Apps (shipped on `main`)
 
-- Calendar/Events/Preaching Plan is ONE single app ("Events")
-- Calendar = viewing/listing/subscribing; Preaching Plan = worship service event types
-- Each app lives at `web/public_html/{appname}/`
+| Slug | Route | What it does |
+| --- | --- | --- |
+| dashboard | `/dashboard` | Portal home with app cards |
+| admin | `/admin` | Users, errors, activity, audit, migrations, integrations, sites, workflows, reports, **captcha config** |
+| auth | `/auth/*` | Local + MS365 + Google + WebAuthn + 2FA TOTP; password policy + strength meter |
+| calendar | `/calendar` | Events, series, RSVP, exports; **seven view modes in flight via #137/#138** |
+| prayer-requests | `/prayer-requests` | Logged-in + anonymous public submission, moderation, lifecycle |
+| attendance | `/attendance` | Sessions, headcount by service type, reports, CSV |
+| expenses | `/expenses` | Submit, approve, treasury, withdraw, multi-approver, PDF, CSV |
+| leadership | `/leadership` | Roles + assignments + history + CSV |
+| announcements | `/announcements` | Per-site noticeboard |
+| documents | `/documents` | File library with categories |
+| tasks | `/tasks` | Reminders / task list |
+| api | `/api/*` | Read-only JSON endpoints (attendance, announcements, users, events) |
+| settings | `/settings` | Generic dot-notation settings editor |
+| help | `/help/*` | In-app guides (getting-started, expenses, calendar, prayer-requests, admin, faq, …) |
+| site | `/site` | Multi-site switcher handler |
+| offline | `/offline` | PWA offline fallback |
+
+Calendar/Events/Preaching Plan is ONE app ("Events") — `/calendar` covers viewing/listing/subscribing; the manage UI handles preaching-plan/worship event types and series.
 
 ## Code Style (MUST FOLLOW)
 
@@ -52,15 +76,27 @@ web/                <- ALL deployable files (synced to server via FTP)
 - `PORTAL_APPS` -- web/public_html/
 - `PORTAL_VENDOR` -- web/vendor/
 - `PORTAL_SQL` -- web/sql/
-- `PORTAL_ENV` -- 'dev' or 'prod'
+- `PORTAL_ENV` -- 'dev', 'beta', or 'prod' (auto-detected from DOCUMENT_ROOT)
+
+## Recent ships (chronological)
+
+- **PR #129** — Prayer Requests app (logged-in + anonymous public route)
+- **PR #130** — Multi-provider Captcha (Turnstile / reCAPTCHA v2+v3 / hCaptcha) with admin priority drag-and-drop
+- **PR #131** — Release prep v0.11.0 (version bump + CHANGELOG stamp)
+- **PR #132** — Password policy hardening (#53) — min 12 chars, full-flow coverage, JS strength meter
+- **PR #133** — Debug mode refused in production (#54), error display silenced
+- **PR #134** — Deploy `dry_run` workflow_dispatch + DEV_NOTES SFTP `--delete` docs (#107)
+- **PR #135** — Anchor colour bound to `--bs-link-color` for both themes (was leaking browser-default blue)
+- **PR #137** (in flight) — Calendar seven view modes (closes #136)
+- **PR #138** (in flight) — Calendar per-month strap-lines + category display-style toggle
 
 ## GitHub Labels
 
 - `type:` -- feature, enhancement, bug, security, docs, infrastructure, refactor
 - `priority:` -- critical, high, medium, low
 - `scope:` (blue) -- core, admin, auth, ui, i18n (cross-cutting concerns)
-- `app:` (salmon) -- calendar, attendance, expenses, admin, dashboard, help, settings
-- `phase:` (purple) -- 3 through 9
+- `app:` (salmon) -- calendar, attendance, expenses, admin, dashboard, help, settings, prayer-requests
+- `phase:` (purple) -- 3 through 13
 - `status:` -- blocked, in-progress, review
 
 ## Standing Instructions (per ProjectBrief)
@@ -69,14 +105,15 @@ When making changes:
 
 1. Create a GitHub Issue with description, scope, and acceptance criteria
 2. Run ALL code through syntax/lint checks -- fix ALL issues until zero remain
-3. Update CHANGELOG.md, DEV_NOTES.md, README.md
+3. Update CHANGELOG.md, **FEATURES.md**, DEV_NOTES.md, README.md as appropriate
 4. Update `.claude/` memory and context
 5. Update GitHub Wiki/Project/Milestones alongside Issues
-6. COMMIT changes (DO NOT PUSH -- user pushes manually)
-7. Close GitHub Issue with commit reference
+6. COMMIT changes (DO NOT PUSH unless the user explicitly asks for a PR)
+7. Close GitHub Issue with commit / PR reference
 
 ## Git Notes
 
 - macOS case-insensitive: use two-step rename for case changes
 - Never commit: `_auth_keys/`, `_uploads/`, `_backups/`, `_libraries/`, `.env`, `*.key`
 - Deploy workflow syncs `web/` only, excluding server-managed dirs
+- Shared dirs (`core/`, `vendor/`, `sql/`, `_includes/`, `_functions/`, `_libraries/`) mirror with `--delete` — manual server-side edits to these dirs vanish on the next deploy (see DEV_NOTES.md → Troubleshooting)

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -1028,6 +1028,201 @@ This was tracked in Issue #82.
 
 ---
 
+## Password policy & strength validation (#53 / PR #132)
+
+`Auth::validatePassword()` and `Auth::passwordPolicy()` are the canonical
+helpers — every password-set flow goes through them (reset, account
+change-password, admin user create / update, and the standalone installer
+which carries a self-contained copy).
+
+**Settings (all `auth.password.*`):**
+
+| Key | Default | Notes |
+| --- | --- | --- |
+| `minLength` | `12` | Bumped from 8 in migration 041 (OWASP ASVS L1) |
+| `maxLength` | `128` | Defence against pathological inputs; bcrypt truncates at 72 anyway |
+| `requireUppercase` | `true` | Independent of lowercase since #132 |
+| `requireLowercase` | `true` | New flag — previously implicit |
+| `requireNumber` | `true` | |
+| `requireSpecial` | `true` | Any non-alphanumeric |
+
+`Auth::passwordPolicy()` returns the active policy as a structured array
+(rules list + min/max + required flags) so password forms can render
+hints consistently. Forms also wire up the JS strength meter via the
+`data-portal-password-input` + `data-portal-password-meter` attributes —
+`portal.js` attaches the meter on every matching input; the installer
+ships an inline copy because it loads before `bootstrap.php`.
+
+**5-step score** mirrors the server policy:
+
+- +1 length ≥ minLength
+- +1 contains lowercase
+- +1 contains uppercase
+- +1 contains digit
+- +1 contains symbol
+
+Bands: 0-1 Very weak (red), 2 Weak (red), 3 Fair (warning), 4 Strong
+(info), 5 Very strong (success).
+
+---
+
+## Multi-provider Captcha (#130)
+
+`Portal\Core\Captcha` accepts three providers — Cloudflare Turnstile,
+Google reCAPTCHA (v2 checkbox or v3 invisible-score), and hCaptcha — and
+picks the active one based on an admin-configurable priority list.
+
+**Settings:**
+
+- `auth.captcha.priority` — comma-separated provider keys
+  (default `turnstile,recaptcha,hcaptcha`); the first one with **both**
+  site + secret keys configured wins.
+- `auth.turnstile.{siteKey,secretKey}`
+- `auth.recaptcha.{siteKey,secretKey,version}` (version = `v2` or `v3`)
+- `auth.recaptcha.v3.{action,threshold}` (default action `submit`,
+  threshold `0.5`)
+- `auth.hcaptcha.{siteKey,secretKey}`
+
+**Public API (unchanged contract from previous Captcha class):**
+
+```php
+Captcha::scriptTag()          // <script> tag(s) for the active provider
+Captcha::widget()             // widget markup (or invisible hidden input for v3)
+Captcha::verify($_POST)       // server-side verification
+Captcha::isConfigured()       // true if at least one provider is wired up
+Captcha::activeProvider()     // 'turnstile' | 'recaptcha' | 'hcaptcha' | ''
+Captcha::listProviders()      // for the admin UI
+Captcha::normalisePriority()  // for the admin save handler
+```
+
+**Admin UI** lives at `/admin/captcha` — SortableJS-powered drag-and-drop
+priority list + per-provider key inputs + v2/v3 toggle + action / score
+threshold inputs for v3.
+
+**reCAPTCHA v3 verification** enforces **both** action match (anti-replay)
+and score threshold; rejections are logged via `Logger::activity()` as
+`CaptchaRejected` so probing surfaces in the activity log.
+
+---
+
+## Debug mode hardening (#54 / PR #133)
+
+`Debug::isEnabled()` and `App::isDebug()` both refuse to enable debug
+mode when `PORTAL_ENV === 'prod'`, regardless of admin status or query
+params. Defence-in-depth:
+
+1. `Debug::isEnabled()` — returns false in prod; `Debug::renderPanel()`
+   is already gated on it. Attempts in prod are logged once per request
+   as `DebugBlocked` activity (IP + path).
+2. `App::isDebug()` — same prod refusal. The global exception handler
+   in `bootstrap.php` already routes detailed traces through
+   `App::isDebug()`, so stack traces / file paths can never leak in
+   prod even on unhandled exceptions.
+3. `bootstrap.php` — forces `display_errors`, `display_startup_errors`,
+   and `html_errors` to `'0'` in prod. `error_reporting(E_ALL)` stays
+   on so `Logger::phpError()` continues to capture everything.
+
+---
+
+## Anchor / link colour theme binding (PR #135)
+
+`portal.css` binds `--portal-link` (and its hover / RGB variants) to
+Bootstrap's `--bs-link-color`, `--bs-link-color-rgb`,
+`--bs-link-hover-color`, and `--bs-link-hover-color-rgb` in both the
+light `:root` and `[data-bs-theme="dark"]` blocks. Without these
+bindings, every plain `<a>` / `.btn-link` / `.alert-link` / `.link-*`
+falls back to the browser-default blue, which clashes hard in dark mode.
+
+`install/index.php` mirrors the same binding in its self-contained
+inline `<style>` block because the installer doesn't load `portal.css`.
+
+Per-site branding still flows through: `--portal-link` resolves to
+`--portal-primary`, which `Site::branding()` overrides on
+`<html style="--portal-primary: …">`, so anchor colour follows the
+site's primary colour automatically.
+
+---
+
+## Calendar view modes (#136 / PRs #137 #138)
+
+`web/public_html/calendar/index.php` is a thin **view router**. It:
+
+1. Validates `?view=` against the whitelist
+   (`day | week | weekdays | weekend | month | year | list`).
+2. Resolves a visible date range from `?date=YYYY-MM-DD`
+   (or `YYYY-MM`, `YYYY`, falling back to today on parse failure).
+3. Fetches every event overlapping that range in **one** query
+   (no per-cell N+1).
+4. Delegates rendering to a per-view partial under `views/`.
+
+**View partials (under `web/public_html/calendar/views/`):**
+
+- `_shared_header.php` — date navigation (◀ Today ▶ + date picker),
+  view switcher, filter row.
+- `_day_columns.php` — **one** hour-timeline renderer reused by day /
+  week / weekdays / weekend, parametrised by column count. Events
+  position absolutely by start time and clip to each column's
+  `[00:00, 24:00]` window. All-day events strip above the timeline.
+- `day.php`, `week.php`, `weekdays.php`, `weekend.php` — thin wrappers
+  around `_day_columns.php` with their own day list.
+- `month.php` — 7-column 5/6-row calendar grid; up to 3 event pills
+  per cell + "+ N more" link to day view.
+- `year.php` — 12-month wall planner. 24-column grid (12 months ×
+  day-number + content sub-columns), 31 day rows, blank cells where
+  months are shorter. Multi-day event bands repeat on every covered
+  day so they read as continuous strips. Auto-built legend with
+  category swatches at the top.
+- `list.php` — the original chronological card grid.
+
+**Settings:** `calendar.defaultView` (default `month`).
+**Per-user:** `localStorage['portal-calendar-view']` remembers the
+last-used view across visits; URL `?view=` always wins.
+
+**Category styling (#138):** `tblEventCategories.color` (hex,
+regex-validated server-side) drives event background tints AND a
+left-border accent. `tblEventCategories.displayStyle` toggles between
+`'background'` (tinted band — default) and `'text'` (coloured text
+on default background — used for Bank Holidays / Notable Days that
+should flag a day rather than fill it).
+
+**Per-month strap-lines (#138):** `tblCalendarMonthThemes` stores one
+text line per `(siteID, year, month)`. Rendered as an italicised
+strap-line under each month name on the year planner. Managed via
+`/calendar/manage/month-themes` (year picker + 12 inputs; empty
+values delete the row).
+
+**Security:** all colour values are hex-validated by regex
+(`/^#[0-9a-fA-F]{3,8}$/`) **before** persistence **and**
+`htmlspecialchars`-escaped on output, blocking CSS injection via
+crafted category colours.
+
+---
+
+## Prayer Requests (#129)
+
+Self-contained app at `/prayer-requests/`. Single table
+(`tblPrayerRequests`) with status lifecycle
+(`pending → active → answered → archived`) and visibility flag
+(`leadership | congregation`).
+
+Anonymous public submission lives at `/prayer-requests/anonymous` —
+no login required — and is gated by:
+
+1. **CSRF** — session token issued by the GET form, verified on POST.
+2. **Captcha** — whichever provider is active per the
+   `auth.captcha.priority` setting (see above).
+3. **RateLimiter** — same per-IP limiter used by the login form.
+4. Hard-coded to `visibility = leadership` and `status = pending`
+   (anonymous submissions never broadcast directly to the congregation).
+5. Always redirects to the same generic success page so abusers can't
+   fingerprint success vs failure.
+
+Logged-in submitters get a "display as Anonymous" toggle — members
+see "Anonymous", but the moderation queue still shows the real
+submitter for pastoral follow-up.
+
+---
+
 ## Troubleshooting
 
 ### "CSRF" error on form submission

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -1,0 +1,412 @@
+# WebMS Intra — Features
+
+> **Living working summary.** Kept current alongside the codebase. Refer to
+> [CHANGELOG.md](CHANGELOG.md) for chronological history and to [README.md](README.md)
+> for setup, deployment, and licence info.
+>
+> **Snapshot:** 2026-05-22 · **Version on `main`:** 0.11.0
+> · **In-flight branches:** `feat/calendar-view-modes` (PR #137),
+> `feat/calendar-themes-and-display-style` (PR #138)
+
+---
+
+## How to read this document
+
+- **Status legend**
+  - ✅ **Shipped** — on `main`, available to users.
+  - 🛠️ **In flight** — open PR; behaviour described is the proposed state.
+  - 🟡 **Partial** — works in some flows but has known gaps.
+  - 🔜 **Planned** — tracked by a GitHub issue but not started.
+- Each section names the **routes**, **DB tables**, and **settings** involved
+  so you can locate the implementation quickly.
+- Anything marked 🛠️ here will move to ✅ when the named PR merges; the
+  description should not need to change.
+
+---
+
+## Core framework (`web/core/`)
+
+Foundational classes loaded by every request via `bootstrap.php`. All ✅.
+
+| Class | Purpose |
+| --- | --- |
+| `App` | Service registry — `db()`, `settings()`, `user()`, `isAdmin()`, `siteId()`, transaction helpers |
+| `Auth` | Sessions, CSRF, local + MS365 + Google OAuth + WebAuthn, password policy, 2FA TOTP, account linking |
+| `Router`, `ApiRouter` | Front-controller URL dispatch + dedicated JSON API dispatch |
+| `Site` | Multi-site context — detection, branding, per-site settings overrides |
+| `Captcha` | Provider-agnostic — Turnstile / reCAPTCHA v2+v3 / hCaptcha with admin-configurable priority |
+| `Mailer`, `MailerGoogle` | Microsoft Graph "SendAs" + Google Workspace SendAs |
+| `ExpenseMailer`, `ExpensePdf`, `Pdf` | Expense email notifier, PDF generator, dompdf wrapper |
+| `Logger` | Activity + error logging into `tblActivityLogs` / `tblErrors` |
+| `Migrator` | Web-based SQL migration runner |
+| `Validator` | Pipe-separated rule validator (`required|email|min:8|…`) |
+| `Asset` | CDN-with-local-fallback loader with SRI |
+| `Avatar` | Cascade: MS365 → local → Gravatar → generated SVG |
+| `Gatekeeper` | Dev/beta channel access control |
+| `RateLimiter` | IP-based login + form rate limiting |
+| `I18n` | Translations, RTL, formatting helpers |
+| `Totp` | TOTP 2FA RFC 6238 implementation |
+| `WebAuthn` | Server-side WebAuthn / PassKeys helper |
+| `Container` | Lightweight DI container |
+| `CsvExporter` | Shared CSV export |
+| `ApiResponse` | JSON API response builder |
+| `Debug` | Debug panel — refuses in prod since #54 |
+
+---
+
+## Apps
+
+### 📊 Dashboard — `/dashboard/` ✅
+
+Portal home with brand banner, hero, app card grid.
+
+- Per-site brand colour + favicon drive the visual identity.
+- App cards link out to every enabled app on the site.
+
+---
+
+### 🛡️ Admin — `/admin/` ✅
+
+Central operations hub for admins / site admins.
+
+| Route | What it does |
+| --- | --- |
+| `/admin` | Dashboard with summary cards (errors, users, activity, pending migrations) |
+| `/admin/users` + `/users/import` + `/users/export` | User CRUD + CSV bulk import + export |
+| `/admin/errors` | Error log viewer (`tblErrors`) |
+| `/admin/activity` + `/activity/export` | Activity log viewer + CSV export |
+| `/admin/audit` | Before/after change tracking (#91) |
+| `/admin/migrations` | Web-based migration runner |
+| `/admin/integrations` | Live integration diagnostics (MS365 OAuth/Graph, Google OAuth/Gmail) |
+| `/admin/sites` | Umbrella admin: site CRUD + per-site user management |
+| `/admin/workflows` | Configurable workflow engine config (#94) |
+| `/admin/reports` | Reporting / analytics dashboard (#93) |
+| `/admin/captcha` | **Multi-provider captcha config — drag-and-drop priority + per-provider keys (#130)** |
+| `/settings` | Generic dot-notation settings editor |
+
+---
+
+### 🔐 Auth — `/auth/` ✅
+
+Local + SSO + multi-factor sign-in.
+
+| Flow | Status |
+| --- | --- |
+| Local username + password login | ✅ |
+| MS365 OAuth (PKCE + ID-token validation) | ✅ |
+| Google OAuth | ✅ |
+| WebAuthn / PassKey registration + login | ✅ |
+| Forgot password → email reset link | ✅ |
+| Reset password (token verified, single-use) | ✅ |
+| Account page (profile, change password, linked accounts, WebAuthn keys, unlink) | ✅ |
+| 2FA TOTP setup / verify / disable | ✅ |
+| **Password policy** — min 12 chars (configurable), independent complexity flags, max length, **client-side strength meter** | ✅ (#132) |
+| Login rate limiting (IP-based currently; #52 wants composite IP+username) | 🟡 |
+
+**Tables:** `tblUsers`, `tblLocalAccounts`, `tblPasswordResets`, `tblLinkedAccounts`, `tblWebAuthnCredentials`, `tblUserTotp`
+**Settings:** `auth.password.minLength`, `auth.password.maxLength`, `auth.password.requireUppercase`, `auth.password.requireLowercase`, `auth.password.requireNumber`, `auth.password.requireSpecial`, `auth.passwordReset.tokenExpiry`, `auth.ms365.*`, `auth.google.*`, `auth.turnstile.*`, `auth.recaptcha.*`, `auth.hcaptcha.*`, `auth.captcha.priority`
+
+---
+
+### 📅 Calendar — `/calendar/` ✅ + 🛠️
+
+Events, series, RSVP, exports, and (in flight) seven view modes.
+
+**Shipped:**
+- Event CRUD with hero images, location, all-day support, public/featured flags.
+- Event series with bulk edit (#75).
+- Event categories + types (hierarchical, per-site).
+- Recurring rules: weekly / fortnightly / monthly / quarterly / yearly / custom.
+- RSVP system (#88) — capacity, waitlist, confirmation emails.
+- iCal export (`/calendar/export`).
+- Public + admin-managed views.
+
+**🛠️ In flight (PR #137 — closes #136):**
+- Seven view modes — `/calendar?view=day|week|weekdays|weekend|month|year|list`.
+- Day / Week / Weekdays / Weekend share an hour-timeline renderer parametrised by column count.
+- Month view as a 7-column grid with up to 3 event pills per cell + "+ N more".
+- Year planner as a 12-month-column wall planner (24-column grid; day-number + content sub-columns; weekend tints; multi-day event bands).
+- Date navigation, view-switcher buttons, filter row.
+- Last-used view persists in `localStorage`; admin sets `calendar.defaultView` (default `month`).
+- Events colour-coded by `tblEventCategories.color` (regex-validated server-side).
+
+**🛠️ In flight (PR #138 — stacked on #137):**
+- Per-month strap-line text under each month name on the year planner (`tblCalendarMonthThemes`).
+- `tblEventCategories.displayStyle` — `'background'` (default — tinted band) vs `'text'` (coloured text, no band) — matches how traditional planners flag Bank Holidays / Notable Days.
+- Admin pages: `/calendar/manage/types` (colour + style picker) and `/calendar/manage/month-themes`.
+
+**🔜 Open issues:**
+- #97–#103: BookIT calendar-provider abstraction (7-PR series).
+- #128: New Order of Service planner with iHymns integration (gated on iHymns permission).
+
+**Tables:** `tblEvents`, `tblEventCategories`, `tblEventTypes`, `tblEventSeries`, `tblEventThemes`, `tblEventRecurrence`, `tblEventRsvps`, `tblCalendarMonthThemes` (🛠️)
+**Settings:** `calendar.enabled`, `calendar.displayName`, `calendar.displayIcon`, `calendar.brandColor`, `calendar.defaultView`, `calendar.enablePublicView`, `calendar.allowRecurringEvents`
+
+---
+
+### 🙏 Prayer Requests — `/prayer-requests/` ✅ (#129)
+
+Per-site prayer-request submission with moderation and anonymous public submission.
+
+- Logged-in submissions with per-request visibility (leadership-only / congregation feed).
+- "Display as Anonymous" toggle (moderators still see who submitted).
+- Public anonymous route at `/prayer-requests/anonymous` (no login) — CSRF + CAPTCHA + RateLimiter; always pending, leadership-only.
+- Lifecycle: pending → active → answered (optional praise/testimony note) → archived.
+- Moderation queue at `/prayer-requests/manage`.
+- Help page at `/help/prayer-requests`.
+
+**Tables:** `tblPrayerRequests`
+**Settings:** `prayerRequests.enabled`, `prayerRequests.allowAnonymous`, `prayerRequests.allowCongregationFeed`, `prayerRequests.requireModeration`, `prayerRequests.allowTestimony`
+
+---
+
+### 📋 Attendance — `/attendance/` ✅
+
+Service-type-aware headcount tracker.
+
+- Sessions with date / time / event linkage / notes.
+- Counts split by service type (hierarchical: e.g. Worship → Sabbath School → Adult).
+- Filters by service type, date range; CSV export; trend reports.
+- Bulk session templates (#74).
+
+**Tables:** `tblAttendanceSessions`, `tblAttendanceCounts`, `tblAttendanceServiceTypes`
+
+---
+
+### 💷 Expenses — `/expenses/` ✅
+
+Full claim lifecycle with multi-approver, treasury, PDF, CSV.
+
+- Submit (`/expenses/submit`) — claim with line items, receipt uploads, auto-attached PDF.
+- Approve (`/expenses/approve`) — multi-approver workflow with comments.
+- Treasury (`/expenses/treasury`) — record reimbursement, payment reference.
+- Withdraw (`/expenses/withdraw`) — claimant can cancel pre-approval (#73).
+- View (`/expenses/view`) — claim detail + audit trail.
+- API endpoints: `/expenses/api/list`, `/expenses/api/export`.
+
+**🔜 Open issues:** #40 (Payment integration prep — design phase).
+
+**Tables:** `tblExpenseClaims`, `tblExpenseLines`, `tblExpenseAttachments`, `tblExpenseApprovals`, `tblExpenseStatuses`
+
+---
+
+### 👥 Leadership — `/leadership/` ✅
+
+Roles + assignments + history.
+
+- Hierarchical roles per site.
+- Assign / unassign users; history preserved (#70 fix: no CASCADE wipe).
+- Leadership transition workflow (#76).
+- CSV export.
+
+**Tables:** `tblLeadershipRoles`, `tblLeadershipAssignments`
+
+---
+
+### 📣 Announcements — `/announcements/` ✅ (#89)
+
+Per-site noticeboard.
+
+- Manage / view / save / delete.
+- Visibility windows (start + end dates).
+
+**Tables:** `tblAnnouncements`
+
+---
+
+### 📁 Documents — `/documents/` ✅ (#90)
+
+File library with categories.
+
+- Upload / download / delete; uploads land under `_uploads/`.
+- Category management.
+
+**Tables:** `tblDocuments`, `tblDocumentCategories`
+
+---
+
+### ✅ Tasks — `/tasks/` ✅ (#96)
+
+Reminder / task system.
+
+- Per-user assigned tasks with due dates.
+- Complete / dismiss actions.
+
+**Tables:** `tblTasks`, `tblTaskReminders`
+
+---
+
+### 🛰️ API — `/api/` 🟡
+
+Read-only JSON list endpoints over `Portal\Core\ApiRouter`.
+
+- `/api/attendance/list`
+- `/api/announcements/list`
+- `/api/users/list`
+- `/api/events/list`, `/api/events/detail`
+
+**Gaps:** #95 was closed as "REST API expansion — CRUD for all modules" but only list endpoints exist. Full CRUD would still be additional work.
+
+---
+
+### ⚙️ Settings — `/settings/` ✅
+
+Generic admin settings editor.
+
+- Auto-grouped by dot-notation prefix.
+- Sensitive values encrypted at rest (libsodium XSalsa20+Poly1305).
+- Site-scoped + global-default behaviour.
+
+**Tables:** `tblSettings`
+
+---
+
+### 📖 Help Centre — `/help/` ✅
+
+In-app documentation per app.
+
+| Page | Covers |
+| --- | --- |
+| `/help/getting-started` | Login, navigation, theme cycle, CB-safe palette, per-site branding |
+| `/help/expenses` | Submit, statuses, receipts, withdrawal |
+| `/help/approvals` | For approvers |
+| `/help/treasury` | For treasury staff |
+| `/help/admin` | Settings, user roles, site branding, captcha config (🛠️ to add: calendar views) |
+| `/help/translations` | Language + i18n |
+| `/help/prayer-requests` | Prayer requests lifecycle, anonymous route, moderation |
+| `/help/faq` | Common questions |
+
+---
+
+### 🌐 Site switcher — `/site/` ✅
+
+Multi-site handler. Switches `Site::id()` for the current session.
+
+---
+
+### ⛅ Offline — `/offline/` ✅
+
+PWA offline fallback page.
+
+---
+
+### 🛠️ Installer — `/install/` ✅
+
+Self-contained 6-step setup wizard (bootstrap-free).
+
+- Prerequisites check (PHP version, extensions, paths).
+- DB credentials + connection test.
+- Schema install from `full_schema.sql`.
+- Admin account creation — **enforces the same 12-char-min password policy as the rest of the portal (#132)**, with the client-side strength meter inline.
+- Encryption key generation.
+- Lock file written; further installation attempts blocked.
+
+---
+
+## Cross-cutting
+
+### 🎨 UI / Design system ✅ (Phase 11)
+
+- Linear-style indigo design tokens (`#5e6ad2`).
+- `color-mix()` derivations with hex fallbacks (Chrome <111 / Safari <16.2 / Firefox <113).
+- Three theme modes: light / dark / auto via `prefers-color-scheme`.
+- CB-safe palette toggle (Wong, Nature Methods 2011).
+- Per-site `Site::branding()` overrides `--portal-primary` and friends via inline style on `<html>`.
+- "Powered by WebMS Intra" attribution rule (Site::usesCustomBranding).
+- `<meta name="generator" content="WebMS Intra">` alongside footer attribution.
+- **Anchor colour now bound to `--portal-link` → `--bs-link-color` in both themes (#135)** — fixes browser-default blue leaking through in dark mode.
+
+### 🔒 Security
+
+| Item | Status |
+| --- | --- |
+| MySQLi prepared statements throughout | ✅ |
+| CSRF rotation after sensitive actions | ✅ |
+| Sensitive settings encrypted at rest (libsodium) | ✅ |
+| RS256 JWT verification with JWKS (MS365) | ✅ |
+| Session cookies: `HttpOnly`, `Secure`, `SameSite=Lax` | ✅ |
+| SRI integrity hashes on CDN resources | ✅ |
+| Security headers (CSP, X-Frame-Options, Referrer-Policy, Permissions-Policy, X-Content-Type-Options) | ✅ |
+| Password policy hardened (min 12, independent complexity, max length, full-flow validation) | ✅ (#132) |
+| Multi-provider Captcha with admin priority | ✅ (#130) |
+| Debug mode refused in production (logged, exception traces don't leak) | ✅ (#54) |
+| Login rate limiting on composite IP+username | 🔜 (#52) |
+| Signed commits enforced | 🔜 (#106) |
+| Prod secrets behind GitHub Environment + reviewer gate | 🔜 (#105) |
+| Privacy / GDPR helpers | 🔜 (#47) |
+| 2FA TOTP available | ✅ (#92) |
+
+### 🌍 Multi-site (Phase 10) ✅
+
+- Umbrella → sites → users with 4-tier permission hierarchy (Umbrella / Site Root / Site Admin / Legacy).
+- Detection modes: subdomain, path-prefix, session.
+- Per-site `tblSites.primaryColor` + `tblSites.faviconPath` drive branding.
+
+### 🌐 Internationalisation (Phase 8) ✅
+
+- `I18n` framework, translations under `web/lang/{xx}.php`.
+- RTL support.
+- Per-user language preference.
+- Date/time format settings (#69).
+
+### 🚀 CI/CD ✅
+
+- 3-branch SFTP deploy (alpha / beta / main) via `lftp`, SSH-key with password fallback.
+- `--delete` mirror on shared dirs (`core/`, `vendor/`, `sql/`, …) — see [DEV_NOTES.md → Troubleshooting](DEV_NOTES.md#troubleshooting) for survival rules.
+- `dry_run` `workflow_dispatch` input on `deploy.yml` for preview-mode deploys (#107).
+- `gitleaks` CLI for secret scanning (free MIT binary, not the licensed action).
+- Repo config audit workflow (#108).
+- `version-bump.yml`, `changelog.yml`, `release.yml`, `auto-merge-alpha.yml`.
+
+### 🧱 Stack baseline
+
+- PHP 8.5 (BC with 8.4), MySQL 8.0+, Apache + mod_rewrite, DreamHost shared.
+- Bootstrap 5.3.3, Font Awesome 6.5.1.
+- dompdf 3.1.5 (fetched at deploy time by `tools/download-dompdf.sh`).
+- Microsoft Graph for email + OAuth (SendAs from a shared mailbox).
+- Google Workspace ready (config slots present).
+- CloudFlare Turnstile preferred for captcha.
+
+---
+
+## Migrations on disk
+
+`web/sql/` contains numbered migrations 000-043. `full_schema.sql` is kept in sync so fresh installs are wired up out of the box.
+
+Latest additions:
+
+| # | What |
+| --- | --- |
+| 039 | Prayer Requests (#129) |
+| 040 | Multi-provider Captcha (#130) |
+| 041 | Password policy hardening (#132) |
+| 042 | Calendar `defaultView` setting (🛠️ #137) |
+| 043 | Calendar category colour + displayStyle, month themes (🛠️ #138) |
+
+---
+
+## In-flight PR stack
+
+| PR | Title | Status |
+| --- | --- | --- |
+| #137 | Calendar seven view modes (closes #136) | 🛠️ Open |
+| #138 | Calendar month themes + category display-style (stacked on #137) | 🛠️ Open |
+
+When these merge, the 🛠️ markers above flip to ✅ without further edits to this file — language is already written in the past tense.
+
+---
+
+## Tracked but not started
+
+| Issue | Scope |
+| --- | --- |
+| #127 | WordPress Multisite integration — design + phased implementation (3–4 weeks) |
+| #128 | Order of Service planner app + iHymns integration (gated on iHymns permission) |
+| #97–#103 | BookIT calendar-provider abstraction (7-PR series) |
+| #111 | UI refresh umbrella — practically done via PRs #114–#126; can likely be closed |
+| #52 | Login rate-limit composite IP+username |
+| #47 | Privacy & GDPR compliance helpers |
+| #40 | Payment integration prep |
+| #106 | Enforce signed commits |
+| #105 | Prod secrets behind GitHub Environment + reviewer gate |
+| #107 | SFTP `--delete` operational documentation (partially addressed by PR #134) |

--- a/README.md
+++ b/README.md
@@ -2,7 +2,9 @@
 
 > **Version:** 0.11.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
 
-A modular internal portal platform for organisations, providing centralised access to internal tools, expense management, leadership directory, multi-site support, and more.
+A modular internal portal platform for organisations, providing centralised access to internal tools, calendar / events, attendance, expenses, leadership directory, prayer requests, announcements, document library, tasks/reminders, multi-site support, and more.
+
+📋 **For the current per-app feature inventory** (what's shipped, what's in flight, what's planned with issue numbers), see **[FEATURES.md](FEATURES.md)**.
 
 ---
 
@@ -197,20 +199,31 @@ branch protection).
 
 ## Roadmap
 
+Phase-level milestones (granular per-feature state lives in [FEATURES.md](FEATURES.md)).
+
 | Phase | Description                                                                     | Status           |
 | ----- | ------------------------------------------------------------------------------- | ---------------- |
 | 1     | Core Framework                                                                  | Done             |
 | 2     | Local Auth Enhancement (forgot/reset password, account page, policy engine)     | Done             |
 | 2.5   | Directory Restructure (web/ consolidation, deploy fix, bug fixes)               | Done             |
 | 3     | Admin UI (error logs, activity logs, user management, migration runner)         | Done             |
-| 4     | Calendar / Events / Preaching Plan                                              | Done             |
+| 4     | Calendar / Events / Preaching Plan (incl. seven view modes — see #136/#137)     | Done             |
 | 5     | Attendance Tracker                                                              | Done             |
 | 6     | Expenses — Multi-Approver, Email, PDF, Treasury                                 | Done             |
 | 7     | SSO & Auth Enhancement (Google OAuth, WebAuthn/PassKeys, Account Linking)       | Done             |
 | 8     | Translations / i18n (I18n framework, RTL support, language switcher)            | Done             |
-| 9     | Polish & Hardening (PWA, WCAG 2.1, Security Hardening)                          | Done             |
+| 9     | Polish & Hardening (PWA, WCAG 2.1, Security Hardening — incl. #53 #54)          | Done             |
 | 10    | Multi-Site Support (umbrella orgs, site detection, 4-tier permissions)          | Done             |
 | 11    | UI Refresh + Design System (themes, CB-safe palette, per-site branding)         | Done             |
+| 12    | Prayer Requests app (incl. anonymous public route — #129)                       | Done             |
+| 13    | Multi-provider Captcha (Turnstile + reCAPTCHA v2/v3 + hCaptcha — #130)          | Done             |
+
+**Currently in flight (open PRs):**
+
+- **#137** — Calendar seven view modes (Day, Week, Weekdays, Weekend, Month, Year planner, List).
+- **#138** — Calendar per-month strap-lines + category `displayStyle` toggle (background-band vs text-only) — stacked on #137.
+
+**Tracked but not started:** WordPress Multisite integration (#127), Order of Service planner with iHymns (#128), BookIT integration cluster (#97–#103), composite IP+username login rate-limit (#52), Privacy / GDPR helpers (#47), Payment integration prep (#40). See [FEATURES.md](FEATURES.md#tracked-but-not-started) for the full backlog with scope notes.
 
 ---
 

--- a/web/public_html/help/admin.php
+++ b/web/public_html/help/admin.php
@@ -230,6 +230,64 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
     </div>
 </div>
 
+<!-- Section: Bot Protection / Captcha -->
+<div class="portal-card p-4 mb-4" id="captcha">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-robot me-2 text-primary"></i>Bot Protection (Captcha)</h2>
+
+    <p>
+        The portal supports three captcha providers, configured at
+        <a href="/admin/captcha">/admin/captcha</a>:
+    </p>
+    <ul>
+        <li><strong>Cloudflare Turnstile</strong> — privacy-friendly default, no challenge for most users.</li>
+        <li><strong>Google reCAPTCHA</strong> — v2 (visible checkbox) or v3 (invisible, score-based). Choose via the version dropdown.</li>
+        <li><strong>hCaptcha</strong> — privacy-friendly alternative to reCAPTCHA.</li>
+    </ul>
+
+    <h5 class="mt-3 mb-2">Priority ordering</h5>
+    <p>
+        Drag the providers in the priority list to set the fallback order. The active provider is the
+        <strong>first one in the list that has both site and secret keys configured</strong>. If nothing is
+        configured, the captcha is silently skipped (forms still submit; no challenge shown).
+    </p>
+
+    <h5 class="mt-3 mb-2">reCAPTCHA v3 specifics</h5>
+    <p>
+        When using reCAPTCHA v3, you can set an <strong>action name</strong> (default: <code>submit</code>)
+        and a <strong>score threshold</strong> (default: <code>0.5</code>). Server-side verification rejects
+        any token whose action doesn't match (anti-replay) or whose score falls below the threshold.
+    </p>
+    <p class="text-muted small">
+        Anonymous prayer-request submissions and the password-reset flow both use the active captcha provider — no per-form configuration needed.
+    </p>
+</div>
+
+<!-- Section: Password Policy -->
+<div class="portal-card p-4 mb-4" id="password-policy">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-shield-halved me-2 text-primary"></i>Password Policy</h2>
+
+    <p>
+        Configurable via <a href="/settings">Settings</a> under the <code>auth.password.*</code> prefix.
+        Defaults follow OWASP ASVS L1.
+    </p>
+
+    <div class="list-group list-group-flush">
+        <div class="list-group-item d-flex justify-content-between"><span><code>auth.password.minLength</code></span><strong>12</strong></div>
+        <div class="list-group-item d-flex justify-content-between"><span><code>auth.password.maxLength</code></span><strong>128</strong></div>
+        <div class="list-group-item d-flex justify-content-between"><span><code>auth.password.requireUppercase</code></span><strong>true</strong></div>
+        <div class="list-group-item d-flex justify-content-between"><span><code>auth.password.requireLowercase</code></span><strong>true</strong></div>
+        <div class="list-group-item d-flex justify-content-between"><span><code>auth.password.requireNumber</code></span><strong>true</strong></div>
+        <div class="list-group-item d-flex justify-content-between"><span><code>auth.password.requireSpecial</code></span><strong>true</strong></div>
+    </div>
+
+    <p class="mt-3 mb-0 text-muted small">
+        The policy is enforced server-side on every password-set flow: account change-password, password reset,
+        admin user create / update, and the installation wizard. A client-side strength meter (5-step Bootstrap
+        progress bar) appears on every password input as a visual aid; final validation always happens
+        server-side.
+    </p>
+</div>
+
 <!-- Section 2: User Roles -->
 <div class="portal-card p-4 mb-4" id="roles">
     <h2 class="h4 mb-3"><i class="fa-solid fa-users-gear me-2 text-primary"></i>User Roles</h2>

--- a/web/public_html/help/calendar.php
+++ b/web/public_html/help/calendar.php
@@ -1,0 +1,169 @@
+<?php
+// Path: public_html/help/calendar.php
+/**
+ * -----------------------------------------------------------------------------
+ * Help Centre — Calendar Guide 📅
+ * -----------------------------------------------------------------------------
+ * Walks members and admins through the seven calendar view modes, date
+ * navigation, filtering, and (for admins) categories, colours, display
+ * styles, and per-month strap-lines.
+ * -----------------------------------------------------------------------------
+ * @package    Portal\Help
+ * @license    All Rights Reserved
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+$pageTitle   = 'Help - Calendar';
+$pageSection = 'help';
+$breadcrumbs = ['Dashboard' => '/', 'Help' => '/help', 'Calendar' => ''];
+
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-calendar-days me-2"></i>Calendar Guide</h1>
+        <p class="text-secondary mb-0">View, filter, and (if you're an admin) configure the calendar's seven view modes.</p>
+    </div>
+    <a href="/help" class="btn btn-outline-secondary btn-sm mt-2 mt-md-0">
+        <i class="fa-solid fa-arrow-left me-1"></i>Back to Help Centre
+    </a>
+</div>
+
+<!-- 🧭 Table of contents -->
+<div class="card mb-4 border-0 bg-body-tertiary">
+    <div class="card-body">
+        <h6 class="card-title mb-2"><i class="fa-solid fa-list me-1"></i>On this page</h6>
+        <div class="d-flex flex-wrap gap-2">
+            <a href="#viewmodes" class="badge text-bg-secondary text-decoration-none">View modes</a>
+            <a href="#navigation" class="badge text-bg-secondary text-decoration-none">Navigation</a>
+            <a href="#filters" class="badge text-bg-secondary text-decoration-none">Filters</a>
+            <a href="#defaults" class="badge text-bg-secondary text-decoration-none">Default view</a>
+            <a href="#admin-categories" class="badge text-bg-secondary text-decoration-none">For admins — categories</a>
+            <a href="#admin-themes" class="badge text-bg-secondary text-decoration-none">For admins — month themes</a>
+        </div>
+    </div>
+</div>
+
+<!-- 1️⃣ View modes -->
+<section id="viewmodes" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-table-cells me-2"></i>The seven view modes</h2>
+    <p>The calendar landing page (<a href="/calendar">/calendar</a>) supports seven different views, each appropriate for a different scale of planning:</p>
+
+    <div class="portal-data-list">
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-calendar-day me-1"></i>Day</strong></div>
+            <div class="col-12 col-md-9">A single day's events on a vertical 24-hour timeline. Events with start times appear at the correct hour and span their duration; all-day events get a strip above the timeline.</div>
+        </div>
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-calendar-week me-1"></i>Week</strong></div>
+            <div class="col-12 col-md-9">Full 7-day grid Monday → Sunday, sharing the same hour timeline.</div>
+        </div>
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-briefcase me-1"></i>Weekdays (Mon-Fri)</strong></div>
+            <div class="col-12 col-md-9">Same timeline, working week only — useful when the weekend is noise.</div>
+        </div>
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-couch me-1"></i>Weekend (Sat-Sun)</strong></div>
+            <div class="col-12 col-md-9">Same timeline, weekend only — useful for worship-service and ministry-event planning.</div>
+        </div>
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-calendar me-1"></i>Month</strong></div>
+            <div class="col-12 col-md-9">7-column calendar grid for the chosen month. Each cell shows up to 3 event pills and a "+ N more" link to the day view if there are more.</div>
+        </div>
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-calendar-days me-1"></i>Year planner</strong></div>
+            <div class="col-12 col-md-9">12 month columns across, 31 day rows down — a wall-planner layout for the whole year at a glance. Multi-day events show as continuous coloured bands; weekend cells get a subtle tint.</div>
+        </div>
+        <div class="portal-data-row">
+            <div class="col-12 col-md-3"><strong><i class="fa-solid fa-list me-1"></i>List</strong></div>
+            <div class="col-12 col-md-9">Chronological card grid — the original list. Includes a "Show past events" toggle and pagination.</div>
+        </div>
+    </div>
+    <p class="text-muted small mt-3 mb-0">
+        Switch between views using the buttons at the top of the calendar page, or
+        directly via <code>?view=day</code>, <code>?view=week</code>, etc. in the URL.
+    </p>
+</section>
+
+<!-- 2️⃣ Navigation -->
+<section id="navigation" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-compass me-2"></i>Date navigation</h2>
+    <p>Every view except List has three navigation controls:</p>
+    <ul>
+        <li><strong>◀</strong> — step back (1 day / 1 week / 1 month / 1 year depending on view).</li>
+        <li><strong>Today</strong> — jump back to today.</li>
+        <li><strong>▶</strong> — step forward.</li>
+    </ul>
+    <p>
+        The <strong>Jump to</strong> date picker (top right) lets you land on any specific date directly.
+        The List view uses pagination instead — Newest-first when "Show past events" is off, oldest-first when on.
+    </p>
+</section>
+
+<!-- 3️⃣ Filters -->
+<section id="filters" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-filter me-2"></i>Filters</h2>
+    <p>Two filters apply across every view:</p>
+    <ul>
+        <li><strong>Category</strong> — picks events from one specific category (e.g. "Area 8", "Conference", "Worship services").</li>
+        <li><strong>Type</strong> — picks events of a specific type (e.g. "Family Worship", "Communion", "Working Bee").</li>
+    </ul>
+    <p>
+        The List view also has a <strong>Show past events</strong> toggle that's hidden in the other views (since the grid is anchored on a specific time window already).
+    </p>
+</section>
+
+<!-- 4️⃣ Default view -->
+<section id="defaults" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-house me-2"></i>Default view + per-device memory</h2>
+    <p>
+        When you arrive at <code>/calendar</code> with no <code>?view=</code> in the URL, the portal picks the view in this order:
+    </p>
+    <ol>
+        <li><strong>Whatever you last used</strong> — your browser remembers the last view you switched to (per device, via <code>localStorage</code>).</li>
+        <li><strong>The site default</strong> — what your admin set as <code>calendar.defaultView</code> (default: Month).</li>
+    </ol>
+    <p>
+        You can always override by typing the view name into the URL — that wins over both the remembered choice and the site default.
+    </p>
+</section>
+
+<!-- 5️⃣ Admin: Categories -->
+<section id="admin-categories" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-tags me-2"></i>For admins — categories &amp; colours</h2>
+    <p>
+        Visit <a href="/calendar/manage/types">/calendar/manage/types</a> to manage event categories.
+        Each category can carry:
+    </p>
+    <ul>
+        <li><strong>Colour</strong> (hex) — drives how events in that category are coloured in the year planner and month grid.</li>
+        <li>
+            <strong>Display style</strong>:
+            <ul>
+                <li><em>Background</em> (default) — events show as a tinted band behind the event text. Best for organisational scopes like "Area", "Conference", "Union".</li>
+                <li><em>Text only</em> — events show as coloured event text on the default background. Best for "tag-style" categories like "Bank Holidays" or "Notable Days" that flag a day without filling the cell.</li>
+            </ul>
+        </li>
+    </ul>
+    <p>The category colour is also picked up by the auto-generated legend at the top of the year planner.</p>
+</section>
+
+<!-- 6️⃣ Admin: Month themes -->
+<section id="admin-themes" class="mb-5">
+    <h2 class="h4 mb-3"><i class="fa-solid fa-quote-left me-2"></i>For admins — month themes / strap-lines</h2>
+    <p>
+        If your organisation runs themed months (e.g. "Healthy connections" for February, "Pause?" for November), you can record a short strap-line per month per year and it will appear underneath the month name on the year planner.
+    </p>
+    <p>
+        Visit <a href="/calendar/manage/month-themes">/calendar/manage/month-themes</a>, pick a year, fill in (or clear) the 12 inputs, save.
+        Empty inputs remove the row so the cell goes back to default.
+    </p>
+    <p class="text-muted small">
+        Strap-lines are per-site, so each site under an umbrella org can run its own themes independently.
+    </p>
+</section>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/help/index.php
+++ b/web/public_html/help/index.php
@@ -130,6 +130,21 @@ require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 
         </a>
     </div>
 
+    <!-- Calendar -->
+    <div class="col-12 col-sm-6 col-lg-4">
+        <a href="/help/calendar" class="text-decoration-none text-reset">
+            <div class="portal-card portal-card-branded h-100 p-4">
+                <div class="d-flex align-items-center gap-3 mb-3">
+                    <span class="d-inline-flex align-items-center justify-content-center rounded-3 bg-primary bg-opacity-10 text-primary" style="width:48px;height:48px;">
+                        <i class="fa-solid fa-calendar-days fa-lg"></i>
+                    </span>
+                    <h5 class="mb-0">Calendar</h5>
+                </div>
+                <p class="text-secondary mb-0 small">Seven view modes (day / week / month / year planner / list), date navigation, filters, and admin tools for categories and month themes.</p>
+            </div>
+        </a>
+    </div>
+
     <!-- Prayer Requests -->
     <div class="col-12 col-sm-6 col-lg-4">
         <a href="/help/prayer-requests" class="text-decoration-none text-reset">

--- a/web/sql/full_schema.sql
+++ b/web/sql/full_schema.sql
@@ -1617,6 +1617,10 @@ INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
 VALUES ('help/translations', 'help/translations.php', 0)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
+VALUES ('help/calendar', 'help/calendar.php', 0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
 -- ─── Calendar ───────────────────────────────────────────────────────────────
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
 VALUES ('calendar', 'calendar/index.php', 0)


### PR DESCRIPTION
## Summary

A thorough documentation refresh covering everything shipped (or in flight) on `main` since v0.10.0. Per-topic commits so each PR's documentation lands in its own diff.

## Commits

| Commit | Scope | Reflects work from |
| --- | --- | --- |
| `56f35c4` | `docs: add FEATURES.md — living feature inventory` | All recent PRs |
| `5415bdb` | `docs(readme): link FEATURES.md + refresh roadmap` | All recent PRs |
| `2b06d6f` | `docs(dev-notes): document recent PRs (#129, #130, #132, #133, #135, #136-#138)` | #129, #130, #132, #133, #135, #136, #137, #138 |
| `1831e42` | `docs(help): add Calendar guide + Captcha/Password admin sections` | #130, #132, #136/#137, #138 |
| `0f64c7f` | `docs(claude): refresh project instructions to current state (v0.11.0)` | All recent PRs |

## What landed

### New
- **`FEATURES.md`** — the living per-app inventory. ✅ shipped / 🛠️ in flight / 🔜 planned status for every app, with routes, tables, settings, and issue numbers. Sits alongside `CHANGELOG.md` (chronological) and `README.md` (setup / deploy / licence). Designed so 🛠️ markers flip to ✅ automatically when the named PR merges — no further edits needed.
- **`web/public_html/help/calendar.php`** — in-app Calendar guide covering the seven view modes (#137), filters, default-view resolution, admin tools for categories (#138) and month themes (#138).

### Updated
- **`README.md`** — lead paragraph names the actual apps; new callout points at FEATURES.md; Roadmap table extended through phases 12-13 with in-flight + backlog footnotes.
- **`DEV_NOTES.md`** — six new sections before Troubleshooting: Password policy (#132), Multi-provider Captcha (#130), Debug mode hardening (#133), Anchor / link colour theme binding (#135), Calendar view modes (#137 / #138), Prayer Requests (#129).
- **`web/public_html/help/admin.php`** — new "Bot Protection (Captcha)" and "Password Policy" sections.
- **`web/public_html/help/index.php`** — Calendar tile added to the help landing.
- **`web/sql/full_schema.sql`** — seeds the new `help/calendar` route.
- **`.claude/CLAUDE.md`** — refreshed from a stale v0.9.0 mental model to current v0.11.0 (full apps table, recent PR timeline, FEATURES.md cross-reference).

### GitHub Wiki (pushed separately to the wiki repo)
- **Home** — version bumped to v0.11.0, phase status table covers phases 1-13, apps row, links to FEATURES.md.
- **Roadmap** — replaced launch-target framing with shipped-versions + in-flight + backlog tables.
- **_Sidebar** — added "Living docs" cluster pointing at FEATURES / CHANGELOG / DEV_NOTES on main.

## Per-PR cross-references

Each open / merged PR I'm tracking gets a comment pointing at this PR + the relevant FEATURES.md section:

- #131 — release prep v0.11.0
- #132 — password policy hardening
- #135 — anchor colour theme binding
- #137 — calendar view modes (still open)
- #138 — calendar themes + display-style (still open, stacked on #137)

## Test plan

- [ ] Skim `FEATURES.md` — confirm every app section reflects what's actually on main.
- [ ] Visit `/help` on a running portal — confirm the new Calendar tile appears and links to a working `/help/calendar` page.
- [ ] Visit `/help/admin` — confirm the new Captcha + Password Policy sections render.
- [ ] Open the GitHub Wiki Home — confirm v0.11.0 banner and FEATURES link.
- [ ] After this PR + #137 + #138 merge, do a final sweep on FEATURES.md to flip the 🛠️ markers to ✅ (one-line edits; no language change needed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)