### PR TITLE
fix(ui): installer link colours + portal alert link/code polish (#167)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,27 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Fixed
+
+- **Installer link colours** (#167) — fixed truncated Bootstrap 5.3.3 CSS
+  SRI hash in `web/_install/index.php` that was causing the browser to
+  reject the stylesheet, leaving anchors (most visibly the `← Back`
+  button on every step) rendered in browser-default blue. Added a
+  defensive `a { color: var(--bs-link-color); }` rule so the installer
+  stays readable even if the CDN is blocked or the integrity check
+  fails again. Added dark-mode overrides for `.alert-info`,
+  `.alert-warning`, `.alert-success`, `.alert-danger` to mirror the
+  runtime portal (`portal.css` already had them — the installer was
+  missing them because it bundles its own standalone CSS). Re-themed
+  the "Already Installed" lockout page to use the indigo palette with
+  `prefers-color-scheme` awareness.
+- **Alert links + code chips, portal-wide** (#167) — added `.alert a`
+  and `.alert code` polish to `portal.css` so anchors and inline code
+  inside any `.alert-*` box pick up the alert's own tonal foreground
+  via `currentColor`, instead of falling through to the global indigo
+  link colour (which clashes against alert-warning amber /
+  alert-success green).
+
 ## [1.0.0] - 2026-05-22 — 🚀 v1.0 launch
 
 A "bumper" release pulling everything needed for the v1.0 launch into one

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -49,15 +49,45 @@ define('INSTALL_VERSION', (string) (require INSTALL_ROOT . DIRECTORY_SEPARATOR .
 // ---------------------------------------------------------------------------
 if (is_file(INSTALL_LOCK_FILE) === true || is_file(INSTALL_CREDS_FILE) === true) {
     http_response_code(403);
+    // 🎨 Themed lockout page — picks up the OS prefers-color-scheme and
+    // uses the same indigo palette as the rest of the installer / portal,
+    // so links / buttons are readable in both light and dark modes
+    // without relying on Bootstrap or browser defaults.
     echo '<!doctype html><html><head><title>Already Installed</title>'
+       . '<meta charset="utf-8">'
        . '<meta name="viewport" content="width=device-width,initial-scale=1">'
-       . '<style>body{font-family:system-ui;text-align:center;padding:4rem;}'
-       . '.btn{display:inline-block;padding:.6rem 1.5rem;background:#0d6efd;color:#fff;'
-       . 'text-decoration:none;border-radius:.4rem;margin-top:1rem;}</style></head>'
-       . '<body><h1>Already Installed</h1>'
+       . '<style>'
+       . ':root{'
+       .   '--bg:#f7f8fa;--surface:#ffffff;--text:#1b2330;--muted:#6b7280;'
+       .   '--border:#e5e7eb;--primary:#5e6ad2;--primary-hover:#4f5bbf;'
+       .   '--code-bg:#eef0fb;--code-text:#1b2330;'
+       . '}'
+       . '@media (prefers-color-scheme: dark){:root{'
+       .   '--bg:#0f1115;--surface:#161a22;--text:#e8eaf0;--muted:#9aa3b2;'
+       .   '--border:#2c3441;--primary:#7b86e8;--primary-hover:#8f99eb;'
+       .   '--code-bg:#1f2347;--code-text:#e8eaf0;'
+       . '}}'
+       . 'html,body{height:100%;}'
+       . 'body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;'
+       .   'background:var(--bg);color:var(--text);text-align:center;'
+       .   'padding:4rem 1.25rem;margin:0;line-height:1.55;}'
+       . '.card{max-width:560px;margin:0 auto;background:var(--surface);'
+       .   'border:1px solid var(--border);border-radius:.75rem;padding:2.5rem 2rem;'
+       .   'box-shadow:0 4px 6px -1px rgba(16,24,40,.08),0 2px 4px -2px rgba(16,24,40,.06);}'
+       . 'h1{margin:0 0 1rem;font-weight:600;letter-spacing:-.01em;}'
+       . 'p{margin:0 0 1rem;color:var(--text);}'
+       . 'code{background:var(--code-bg);color:var(--code-text);'
+       .   'padding:.125rem .4rem;border-radius:.375rem;font-size:.9em;'
+       .   'font-family:ui-monospace,SFMono-Regular,Menlo,Monaco,Consolas,monospace;}'
+       . '.btn{display:inline-block;padding:.625rem 1.25rem;background:var(--primary);'
+       .   'color:#fff;text-decoration:none;border-radius:.375rem;margin-top:1rem;'
+       .   'font-weight:500;transition:background 120ms ease;}'
+       . '.btn:hover,.btn:focus{background:var(--primary-hover);color:#fff;}'
+       . '</style></head>'
+       . '<body><div class="card"><h1>Already Installed</h1>'
        . '<p>WebMS Intra has already been installed. To re-run the installer, '
        . 'remove both the lock file and credentials file from the <code>_auth_keys/</code> directory.</p>'
-       . '<a class="btn" href="/">Go to Portal</a></body></html>';
+       . '<a class="btn" href="/">Go to Portal</a></div></body></html>';
     exit();
 }
 
@@ -464,7 +494,7 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title><?php echo htmlspecialchars($pageTitle, ENT_QUOTES, 'UTF-8'); ?></title>
     <link href="https://cdn.jsdelivr.net/npm/bootstrap@5.3.3/dist/css/bootstrap.min.css" rel="stylesheet"
-          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YcnS/1PTgCq0l0vD8pVNSNZS1p0H084UB" crossorigin="anonymous">
+          integrity="sha384-QWTKZyjpPEjISv5WaRU9OFeRpok6YcnS/NPqOGZ2eLNphkfv02LPMoJiDFhNSz7K" crossorigin="anonymous">
     <style>
         /* =====================================================================
          * Installer styles — comprehensive across all 6 step layouts.
@@ -859,6 +889,36 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
         .prereq-fail { color: var(--portal-danger);  font-weight: 500; }
 
         /* =====================================================================
+         * 🔗 Defensive anchor styling — bind <a> directly to the brand link
+         * colour. `--bs-link-color` is already pointed at the indigo palette
+         * above, but if Bootstrap fails to load (CDN outage / SRI mismatch)
+         * Bootstrap's own `a { color: var(--bs-link-color); }` rule never
+         * runs and anchors fall back to the browser default (underlined
+         * blue, visited purple — particularly ugly in dark mode). This
+         * rule guarantees readability even with zero external CSS.
+         * =================================================================*/
+        a {
+            color: var(--bs-link-color);
+            text-decoration: underline;
+            text-underline-offset: 0.15em;
+        }
+        a:hover,
+        a:focus {
+            color: var(--bs-link-hover-color);
+        }
+        a:visited {
+            color: var(--bs-link-color);
+        }
+        /* Buttons-as-links keep their button look, never link-blue */
+        a.btn,
+        a.btn:hover,
+        a.btn:focus,
+        a.btn:visited {
+            text-decoration: none;
+            color: var(--bs-btn-color, inherit);
+        }
+
+        /* =====================================================================
          * Alerts (steps 3 / 5 / 6 use these heavily)
          * =================================================================*/
         .install-card .alert {
@@ -876,12 +936,36 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
             margin: 0.5rem 0 0;
         }
         .install-card .alert li { margin: 0.25rem 0; }
+        /* Code chips inside alerts: tonal-on-tonal so they read clearly on
+         * both the light-mode pastel and the dark-mode deep-shade backgrounds,
+         * without the bright white pill that previously washed out the text. */
         .install-card .alert code {
-            background: rgba(255,255,255,0.55);
-            padding: 0.125rem 0.4rem;
+            background:    rgba(0, 0, 0, 0.08);
+            color:         currentColor;
+            padding:       0.125rem 0.4rem;
             border-radius: var(--portal-radius-sm);
-            font-size: 0.875em;
+            font-size:     0.875em;
+            font-family:   ui-monospace, SFMono-Regular, "SF Mono", Menlo,
+                           Monaco, Consolas, monospace;
         }
+        [data-bs-theme="dark"] .install-card .alert code {
+            background: rgba(255, 255, 255, 0.12);
+        }
+        /* Links inside alerts — pull from currentColor so the underline
+         * inherits the alert's own tonal foreground (dark-on-light or
+         * light-on-dark) and is always readable against the tinted bg. */
+        .install-card .alert a {
+            color: currentColor;
+            text-decoration: underline;
+            font-weight: 600;
+        }
+        .install-card .alert a:hover,
+        .install-card .alert a:focus {
+            color: currentColor;
+            opacity: 0.8;
+        }
+
+        /* Light-mode alert palettes — pastel backgrounds, deep tonal text */
         .install-card .alert-info {
             background:    #eef2ff;     /* indigo-tinted */
             border-color:  #c7d2fe;
@@ -901,6 +985,29 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
             background:    #fef2f2;
             border-color:  #fecaca;
             color:         #991b1b;
+        }
+        /* Dark-mode alert palettes — mirrors portal.css so the installer
+         * stays consistent with the runtime portal. Deep-shade bg, light
+         * tonal text — readable, no white "punch" in dark mode. */
+        [data-bs-theme="dark"] .install-card .alert-info {
+            background:    #1e1b4b;
+            border-color:  #312e81;
+            color:         #c7d2fe;
+        }
+        [data-bs-theme="dark"] .install-card .alert-warning {
+            background:    #451a03;
+            border-color:  #92400e;
+            color:         #fde68a;
+        }
+        [data-bs-theme="dark"] .install-card .alert-success {
+            background:    #052e16;
+            border-color:  #166534;
+            color:         #bbf7d0;
+        }
+        [data-bs-theme="dark"] .install-card .alert-danger {
+            background:    #450a0a;
+            border-color:  #991b1b;
+            color:         #fecaca;
         }
         /* Top-of-card error/success messages (different markup: alert + install-card class) */
         .alert.install-card { box-shadow: none; margin-bottom: 1.5rem; }

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -1118,6 +1118,32 @@ body.d-flex.vh-100 > .card h1 {
 [data-bs-theme="dark"] .alert-danger {
     background-color: #450a0a; border-color: #991b1b; color: #fecaca;
 }
+/* 🔗 Links + <code> inside coloured alerts — bind to the alert's own
+ * tonal foreground (via currentColor) so they remain readable against
+ * the tinted background in both themes. Without this, anchors inherit
+ * the global indigo link colour, which can clash against alert-warning
+ * amber, alert-success green, etc. */
+.alert a {
+    color: currentColor;
+    text-decoration: underline;
+    font-weight: var(--portal-font-weight-bold);
+}
+.alert a:hover,
+.alert a:focus {
+    color: currentColor;
+    opacity: 0.8;
+}
+.alert code {
+    background-color: rgba(0, 0, 0, 0.08);
+    color: currentColor;
+    padding: 0.125rem 0.4rem;
+    border-radius: var(--portal-radius-xs);
+    font-size: 0.875em;
+    font-family: var(--portal-font-mono);
+}
+[data-bs-theme="dark"] .alert code {
+    background-color: rgba(255, 255, 255, 0.12);
+}
 
 /* ----- Buttons (extend the existing .btn-primary override to the others) ----- */
 .btn {


### PR DESCRIPTION
## Summary

Closes #167.

The installer's bootstrap-free wizard was rendering text links (most visibly the `← Back` button on every step, and the `<code>` chip inside the step-3 info box) in **browser-default blue / purple-visited** — tacky in light mode, unreadable against the alert's indigo background in dark mode.

### Root cause

The Bootstrap 5.3.3 CSS `integrity="sha384-…"` hash in `web/_install/index.php:467` was **truncated to 60 chars** (the published hash is 64), so the browser was rejecting the stylesheet outright. With no Bootstrap loaded, none of the `.btn-outline-secondary` / `--bs-link-color` work in the inline `<style>` block had any effect, and anchors fell through to browser defaults.

### What's in the fix

- **Restored the correct Bootstrap 5.3.3 SRI hash** — now matches the hash in `_core/Asset.php` that the runtime uses successfully.
- **Defensive `a { color: var(--bs-link-color); }`** added to the installer's inline CSS so links stay on-brand even if Bootstrap ever fails to load again (CDN outage, future integrity mismatch, blocked network).
- **Dark-mode overrides** for `.alert-info` / `.alert-warning` / `.alert-success` / `.alert-danger` added to the installer (the runtime `portal.css` already had them — the standalone installer was missing them).
- **`.alert a` + `.alert code` polish via `currentColor`** — links and code chips inside alerts now inherit the alert's own tonal foreground, so they're readable against the tinted background in both themes. Applied in **both** the installer **and** `portal.css` (defence in depth across every app).
- **Re-themed the "Already Installed" lockout page** with `prefers-color-scheme` awareness instead of the hardcoded `#0d6efd` Bootstrap blue button.
- **CHANGELOG.md** — Unreleased / Fixed entry.

## Files changed

- `web/_install/index.php`
- `web/public_html/assets/css/portal.css`
- `CHANGELOG.md`

## Test plan

- [ ] Visit `/install/` on a fresh environment — confirm `← Back` button on step 2 / 3 / 4 / 5 uses the muted text-link styling (not browser-default blue).
- [ ] Toggle the installer's theme switcher to dark mode on step 3 — confirm the alert-info box uses the dark indigo background (`#1e1b4b`) with light text (`#c7d2fe`) and the `CREATE TABLE IF NOT EXISTS` code chip is clearly readable.
- [ ] Toggle to light mode — confirm same alert renders with pastel indigo background and deep indigo text, code chip readable.
- [ ] Block the jsdelivr CDN in DevTools → reload the installer → confirm anchors still render in the indigo brand colour (defensive `a` rule kicks in).
- [ ] Trip the "Already Installed" lockout (rename `_auth_keys/.installed` back into place) and visit `/install/` in both light and dark OS theme — confirm the lockout page picks up `prefers-color-scheme` and uses the indigo palette.
- [ ] In the runtime portal, place a link inside any `.alert-warning` / `.alert-success` and confirm it's readable in both themes (e.g. on `/admin` flash messages).
- [x] `php -l web/_install/index.php` → no syntax errors.
- [x] CSS brace balance verified (88/88 installer, 328/328 portal.css).

## Notes

- Hash sourced from `web/_core/Asset.php:55-56` (the runtime equivalent, which already worked correctly on the live portal — so the published library hasn't changed, only the installer's copy had drifted).
- No new dependencies, no schema changes, no migration required.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_