### PR TITLE
fix(sql): seed default tblSites row in full_schema.sql (#171)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,20 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ### Fixed
 
+- **`full_schema.sql` missing default site seed** (#171) — every
+  fresh install since the migrations were consolidated into
+  `web/_sql/full_schema.sql` was failing at step 3 with
+  `Cannot add or update a child row: a foreign key constraint
+  fails (...\`tblEventTypes\`, CONSTRAINT \`fk_etype_site\` FOREIGN KEY
+  (\`siteID\`) REFERENCES \`tblSites\`(\`siteID\`))`. A dozen tables
+  declare `siteID INT NOT NULL DEFAULT 1` with an FK back to
+  `tblSites`, but the consolidated schema had dropped the
+  `INSERT INTO tblSites … siteID=1 …` seed that the original
+  `015_multisite.sql` migration provided. Restored the seed at the
+  top of the data-seed section using the same idempotent
+  `INSERT … SELECT … WHERE NOT EXISTS` pattern. This was masked by
+  the original HTTP 500 (#169); now that the installer surfaces the
+  underlying MySQL message the cause is visible and fixable.
 - **Installer HTTP 500 on steps 3 and 4** (#169) — the `install_schema`
   and `create_admin` POST handlers in `web/_install/index.php` ran
   `multi_query` / `prepare` / `execute` without try/catch wrappers.

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -995,6 +995,19 @@ COMMENT='Centralised error log for all platforms/libraries. See core/Logger.php.
 -- (ON DUPLICATE KEY preserves existing values)
 -- #############################################################################
 
+-- 🏠 Default site (siteID=1) — bootstrap before any FK-dependent seed.
+--    A dozen tables (tblEventTypes, tblEventCategories, tblUserSites, …)
+--    declare `siteID INT NOT NULL DEFAULT 1` with an FK back to
+--    `tblSites(siteID)`. Without this row the SECTION 5B / 6 INSERTs
+--    further down trip the FK and the installer's step-3 schema run
+--    halts. Originally seeded by migration `015_multisite.sql`; dropped
+--    when the migrations were consolidated into this file — restored
+--    here. Idempotent: re-runs skip via `WHERE NOT EXISTS`.
+INSERT INTO `tblSites` (`siteID`, `siteName`, `siteKey`, `copyrightOrg`, `timezone`)
+SELECT 1, 'Portal', 'default', 'Organisation', 'UTC'
+FROM DUAL
+WHERE NOT EXISTS (SELECT 1 FROM `tblSites` WHERE `siteID` = 1);
+
 -- ─── Site settings ───────────────────────────────────────────────────────────
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
 VALUES ('site.name', 'Portal', 0, 'Portal')


### PR DESCRIPTION
## Summary

Closes #171. **Unblocks fresh installs.** With #169 already merged, the installer now surfaces the underlying MySQL error instead of a bare 500 — and that error reveals this latent schema bug.

### Root cause

`web/_sql/full_schema.sql` defines `tblSites` and a dozen tables that reference it via `FOREIGN KEY (siteID) REFERENCES tblSites(siteID)` with `siteID INT NOT NULL DEFAULT 1`. But the consolidated schema's seed section **never inserts the default `siteID = 1` row**, so the first FK-dependent seed INSERT (`tblEventTypes` at line 1456) trips `fk_etype_site` and step 3 halts with:

> Cannot add or update a child row: a foreign key constraint fails (...\`tblEventTypes\`, CONSTRAINT \`fk_etype_site\` FOREIGN KEY (\`siteID\`) REFERENCES \`tblSites\` (\`siteID\`))

The original migration `015_multisite.sql` had this seed:

```sql
INSERT INTO `tblSites` (`siteID`, `siteName`, `siteKey`, `copyrightOrg`, `timezone`)
SELECT 1, COALESCE((SELECT settingValue FROM tblSettings WHERE settingKey='site.name'), 'Portal'),
       'default',
       COALESCE((SELECT settingValue FROM tblSettings WHERE settingKey='site.copyrightOrg'), 'Organisation'),
       COALESCE((SELECT settingValue FROM tblSettings WHERE settingKey='site.timezone'), 'UTC')
FROM DUAL
WHERE NOT EXISTS (SELECT 1 FROM `tblSites` WHERE `siteID` = 1);
```

When migrations were consolidated into `full_schema.sql`, this seed block got dropped. Every fresh install since has been broken — masked until now by the HTTP 500 fix in #169.

`tblEventCategories` (line 1478) and the installer's `create_admin → tblUserSites` INSERT would also fail with the same FK violation for the same reason.

### Fix

- `web/_sql/full_schema.sql`
  - Add the `tblSites siteID=1` seed at the top of `SECTION 5: SEED DATA`, **before** any FK-dependent INSERT.
  - Idempotent: `INSERT … SELECT … FROM DUAL WHERE NOT EXISTS (SELECT 1 FROM tblSites WHERE siteID = 1)` — re-runs preserve any existing custom values.
  - Uses literal defaults (`'Portal'` / `'default'` / `'Organisation'` / `'UTC'`) since at fresh-install time `tblSettings` is also empty; simpler than the migration #015 COALESCE chain, with the same outcome on a clean DB.
- `CHANGELOG.md` — Unreleased / Fixed entry.

### Test plan

- [ ] **Repro confirmed**: user's screenshot from `?step=3` showed the exact FK error string captured in the issue body.
- [ ] On a clean database, click "Install Schema" on step 3. Expect: green "✓" step indicator → redirect to step 4. (Previously: red banner with FK error.)
- [ ] Continue to step 4 (Create Admin). Expect: admin row inserted, `tblUserSites` insert succeeds, redirect to step 5.
- [ ] Verify in the DB: `SELECT siteID, siteName, siteKey FROM tblSites;` returns `(1, 'Portal', 'default')`.
- [ ] **Idempotency**: re-run the schema on a DB that already has a custom `tblSites` row (e.g. one renamed to your real site name). Expect: the existing row is preserved untouched (the `WHERE NOT EXISTS` skips the INSERT).
- [ ] CI lint / Psalm / static security checks all green.

### Files changed

- `web/_sql/full_schema.sql`
- `CHANGELOG.md`

### Note on local verification

No MySQL/MariaDB or container runtime was available in the sandbox to execute the schema end-to-end. The added INSERT is verbatim the pattern from `015_multisite.sql` which has been running on this very production database without issue, so the syntax is known-good.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_