### PR TITLE
fix(install): restore handler/installer paths broken by core→_core rename

### DIFF
--- a/web/_core/I18n.php
+++ b/web/_core/I18n.php
@@ -214,7 +214,7 @@ class I18n
             return;
         }
 
-        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . 'lang';
+        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . '_lang';
         $file    = $langDir . DIRECTORY_SEPARATOR . $locale . '.php';
 
         if (is_readable($file) === true) {
@@ -389,7 +389,7 @@ class I18n
      */
     public static function enabledLocales(): array
     {
-        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . 'lang';
+        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . '_lang';
         $enabled = [];
 
         foreach (self::$locales as $code => $meta) {

--- a/web/_core/Migrator.php
+++ b/web/_core/Migrator.php
@@ -51,11 +51,11 @@ class Migrator
     {
         $this->db = $db;
 
-        // 📂 Determine sql/ directory path using platform-neutral constants
+        // 📂 Determine _sql/ directory path using platform-neutral constants
         if ($sqlDir !== '') {
             $this->sqlDir = rtrim($sqlDir, DIRECTORY_SEPARATOR);
         } else {
-            $this->sqlDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . 'sql';
+            $this->sqlDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . '_sql';
         }
 
         // 🛡️ Ensure the migrations tracking table exists

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -34,7 +34,7 @@ declare(strict_types=1);
 // Constants for this self-contained installer
 // ---------------------------------------------------------------------------
 define('INSTALL_ROOT', realpath(__DIR__ . DIRECTORY_SEPARATOR . '..'));
-define('INSTALL_SQL', INSTALL_ROOT . DIRECTORY_SEPARATOR . 'sql');
+define('INSTALL_SQL', INSTALL_ROOT . DIRECTORY_SEPARATOR . '_sql');
 define('INSTALL_AUTH_DIR', INSTALL_ROOT . DIRECTORY_SEPARATOR . '_auth_keys');
 define('INSTALL_CREDS_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . 'auth_creds.php');
 define('INSTALL_ENC_KEY_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . 'enc.key');
@@ -160,7 +160,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             $schemaFile = INSTALL_SQL . DIRECTORY_SEPARATOR . 'full_schema.sql';
             if (is_readable($schemaFile) === false) {
-                $error = 'Schema file not found: sql/full_schema.sql';
+                $error = 'Schema file not found: _sql/full_schema.sql';
                 $step = 3;
             } else {
                 $sql = file_get_contents($schemaFile);
@@ -415,7 +415,7 @@ $prereqs = [
         'value' => extension_loaded('mbstring') ? 'Loaded' : 'Missing',
     ],
     'sql_dir' => [
-        'label' => 'sql/ directory readable',
+        'label' => '_sql/ directory readable',
         'pass'  => is_dir(INSTALL_SQL) && is_readable(INSTALL_SQL),
         'value' => is_dir(INSTALL_SQL) ? 'Found' : 'Missing',
     ],

--- a/web/_install/upgrade.php
+++ b/web/_install/upgrade.php
@@ -25,7 +25,7 @@
 declare(strict_types=1);
 
 // Load the full portal bootstrap (requires working config)
-require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/admin/activity/export.php
+++ b/web/public_html/admin/activity/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/admin/index.php
+++ b/web/public_html/admin/index.php
@@ -109,7 +109,7 @@ if ($stmt !== false) {
 }
 
 // 📂 Count SQL files in the migrations directory
-$sqlDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'sql';
+$sqlDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_sql';
 $sqlFiles = [];
 if (is_dir($sqlDir) === true) {
     $scan = scandir($sqlDir);

--- a/web/public_html/admin/users/export.php
+++ b/web/public_html/admin/users/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/attendance/export.php
+++ b/web/public_html/attendance/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/auth/account/change-password.php
+++ b/web/public_html/auth/account/change-password.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\Logger;

--- a/web/public_html/auth/account/save.php
+++ b/web/public_html/auth/account/save.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/auth/forgot-password/index.php
+++ b/web/public_html/auth/forgot-password/index.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Asset;
 use Portal\Core\Auth;

--- a/web/public_html/auth/forgot-password/save.php
+++ b/web/public_html/auth/forgot-password/save.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/auth/login/index.php
+++ b/web/public_html/auth/login/index.php
@@ -25,7 +25,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Asset;

--- a/web/public_html/auth/login/webauthn.php
+++ b/web/public_html/auth/login/webauthn.php
@@ -19,7 +19,7 @@
  */
 
 declare(strict_types=1);
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/auth/reset-password/index.php
+++ b/web/public_html/auth/reset-password/index.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Asset;
 use Portal\Core\Auth;

--- a/web/public_html/auth/reset-password/save.php
+++ b/web/public_html/auth/reset-password/save.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\Captcha;

--- a/web/public_html/expenses/api/export.php
+++ b/web/public_html/expenses/api/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/expenses/approve/save.php
+++ b/web/public_html/expenses/approve/save.php
@@ -25,7 +25,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/expenses/submit/save.php
+++ b/web/public_html/expenses/submit/save.php
@@ -17,7 +17,7 @@
  */
 
 declare(strict_types=1);
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/expenses/treasury/save.php
+++ b/web/public_html/expenses/treasury/save.php
@@ -16,7 +16,7 @@
  */
 
 declare(strict_types=1);
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/expenses/withdraw/save.php
+++ b/web/public_html/expenses/withdraw/save.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\Logger;

--- a/web/public_html/leadership/export.php
+++ b/web/public_html/leadership/export.php
@@ -16,7 +16,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/prayer-requests/anonymous-save.php
+++ b/web/public_html/prayer-requests/anonymous-save.php
@@ -23,7 +23,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/prayer-requests/anonymous.php
+++ b/web/public_html/prayer-requests/anonymous.php
@@ -24,7 +24,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Asset;


### PR DESCRIPTION
## Summary

Fixes a regression introduced by the directory rename in #158 (`core/`→`_core/`, `sql/`→`_sql/`, `lang/`→`_lang/`). The PORTAL_* constants in bootstrap.php were updated but **24 files still had the old literal path strings hard-coded**.

## User-visible symptom

The installation wizard's Step 1 prereq check failed with:

- ✘ `sql/ directory readable: Missing`
- ✘ `full_schema.sql exists: Missing`

…blocking any fresh install. Existing handlers had the same bug — they only kept working because `index.php` loaded bootstrap first, and any direct route hit would have fatal-errored on the broken `require_once`.

## Files touched

**20 handler `require_once` lines** (all of the form `dirname(__DIR__, N) . DIRECTORY_SEPARATOR . 'core' . ...`):
- All auth flows: login, login/webauthn, forgot-password (×2), reset-password (×2), account/save, account/change-password
- Expenses: submit/save, approve/save, treasury/save, withdraw/save, api/export
- Admin: activity/export, users/export
- Attendance, leadership, prayer-requests (×2) exports/handlers
- `web/_install/upgrade.php` bootstrap require

**5 targeted constant/path fixes**:
- [web/_install/index.php](web/_install/index.php) — `INSTALL_SQL` constant, prereq label, error message
- [web/_core/Migrator.php](web/_core/Migrator.php) — default `sqlDir` path
- [web/_core/I18n.php](web/_core/I18n.php) — `$langDir` paths (×2: `loadLocale` + `enabledLocales`)
- [web/public_html/admin/index.php](web/public_html/admin/index.php) — `$sqlDir` for migration counter

## Why these were missed in #158

The original rename used `git mv` (which moves files) plus updated the bootstrap.php constants — but the rename PR's sweep for stale references caught the docs/workflow files and missed these literal path strings inside PHP code. Fixed now with a comprehensive grep audit; final sweep confirms zero remaining stale references for `core`, `sql`, `lang`, `install`, or `vendor` as path literals.

## Test plan

- [ ] Deploy to alpha; load `/install/` → Step 1 prereq check now shows ✔ `_sql/ directory readable` and ✔ `full_schema.sql exists`
- [ ] Walk through full installer flow (Steps 1-6) without errors
- [ ] Auth: login + 2FA + password reset all reach their handlers (not 500)
- [ ] Expenses: submit + approve + treasury + withdraw flows reach handlers
- [ ] Admin: migration counter shows correct count of `_sql/*.sql` files
- [ ] I18n: `cy` locale loads correctly from `_lang/cy.php`

## Security notes

Pure path-string updates. No new input handling, no SQL changes, no HTML output changes, no auth changes, no new dependencies. Risk surface limited to "did the new path exist on the server" — confirmed via local lint pass + verification grep.

🤖 Generated with [Claude Code](https://claude.com/claude-code)