### PR TITLE
feat(security): brand X-Powered-By as WebMS-Intra/<version>

### DIFF
--- a/web/_core/bootstrap.php
+++ b/web/_core/bootstrap.php
@@ -83,13 +83,28 @@ if ($env === false || $env === '') {
 }
 define('PORTAL_ENV', $env);
 
-// 🤫 Strip the default `X-Powered-By: PHP/8.x.y` response header so probes
-// can't fingerprint the backend stack. Apache's mod_headers also unsets it
-// from .htaccess as a belt-and-braces second layer; we set ours here too
-// because that runs for ALL responses regardless of Apache config drift.
-// See: https://www.php.net/manual/en/function.header-remove.php
+// 🏷️ Replace the default `X-Powered-By: PHP/8.x.y` response header with our
+// own branded value (matching the in-page "Powered by" attribution + the
+// <meta name="generator"> tag). The PHP default leaks the backend stack
+// AND the exact PHP version, useful only to attackers looking up CVEs.
+//
+// The actual header value depends on `branding.hidePoweredBy`:
+//   - 'true'   → strip the header entirely (no brand reveal at all)
+//   - else     → "WebMS-Intra/<version>"  (default)
+//
+// The setting is read from $SETTINGS directly (already populated above);
+// we can't use App::settings() yet because App::init() runs later.
+// See: https://www.php.net/manual/en/function.header.php
 if (function_exists('header_remove') === true) {
     header_remove('X-Powered-By');
+}
+$hidePoweredBy = ($SETTINGS['branding']['hidePoweredBy'] ?? 'false') === 'true';
+if ($hidePoweredBy === false) {
+    // 📋 Pull version from settings if available, else fall back to the
+    // App class's compiled default (read here without App::init() because
+    // we need it before App::init runs — keep this in sync with App.php).
+    $brandedVersion = (string) ($SETTINGS['portal']['version'] ?? '1.0.0');
+    header('X-Powered-By: WebMS-Intra/' . $brandedVersion);
 }
 
 // 🛡️ PHP error display hardening

--- a/web/public_html/.htaccess
+++ b/web/public_html/.htaccess
@@ -55,10 +55,11 @@ RewriteCond %{REQUEST_FILENAME} !-d
 # 🎯 Route everything else through the front controller
 RewriteRule ^(.*)$ index.php [QSA,L]
 
-# 🤫 Strip headers that leak the backend stack. PHP also calls
-#     header_remove('X-Powered-By') in bootstrap.php as the primary defence;
-#     this is the belt-and-braces Apache-layer removal.
+# 🏷️ Brand response headers.
+#     X-Powered-By is set by PHP in bootstrap.php to "WebMS-Intra/<version>"
+#     (replacing PHP's default "PHP/8.x.y"). Apache must NOT unset it here,
+#     or our branded value would be stripped along with the default.
+#     The Server header is still stripped — it leaks the Apache version.
 <IfModule mod_headers.c>
-    Header always unset X-Powered-By
     Header always unset Server
 </IfModule>


### PR DESCRIPTION
## Summary

- Replace PHP's default `X-Powered-By: PHP/8.x.y` response header with a branded `WebMS-Intra/<version>` value so we still get product attribution without leaking the backend language + exact PHP patch version.
- Strip Apache's now-redundant `Header always unset X-Powered-By` from `.htaccess` — it ran *after* PHP's `header()` call and would strip our branded value along with the default.
- Keeps the existing `branding.hidePoweredBy='true'` admin setting honoured (full strip if the admin prefers no header at all).

This is a small follow-up to the v1.0.0 launch sprint (#158) — bundling it before the v1.0.0 tag so the released build ships with the branded header.

## Why

The old behaviour (`header_remove('X-Powered-By')`) plus Apache `Header always unset X-Powered-By` produced no `X-Powered-By` header at all. That hides the language fingerprint, but also throws away the legitimate "yes, this is WebMS-Intra" attribution surface we already publish in the footer + `<meta name=\"generator\">`. The branded value preserves attribution without giving a CVE-hunter the PHP version.

## Files changed

| File | Change |
| --- | --- |
| [web/_core/bootstrap.php](web/_core/bootstrap.php) | Replace bare `header_remove()` with conditional branded header. Reads `$SETTINGS` directly because `App::init()` runs later. |
| [web/public_html/.htaccess](web/public_html/.htaccess) | Remove `Header always unset X-Powered-By` (would strip our branded value); keep `Header always unset Server`. |

## Security notes

- **CRLF injection**: PHP's `header()` refuses values containing `\\r` or `\\n` since PHP 5.1.2, so even a malicious admin editing the `portal.version` setting can't smuggle additional headers — the call simply emits a warning and skips. No additional sanitisation needed.
- **Info disclosure trade-off**: the new header reveals (a) the product name and (b) the version. This is *less* informative than the PHP default (no language signal at all, no PHP version) but *more* than a stripped header. Admin opt-out via `branding.hidePoweredBy='true'` is preserved for orgs that want full silence.
- **Behaviour on missing settings**: if `$SETTINGS['portal']['version']` is somehow absent during bootstrap, we fall back to the literal string `1.0.0` rather than emitting `WebMS-Intra/` with no version — keeps the header parseable.

## Test plan

- [ ] `curl -I https://portal.alpha.millrdsdacambridge.uk/` shows `X-Powered-By: WebMS-Intra/1.0.0` (and no `PHP/8.x.y`)
- [ ] Set `branding.hidePoweredBy = 'true'` via admin settings → reload → `curl -I` shows no `X-Powered-By` header at all
- [ ] Set it back to `'false'` → branded value returns
- [ ] No `Server: Apache/...` header present in response (existing strip still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)