### PR TITLE
refactor(version): single source of truth in _core/version.php

### DIFF
--- a/web/_core/App.php
+++ b/web/_core/App.php
@@ -52,8 +52,8 @@ class App
     /** @var bool Whether the user data has been loaded (to distinguish null = "not loaded" vs "not logged in") */
     private static bool $userLoaded = false;
 
-    /** @var string Portal version number */
-    private static string $version = '1.0.0';
+    /** @var string Portal version number — lazy-loaded from _core/version.php (single source of truth) */
+    private static string $version = '';
 
     /**
      * Initialise the App registry. Called from bootstrap.php after DB and settings are ready.
@@ -68,11 +68,26 @@ class App
         self::$db       = $db;
         self::$settings = $settings;
 
-        // 📌 Load version from settings if available, otherwise use default
+        // 📌 Load version from settings if available, else from _core/version.php
+        // (the single source of truth shared with the bootstrap-free installer).
         $settingsVersion = self::settings('portal.version');
         if ($settingsVersion !== null && $settingsVersion !== '') {
             self::$version = $settingsVersion;
+        } else {
+            self::$version = self::loadVersionFile();
         }
+    }
+
+    /**
+     * Read the authoritative portal version from _core/version.php.
+     * Used both by init() and as a lazy fallback in version() if init()
+     * hasn't been called yet.
+     *
+     * @return string
+     */
+    private static function loadVersionFile(): string
+    {
+        return (string) (require __DIR__ . DIRECTORY_SEPARATOR . 'version.php');
     }
 
     /**
@@ -223,6 +238,11 @@ class App
      */
     public static function version(): string
     {
+        // 🛟 Lazy-load if version() is called before init() (e.g. from a
+        // bootstrap-only script). Keeps the API safe regardless of caller order.
+        if (self::$version === '') {
+            self::$version = self::loadVersionFile();
+        }
         return self::$version;
     }
 

--- a/web/_core/bootstrap.php
+++ b/web/_core/bootstrap.php
@@ -59,6 +59,11 @@ define('PORTAL_APPS',   PORTAL_ROOT . DIRECTORY_SEPARATOR . 'public_html');
 define('PORTAL_VENDOR', PORTAL_ROOT . DIRECTORY_SEPARATOR . '_vendor');
 define('PORTAL_SQL',    PORTAL_ROOT . DIRECTORY_SEPARATOR . '_sql');
 
+// 📌 Authoritative portal version — single source of truth shared with the
+// bootstrap-free installer (web/_install/) so they cannot drift apart.
+// See _core/version.php for the release-bump procedure.
+define('PORTAL_VERSION', (string) (require PORTAL_CORE . DIRECTORY_SEPARATOR . 'version.php'));
+
 // 🌍 Determine runtime environment flag (dev | beta | prod)
 // Priority: 1) PORTAL_ENV env var  2) directory name detection  3) default 'dev'
 // Primary directories: public_html (prod), public_html_beta (beta), public_html_dev (dev)
@@ -100,10 +105,9 @@ if (function_exists('header_remove') === true) {
 }
 $hidePoweredBy = ($SETTINGS['branding']['hidePoweredBy'] ?? 'false') === 'true';
 if ($hidePoweredBy === false) {
-    // 📋 Pull version from settings if available, else fall back to the
-    // App class's compiled default (read here without App::init() because
-    // we need it before App::init runs — keep this in sync with App.php).
-    $brandedVersion = (string) ($SETTINGS['portal']['version'] ?? '1.0.0');
+    // 📋 Use the DB-settings override if present, else the authoritative
+    // PORTAL_VERSION constant (loaded from _core/version.php above).
+    $brandedVersion = (string) ($SETTINGS['portal']['version'] ?? PORTAL_VERSION);
     header('X-Powered-By: WebMS-Intra/' . $brandedVersion);
 }
 

