### PR TITLE
chore: v1.0.0 follow-ups — installer path fix + X-Powered-By branding

### DIFF
--- a/web/_core/I18n.php
+++ b/web/_core/I18n.php
@@ -214,7 +214,7 @@ class I18n
             return;
         }
 
-        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . 'lang';
+        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . '_lang';
         $file    = $langDir . DIRECTORY_SEPARATOR . $locale . '.php';
 
         if (is_readable($file) === true) {
@@ -389,7 +389,7 @@ class I18n
      */
     public static function enabledLocales(): array
     {
-        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . 'lang';
+        $langDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . '_lang';
         $enabled = [];
 
         foreach (self::$locales as $code => $meta) {

--- a/web/_core/Migrator.php
+++ b/web/_core/Migrator.php
@@ -51,11 +51,11 @@ class Migrator
     {
         $this->db = $db;
 
-        // 📂 Determine sql/ directory path using platform-neutral constants
+        // 📂 Determine _sql/ directory path using platform-neutral constants
         if ($sqlDir !== '') {
             $this->sqlDir = rtrim($sqlDir, DIRECTORY_SEPARATOR);
         } else {
-            $this->sqlDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . 'sql';
+            $this->sqlDir = PORTAL_ROOT . DIRECTORY_SEPARATOR . '_sql';
         }
 
         // 🛡️ Ensure the migrations tracking table exists

--- a/web/_core/bootstrap.php
+++ b/web/_core/bootstrap.php
@@ -83,13 +83,28 @@ if ($env === false || $env === '') {
 }
 define('PORTAL_ENV', $env);
 
-// 🤫 Strip the default `X-Powered-By: PHP/8.x.y` response header so probes
-// can't fingerprint the backend stack. Apache's mod_headers also unsets it
-// from .htaccess as a belt-and-braces second layer; we set ours here too
-// because that runs for ALL responses regardless of Apache config drift.
-// See: https://www.php.net/manual/en/function.header-remove.php
+// 🏷️ Replace the default `X-Powered-By: PHP/8.x.y` response header with our
+// own branded value (matching the in-page "Powered by" attribution + the
+// <meta name="generator"> tag). The PHP default leaks the backend stack
+// AND the exact PHP version, useful only to attackers looking up CVEs.
+//
+// The actual header value depends on `branding.hidePoweredBy`:
+//   - 'true'   → strip the header entirely (no brand reveal at all)
+//   - else     → "WebMS-Intra/<version>"  (default)
+//
+// The setting is read from $SETTINGS directly (already populated above);
+// we can't use App::settings() yet because App::init() runs later.
+// See: https://www.php.net/manual/en/function.header.php
 if (function_exists('header_remove') === true) {
     header_remove('X-Powered-By');
+}
+$hidePoweredBy = ($SETTINGS['branding']['hidePoweredBy'] ?? 'false') === 'true';
+if ($hidePoweredBy === false) {
+    // 📋 Pull version from settings if available, else fall back to the
+    // App class's compiled default (read here without App::init() because
+    // we need it before App::init runs — keep this in sync with App.php).
+    $brandedVersion = (string) ($SETTINGS['portal']['version'] ?? '1.0.0');
+    header('X-Powered-By: WebMS-Intra/' . $brandedVersion);
 }
 
 // 🛡️ PHP error display hardening

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -34,7 +34,7 @@ declare(strict_types=1);
 // Constants for this self-contained installer
 // ---------------------------------------------------------------------------
 define('INSTALL_ROOT', realpath(__DIR__ . DIRECTORY_SEPARATOR . '..'));
-define('INSTALL_SQL', INSTALL_ROOT . DIRECTORY_SEPARATOR . 'sql');
+define('INSTALL_SQL', INSTALL_ROOT . DIRECTORY_SEPARATOR . '_sql');
 define('INSTALL_AUTH_DIR', INSTALL_ROOT . DIRECTORY_SEPARATOR . '_auth_keys');
 define('INSTALL_CREDS_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . 'auth_creds.php');
 define('INSTALL_ENC_KEY_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . 'enc.key');
@@ -160,7 +160,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         } else {
             $schemaFile = INSTALL_SQL . DIRECTORY_SEPARATOR . 'full_schema.sql';
             if (is_readable($schemaFile) === false) {
-                $error = 'Schema file not found: sql/full_schema.sql';
+                $error = 'Schema file not found: _sql/full_schema.sql';
                 $step = 3;
             } else {
                 $sql = file_get_contents($schemaFile);
@@ -415,7 +415,7 @@ $prereqs = [
         'value' => extension_loaded('mbstring') ? 'Loaded' : 'Missing',
     ],
     'sql_dir' => [
-        'label' => 'sql/ directory readable',
+        'label' => '_sql/ directory readable',
         'pass'  => is_dir(INSTALL_SQL) && is_readable(INSTALL_SQL),
         'value' => is_dir(INSTALL_SQL) ? 'Found' : 'Missing',
     ],

--- a/web/_install/upgrade.php
+++ b/web/_install/upgrade.php
@@ -25,7 +25,7 @@
 declare(strict_types=1);
 
 // Load the full portal bootstrap (requires working config)
-require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/.htaccess
+++ b/web/public_html/.htaccess
@@ -55,10 +55,11 @@ RewriteCond %{REQUEST_FILENAME} !-d
 # 🎯 Route everything else through the front controller
 RewriteRule ^(.*)$ index.php [QSA,L]
 
-# 🤫 Strip headers that leak the backend stack. PHP also calls
-#     header_remove('X-Powered-By') in bootstrap.php as the primary defence;
-#     this is the belt-and-braces Apache-layer removal.
+# 🏷️ Brand response headers.
+#     X-Powered-By is set by PHP in bootstrap.php to "WebMS-Intra/<version>"
+#     (replacing PHP's default "PHP/8.x.y"). Apache must NOT unset it here,
+#     or our branded value would be stripped along with the default.
+#     The Server header is still stripped — it leaks the Apache version.
 <IfModule mod_headers.c>
-    Header always unset X-Powered-By
     Header always unset Server
 </IfModule>

--- a/web/public_html/admin/activity/export.php
+++ b/web/public_html/admin/activity/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/admin/index.php
+++ b/web/public_html/admin/index.php
@@ -109,7 +109,7 @@ if ($stmt !== false) {
 }
 
 // 📂 Count SQL files in the migrations directory
-$sqlDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'sql';
+$sqlDir = dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_sql';
 $sqlFiles = [];
 if (is_dir($sqlDir) === true) {
     $scan = scandir($sqlDir);

--- a/web/public_html/admin/users/export.php
+++ b/web/public_html/admin/users/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/attendance/export.php
+++ b/web/public_html/attendance/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/auth/account/change-password.php
+++ b/web/public_html/auth/account/change-password.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\Logger;

--- a/web/public_html/auth/account/save.php
+++ b/web/public_html/auth/account/save.php
@@ -18,7 +18,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/auth/forgot-password/index.php
+++ b/web/public_html/auth/forgot-password/index.php
@@ -21,7 +21,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Asset;
 use Portal\Core\Auth;

--- a/web/public_html/auth/forgot-password/save.php
+++ b/web/public_html/auth/forgot-password/save.php
@@ -26,7 +26,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/auth/login/index.php
+++ b/web/public_html/auth/login/index.php
@@ -25,7 +25,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Asset;

--- a/web/public_html/auth/login/webauthn.php
+++ b/web/public_html/auth/login/webauthn.php
@@ -19,7 +19,7 @@
  */
 
 declare(strict_types=1);
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/auth/reset-password/index.php
+++ b/web/public_html/auth/reset-password/index.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Asset;
 use Portal\Core\Auth;

--- a/web/public_html/auth/reset-password/save.php
+++ b/web/public_html/auth/reset-password/save.php
@@ -20,7 +20,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\Captcha;

--- a/web/public_html/expenses/api/export.php
+++ b/web/public_html/expenses/api/export.php
@@ -15,7 +15,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/expenses/approve/save.php
+++ b/web/public_html/expenses/approve/save.php
@@ -25,7 +25,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/expenses/submit/save.php
+++ b/web/public_html/expenses/submit/save.php
@@ -17,7 +17,7 @@
  */
 
 declare(strict_types=1);
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/expenses/treasury/save.php
+++ b/web/public_html/expenses/treasury/save.php
@@ -16,7 +16,7 @@
  */
 
 declare(strict_types=1);
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/expenses/withdraw/save.php
+++ b/web/public_html/expenses/withdraw/save.php
@@ -19,7 +19,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 3) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\Logger;

--- a/web/public_html/leadership/export.php
+++ b/web/public_html/leadership/export.php
@@ -16,7 +16,7 @@
 declare(strict_types=1);
 
 // 🔧 Bootstrap
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\Auth;
 use Portal\Core\App;

--- a/web/public_html/prayer-requests/anonymous-save.php
+++ b/web/public_html/prayer-requests/anonymous-save.php
@@ -23,7 +23,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Auth;

--- a/web/public_html/prayer-requests/anonymous.php
+++ b/web/public_html/prayer-requests/anonymous.php
@@ -24,7 +24,7 @@
 
 declare(strict_types=1);
 
-require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . 'core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
+require_once dirname(__DIR__, 2) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
 use Portal\Core\App;
 use Portal\Core\Asset;


### PR DESCRIPTION
## Summary

Bundles two small follow-ups to the v1.0.0 launch sprint (#158) into one PR ahead of the v1.0.0 tag:

1. **`fix(install)`** — restore 24 handler/installer paths broken by the `core/`→`_core/` rename (high priority; fresh installs are currently blocked)
2. **`feat(security)`** — replace `X-Powered-By: PHP/8.x.y` with `WebMS-Intra/<version>` (low priority; small attribution polish)

Replaces #163 and #164 (both closed).

---

## Part 1 — `fix(install)`: post-rename stale path refs

PR #158's directory rename (`core/`→`_core/`, `sql/`→`_sql/`, `lang/`→`_lang/`) updated the `PORTAL_*` constants in bootstrap.php but **missed 24 files with the old literal path strings still hard-coded**.

### User-visible symptom

Installation wizard Step 1 prereq check fails with:
- ✘ `sql/ directory readable: Missing`
- ✘ `full_schema.sql exists: Missing`

…blocking fresh installs. App handlers were silently broken too — they only worked because `index.php` had already loaded bootstrap by the time the handler's `require_once` ran.

### Files touched (24)

**20 handler `require_once` lines** (all `dirname(__DIR__, N) . DIRECTORY_SEPARATOR . 'core' . ...`):
- Auth: login, login/webauthn, forgot-password (×2), reset-password (×2), account/save, account/change-password
- Expenses: submit/save, approve/save, treasury/save, withdraw/save, api/export
- Admin: activity/export, users/export
- Other: attendance/export, leadership/export, prayer-requests/anonymous (×2), `_install/upgrade.php`

**4 targeted constant/path fixes**:
- [web/_install/index.php](web/_install/index.php) — `INSTALL_SQL` constant, prereq label, error message
- [web/_core/Migrator.php](web/_core/Migrator.php) — default `sqlDir` path
- [web/_core/I18n.php](web/_core/I18n.php) — `$langDir` paths (×2)
- [web/public_html/admin/index.php](web/public_html/admin/index.php) — `$sqlDir` migration counter

Pure path-string updates (`'core'`→`'_core'`, `'sql'`→`'_sql'`, `'lang'`→`'_lang'`). No functional changes.

---

## Part 2 — `feat(security)`: brand X-Powered-By

Replace PHP's default `X-Powered-By: PHP/8.x.y` (which leaks the backend language + exact patch version) with a branded `WebMS-Intra/<version>` value matching the in-footer attribution and `<meta name=\"generator\">` tag.

The existing `branding.hidePoweredBy='true'` admin setting is preserved for orgs that want full silence.

### Files touched

- [web/_core/bootstrap.php](web/_core/bootstrap.php) — read `$SETTINGS` directly (App::init() runs later) → either `header_remove()` or set branded value
- [web/public_html/.htaccess](web/public_html/.htaccess) — drop `Header always unset X-Powered-By` (would strip our branded value); keep `Header always unset Server`

### Security notes

- **CRLF injection**: PHP's `header()` refuses values containing `\\r`/`\\n` since 5.1.2, so even a malicious admin editing `portal.version` can't smuggle headers — the call emits a warning and skips.
- **Disclosure trade-off**: branded header reveals product + version, but no language/PHP-version signal. Admin opt-out preserved via the existing `branding.hidePoweredBy` setting.

---

## Test plan

### Installer fix (Part 1)
- [ ] Deploy to alpha; load `/install/` → Step 1 shows ✔ `_sql/ directory readable` and ✔ `full_schema.sql exists`
- [ ] Walk through full installer flow (Steps 1-6) without errors
- [ ] Auth: login + 2FA + password reset all reach their handlers (not 500)
- [ ] Expenses: submit + approve + treasury + withdraw flows reach handlers
- [ ] Admin migration counter shows correct count of `_sql/*.sql` files
- [ ] I18n: `cy` locale loads correctly from `_lang/cy.php`

### X-Powered-By branding (Part 2)
- [ ] `curl -I https://portal.alpha.millrdsdacambridge.uk/` shows `X-Powered-By: WebMS-Intra/1.0.0` (no `PHP/8.x.y`)
- [ ] Set `branding.hidePoweredBy='true'` → reload → no `X-Powered-By` header at all
- [ ] Set back to `'false'` → branded value returns
- [ ] No `Server: Apache/...` header (existing strip still works)

🤖 Generated with [Claude Code](https://claude.com/claude-code)