### PR TITLE
fix(installer): catch mysqli_sql_exception in steps 3 + 4 (#169)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,22 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ### Fixed
 
+- **Installer HTTP 500 on steps 3 and 4** (#169) — the `install_schema`
+  and `create_admin` POST handlers in `web/_install/index.php` ran
+  `multi_query` / `prepare` / `execute` without try/catch wrappers.
+  Under PHP 8.1+ mysqli defaults to strict-exception mode (and
+  `installGetDb()` re-asserts it), so ANY SQL error in
+  `full_schema.sql` (DDL conflict, FK ordering, version-specific
+  syntax, privilege denied, charset mismatch, …) — or a duplicate-email
+  INSERT during admin creation — threw an uncaught
+  `mysqli_sql_exception` and fatalled the request with a bare
+  HTTP 500. The existing `if ($stmt === false)` / `$db->errno`
+  branches were dead code under strict mode. Both handlers are now
+  wrapped in `try { … } catch (\mysqli_sql_exception $e) { … }` that
+  surfaces the real MySQL message to the user and re-renders the
+  current step. The schema-error capture loop now keeps the FIRST
+  error message (was overwriting with later "Commands out of sync"
+  follow-ups).
 - **Installer link colours** (#167) — fixed truncated Bootstrap 5.3.3 CSS
   SRI hash in `web/_install/index.php` that was causing the browser to
   reject the stylesheet, leaving anchors (most visibly the `← Back`

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -197,26 +197,46 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $step = 3;
             } else {
                 $sql = file_get_contents($schemaFile);
-                $db->multi_query($sql);
+                // 🛡️ Wrap multi_query + result-set walking in try/catch.
+                // mysqli is in strict-exception mode (PHP 8.1+ default,
+                // also re-asserted by installGetDb()), so ANY SQL error
+                // in full_schema.sql — DDL conflict, version-specific
+                // syntax, FK ordering issue, privilege denied, etc. —
+                // would otherwise throw an uncaught mysqli_sql_exception
+                // and fatal the request with a bare HTTP 500. Catching
+                // here surfaces the real MySQL message to the user
+                // instead. The $db->errno checks below remain in place
+                // as belt-and-braces for the (now unreachable) silent-
+                // failure mode on legacy PHP <8.1 hosts.
+                try {
+                    $db->multi_query($sql);
 
-                // Consume all result sets from multi_query
-                $queryError = '';
-                do {
-                    $result = $db->store_result();
-                    if ($result !== false) {
-                        $result->free();
-                    }
-                    if ($db->errno !== 0) {
-                        $queryError = $db->error;
-                    }
-                } while ($db->more_results() === true && $db->next_result());
+                    // Consume all result sets from multi_query
+                    $queryError = '';
+                    do {
+                        $result = $db->store_result();
+                        if ($result !== false) {
+                            $result->free();
+                        }
+                        // 🪞 Keep the FIRST error — a later "Commands out
+                        //    of sync" follow-up would otherwise overwrite
+                        //    the useful root-cause message.
+                        if ($db->errno !== 0 && $queryError === '') {
+                            $queryError = $db->error;
+                        }
+                    } while ($db->more_results() === true && $db->next_result());
 
-                if ($queryError !== '') {
-                    $error = 'Schema installation error: ' . $queryError;
+                    if ($queryError !== '') {
+                        $error = 'Schema installation error: ' . $queryError;
+                        $step = 3;
+                    } else {
+                        $db->close();
+                        header('Location: ?step=4');
+                        exit();
+                    }
+                } catch (\mysqli_sql_exception $e) {
+                    $error = 'Schema installation error: ' . $e->getMessage();
                     $step = 3;
-                } else {
-                    header('Location: ?step=4');
-                    exit();
                 }
             }
             $db->close();
@@ -270,57 +290,72 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 $error = 'Database connection lost. Please go back to Step 2.';
                 $step = 2;
             } else {
-                // Insert admin user
-                $hash = password_hash($adminPass, PASSWORD_DEFAULT);
-                $stmt = $db->prepare(
-                    'INSERT INTO tblUsers (fullName, emailAddress, isAdmin, isRootAdmin, isActive, createdAt, siteID) '
-                    . 'VALUES (?, ?, 1, 1, 1, NOW(), 1)'
-                );
-                if ($stmt === false) {
-                    $error = 'Failed to prepare user insert: ' . $db->error;
+                // 🛡️ Wrap the whole admin-create flow in try/catch — see
+                // step 3 above for the rationale. A duplicate-email INSERT,
+                // an FK violation, or any other constraint failure would
+                // otherwise throw an uncaught mysqli_sql_exception and
+                // fatal the request. The `$stmt === false` and
+                // `if ($stmtLocal !== false)` guards below are kept as
+                // belt-and-braces — under strict mode they're effectively
+                // dead code, but they keep the handler safe if a future
+                // change toggles mysqli_report back to silent.
+                try {
+                    // Insert admin user
+                    $hash = password_hash($adminPass, PASSWORD_DEFAULT);
+                    $stmt = $db->prepare(
+                        'INSERT INTO tblUsers (fullName, emailAddress, isAdmin, isRootAdmin, isActive, createdAt, siteID) '
+                        . 'VALUES (?, ?, 1, 1, 1, NOW(), 1)'
+                    );
+                    if ($stmt === false) {
+                        $error = 'Failed to prepare user insert: ' . $db->error;
+                        $step = 4;
+                    } else {
+                        $stmt->bind_param('ss', $adminName, $adminEmail);
+                        $stmt->execute();
+                        $newUserId = $stmt->insert_id;
+                        $stmt->close();
+
+                        // Create local auth account
+                        $stmtLocal = $db->prepare(
+                            'INSERT INTO tblLocalAccounts (userID, username, passwordHash, isVerified, createdAt) '
+                            . 'VALUES (?, ?, ?, 1, NOW())'
+                        );
+                        if ($stmtLocal !== false) {
+                            $stmtLocal->bind_param('iss', $newUserId, $adminEmail, $hash);
+                            $stmtLocal->execute();
+                            $stmtLocal->close();
+                        }
+
+                        // Assign to default site
+                        $stmtSite = $db->prepare(
+                            'INSERT INTO tblUserSites (userID, siteID, isSiteAdmin, isSiteRootAdmin, isActive) '
+                            . 'VALUES (?, 1, 1, 1, 1)'
+                        );
+                        if ($stmtSite !== false) {
+                            $stmtSite->bind_param('i', $newUserId);
+                            $stmtSite->execute();
+                            $stmtSite->close();
+                        }
+
+                        // Update default site settings with the admin's email
+                        $stmtSetting = $db->prepare(
+                            'UPDATE tblSettings SET settingValue = ? WHERE settingKey = \'site.adminEmail\' AND siteID IS NULL'
+                        );
+                        if ($stmtSetting !== false) {
+                            $stmtSetting->bind_param('s', $adminEmail);
+                            $stmtSetting->execute();
+                            $stmtSetting->close();
+                        }
+
+                        $db->close();
+                        header('Location: ?step=5');
+                        exit();
+                    }
+                } catch (\mysqli_sql_exception $e) {
+                    $error = 'Failed to create administrator: ' . $e->getMessage();
                     $step = 4;
-                } else {
-                    $stmt->bind_param('ss', $adminName, $adminEmail);
-                    $stmt->execute();
-                    $newUserId = $stmt->insert_id;
-                    $stmt->close();
-
-                    // Create local auth account
-                    $stmtLocal = $db->prepare(
-                        'INSERT INTO tblLocalAccounts (userID, username, passwordHash, isVerified, createdAt) '
-                        . 'VALUES (?, ?, ?, 1, NOW())'
-                    );
-                    if ($stmtLocal !== false) {
-                        $stmtLocal->bind_param('iss', $newUserId, $adminEmail, $hash);
-                        $stmtLocal->execute();
-                        $stmtLocal->close();
-                    }
-
-                    // Assign to default site
-                    $stmtSite = $db->prepare(
-                        'INSERT INTO tblUserSites (userID, siteID, isSiteAdmin, isSiteRootAdmin, isActive) '
-                        . 'VALUES (?, 1, 1, 1, 1)'
-                    );
-                    if ($stmtSite !== false) {
-                        $stmtSite->bind_param('i', $newUserId);
-                        $stmtSite->execute();
-                        $stmtSite->close();
-                    }
-
-                    // Update default site settings with the admin's email
-                    $stmtSetting = $db->prepare(
-                        'UPDATE tblSettings SET settingValue = ? WHERE settingKey = \'site.adminEmail\' AND siteID IS NULL'
-                    );
-                    if ($stmtSetting !== false) {
-                        $stmtSetting->bind_param('s', $adminEmail);
-                        $stmtSetting->execute();
-                        $stmtSetting->close();
-                    }
-
-                    $db->close();
-                    header('Location: ?step=5');
-                    exit();
                 }
+                $db->close();
             }
         }
     }


### PR DESCRIPTION
## Summary

Closes #169. **Fixes the HTTP 500 on installer step 3 (and the same latent bug on step 4).**

### Root cause

Under **PHP 8.1+**, the default `mysqli_report()` mode is `MYSQLI_REPORT_ERROR | MYSQLI_REPORT_STRICT` — every mysqli error throws `mysqli_sql_exception`. `installGetDb()` (`web/install/index.php:343`) also sets this mode explicitly, and it's process-global for the rest of the request.

The `install_schema` and `create_admin` POST handlers ran their mysqli calls **without any try/catch wrapper**:

| Step | Handler | Unguarded calls |
|------|---------|-----------------|
| 3 | `install_schema` | `$db->multi_query($sql)` + `$db->next_result()` loop |
| 4 | `create_admin` | `$stmt = $db->prepare(...)`, `$stmt->execute()` ×4 |

So **any** SQL hiccup in `full_schema.sql` (DDL conflict, FK ordering, version-specific syntax, privilege denied, charset mismatch, etc.) — or a duplicate-email INSERT on step 4 — produced an uncaught fatal and a bare HTTP 500, with **no useful error visible to the user**.

The existing `if ($stmt === false)` / `if ($db->errno !== 0)` return-value guards were dead code under strict mode (the exception fires first).

### Fix

- `web/install/index.php`
  - Wrap step 3's `multi_query` + result-set walk in `try { … } catch (\mysqli_sql_exception $e) { … }` — surface the MySQL message as `$error` and re-render step 3 with the red banner.
  - Wrap step 4's admin-create flow the same way; surface `"Failed to create administrator: <reason>"`.
  - Capture the **first** query error in the result-set loop instead of the last so a later "Commands out of sync" follow-up doesn't overwrite the useful root-cause message.
  - Ensure `$db->close()` runs on the exception path too.
  - Keep the existing return-value guards as belt-and-braces.
- `CHANGELOG.md` — Unreleased / Fixed entry.

### Verification

- **Repro confirmed**: a minimal harness that simulates `multi_query` throwing under strict mode produces `PHP Fatal error: Uncaught mysqli_sql_exception` + exit code 255 with the old code, exactly matching the user's HTTP 500.
- **Fix confirmed**: same harness against the patched handler shape prints `Step: 3 / Error: Schema installation error: <message> / PASS — handler caught exception, no 500`.
- **Lint**: `php -l web/install/index.php` clean (PHP 8.4 — server runs 8.5, same default).

### Note on scope

This is **unrelated to PR #168** (which was CSS-only). It's a pre-existing runtime bug latent since whenever the installer was last exercised on a PHP 8.1+ host.

## Test plan

- [ ] Re-trigger the installer on `portal.millrdsdacambridge.uk` (clear the `_auth_keys/.installed` lock + `_auth_keys/auth_creds.php`).
- [ ] Walk steps 1 → 2. Step 2 should still complete unchanged.
- [ ] Click "Install Schema" on step 3 against a database that currently has the partial / conflicting state that was causing the 500. Expect: **friendly error banner with the MySQL message**, page renders normally, NOT a 500.
- [ ] Resolve the underlying SQL issue (drop conflicting tables / fix privileges / whatever the banner reveals) and re-submit. Expect: successful redirect to step 4.
- [ ] Complete steps 4 → 6 end-to-end on a clean database. Expect: happy path unchanged.
- [ ] (Regression) Submit step 4 twice with the same email. Expect: red banner explaining the duplicate, NOT a 500.
- [x] `php -l web/install/index.php` clean.
- [x] Runtime catch verified with mock-mysqli harness.

## Files changed

- `web/install/index.php`
- `CHANGELOG.md`


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_