--- a/web/_core/version.php
+++ b/web/_core/version.php
@@ -1,0 +1,39 @@
+<?php
+// Path: _core/version.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — Authoritative Version Number 📌
+ * -----------------------------------------------------------------------------
+ * SINGLE SOURCE OF TRUTH for the portal version string. Both the runtime
+ * (via Portal\Core\App and bootstrap.php → PORTAL_VERSION) AND the
+ * bootstrap-free installer (web/_install/index.php → INSTALL_VERSION)
+ * read this file to derive their displayed version.
+ *
+ * 🛠️ Release process:
+ *   1. Bump the string returned below
+ *   2. Update CHANGELOG.md entry header
+ *   3. Tag the release commit
+ * Nothing else needs to change to keep the installer + runtime in sync.
+ *
+ * 📐 Design notes:
+ *   - Returns a plain string so it can be `require`d from both classes
+ *     (which have a namespace) and bootstrap-free scripts (which don't).
+ *   - Bootstrap-free: this file MUST NOT use the Portal\Core\ namespace or
+ *     reference any class, constant, or function defined elsewhere. It is
+ *     loaded by the installer BEFORE any autoloader is available.
+ *   - The runtime can still override this via the `portal.version` setting
+ *     in tblSettings (loaded by App::init() after bootstrap), which is
+ *     useful only for testing — production should match the constant.
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+return '1.0.0';

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -23,7 +23,7 @@
  * @author    MWBM Partners Ltd (t/a MWservices)
  * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
  * @license   All Rights Reserved
- * @version   0.8.1
+ * @version   1.0.0
  * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/84
  * -----------------------------------------------------------------------------
  */
@@ -39,7 +39,10 @@ define('INSTALL_AUTH_DIR', INSTALL_ROOT . DIRECTORY_SEPARATOR . '_auth_keys');
 define('INSTALL_CREDS_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . 'auth_creds.php');
 define('INSTALL_ENC_KEY_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . 'enc.key');
 define('INSTALL_LOCK_FILE', INSTALL_AUTH_DIR . DIRECTORY_SEPARATOR . '.installed');
-define('INSTALL_VERSION', '0.8.1');
+// 📌 Single source of truth — same file App.php and bootstrap.php read.
+// Even though this installer is bootstrap-free, _core/version.php is a
+// plain `return <string>` and safe to `require` independently.
+define('INSTALL_VERSION', (string) (require INSTALL_ROOT . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'version.php'));
 
 // ---------------------------------------------------------------------------
 // Block re-installation if lock file exists

--- a/web/_install/upgrade.php
+++ b/web/_install/upgrade.php
@@ -17,7 +17,7 @@
  * @author    MWBM Partners Ltd (t/a MWservices)
  * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
  * @license   All Rights Reserved
- * @version   0.8.1
+ * @version   1.0.0
  * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/84
  * -----------------------------------------------------------------------------
  */


### PR DESCRIPTION
## Summary

Eliminate the version-string drift that surfaced as \"installer wizard shows v0.8.1\" last release. All three consumers now read from a single file, [web/_core/version.php](web/_core/version.php) — release prep becomes one edit instead of three.

## Why this matters

Before this PR the portal version was hardcoded in **three independent places** and they had to be hand-synchronised at each release:

| File | What it controls | Was |
|---|---|---|
| [web/_core/App.php:56](web/_core/App.php#L56) | `App::version()` runtime API | `'1.0.0'` |
| [web/_core/bootstrap.php:106](web/_core/bootstrap.php#L106) | `X-Powered-By` header fallback | `'1.0.0'` |
| [web/_install/index.php:42](web/_install/index.php#L42) | Installer wizard display | `'0.8.1'` ← drifted |

We caught the drift only because a user opened the wizard on production after the v1.0.0 merge. Predictable drift = bad release hygiene.

## The fix

Introduce a single bootstrap-free version file:

```php
<?php
// web/_core/version.php
return '1.0.0';
```

…and wire all three consumers to read it.

### Files changed

- **`web/_core/version.php` (new)** — authoritative version string, returned via `return` so any consumer can `require` it
- **[web/_core/bootstrap.php](web/_core/bootstrap.php)** — defines `PORTAL_VERSION` constant from the file (next to other `PORTAL_*` constants); uses it as the X-Powered-By fallback
- **[web/_core/App.php](web/_core/App.php)** — lazy-loads `$version` via new `loadVersionFile()` helper; called from `init()` and from the `version()` getter as a safety net
- **[web/_install/index.php](web/_install/index.php)** — defines `INSTALL_VERSION` by `require`ing the file directly (still bootstrap-free; the file is a plain `return <string>` and safe to load standalone)
- **`web/_install/upgrade.php`** — bumps stale `@version 0.8.1` → `1.0.0` doc tag (no functional change)

## Future release process

Just edit `web/_core/version.php`:

```diff
-return '1.0.0';
+return '1.0.1';
```

Bump CHANGELOG.md, tag the release. The installer + runtime + X-Powered-By header stay in sync automatically. No more multi-file find-and-replace at release time.

## Trade-offs considered

- **DB-settings override preserved.** `App::init()` still checks for a `portal.version` value in `tblSettings` and prefers it over the file value if present. This is useful for testing scenarios and matches the pre-existing semantics. The installer, by contrast, always uses the file (it runs before settings are loaded).
- **Bootstrap-free constraint respected.** `_core/version.php` deliberately avoids the `Portal\Core\` namespace and references no other class/function/constant, so the installer can `require` it without pulling in the autoloader.
- **No DB migration required.** `tblSettings.portal.version` rows from prior installs continue to work as overrides.

## Security notes

Pure refactor — no input handling, no SQL, no auth, no new HTML output, no new dependencies. The only externally-visible behaviour change is what the installer wizard displays in its header/footer (`v1.0.0` instead of `v0.8.1`). The X-Powered-By header value is unchanged in practice (`WebMS-Intra/1.0.0` either way, since the prior `?? '1.0.0'` fallback already matched).

## Test plan

- [ ] `php -r \"echo (require 'web/_core/version.php') . PHP_EOL;\"` → prints `1.0.0`
- [ ] Local lint: `php -l` on all five changed files
- [ ] Deploy to alpha; load `/install/` → wizard header shows `Installation Wizard — v1.0.0`
- [ ] `curl -I` on a deployed page → `X-Powered-By: WebMS-Intra/1.0.0`
- [ ] In admin/about (or wherever `App::version()` is surfaced) → shows `1.0.0`
- [ ] Set `portal.version = '1.0.0-test'` in tblSettings → reload → `App::version()` and X-Powered-By both reflect override; installer still shows `1.0.0` from the file (expected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)