### PR TITLE
chore: prep release v0.12.0 — version bump + CHANGELOG stamp

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,8 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+## [0.12.0] - 2026-05-22
+
 ### Added — Calendar: per-month strap-lines + category display-style toggle (follow-ups to #136)
 
 Two enhancements deferred from the original calendar-views PR (#137):

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # WebMS Intra
 
-> **Version:** 0.11.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
+> **Version:** 0.12.0 | **PHP** 8.5 (backward-compatible with 8.4) | **MySQL** 8.0+ | **DreamHost** shared hosting
 
 A modular internal portal platform for organisations, providing centralised access to internal tools, calendar / events, attendance, expenses, leadership directory, prayer requests, announcements, document library, tasks/reminders, multi-site support, and more.
 

--- a/web/core/App.php
+++ b/web/core/App.php
@@ -53,7 +53,7 @@ class App
     private static bool $userLoaded = false;
 
     /** @var string Portal version number */
-    private static string $version = '0.11.0';
+    private static string $version = '0.12.0';
 
     /**
      * Initialise the App registry. Called from bootstrap.php after DB and settings are ready.


### PR DESCRIPTION
## Summary

Release-prep PR for **v0.12.0**. Bumps version + stamps CHANGELOG so a subsequent `git tag v0.12.0` picks up clean release notes via `release.yml`.

## Why v0.12.0

Substantial work landed on `main` since v0.11.0 was prepped:

- **#132** — Password policy hardening (min 12 chars + strength meter + full-flow coverage)
- **#133** — Debug mode refused in production
- **#134** — Deploy dry-run dispatch + SFTP `--delete` docs
- **#135** — Anchor colour theme binding (dark-mode fix)
- **#137** — Calendar seven view modes (Day / Week / Weekdays / Weekend / Month / Year planner / List)
- **#138** — Calendar per-month strap-lines + category `displayStyle` toggle
- **#139** — Comprehensive documentation sweep (FEATURES.md + wiki + README + DEV_NOTES + in-app help)

Per semver, the new calendar view modes + display-style infrastructure are clear minor-version additions.

## Files

```text
web/core/App.php   ($version '0.11.0' -> '0.12.0' fallback)
README.md          (banner Version: 0.11.0 -> 0.12.0)
CHANGELOG.md       (new [0.12.0] - 2026-05-22 heading wrapping the Unreleased entries)
```

## Release ordering

This PR also retroactively pinned **v0.11.0** as a real tag (it was prepped via PR #131 in 2026-05-22 but never tagged). v0.11.0 covers:

- #129 Prayer Requests app
- #130 Multi-provider Captcha

## After merge

Once this lands on main, tag the v0.12.0 release:

```bash
git fetch origin
git checkout main
git pull --ff-only
git tag -a v0.12.0 -m "v0.12.0 — Calendar views + security + docs sweep"
git push origin v0.12.0
```

Pushing the tag fires `release.yml`, which:

- Detects the `v*` tag pattern
- Extracts release notes from the `[0.12.0]` section of CHANGELOG.md
- Creates a GitHub Release with those notes
- Marked non-prerelease (no `-beta` / `-rc` suffix)

## Test plan

- [ ] PR Security Checks pass
- [ ] After merge: `App::version()` returns `"0.12.0"`
- [ ] After tagging: GitHub Releases page shows v0.12.0 + v0.11.0 with their respective CHANGELOG sections as release notes

🤖 Generated with [Claude Code](https://claude.com/claude-code)