### PR TITLE
fix: SQL column-name mismatches across installer + import + GDPR export (#198)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,41 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Fixed — Audit follow-up #2: SQL column-name mismatches (#198)
+
+A class of bug my prior audit didn't check for: runtime SQL statements
+that reference columns which don't exist on the named table. Surfaced
+when the user hit step 4 of the installer with `Unknown column 'siteID'
+in 'field list'`. A targeted re-audit found 5 more instances of the
+same shape across 3 files.
+
+- **Installer step 4** — `web/_install/index.php:306` removed `siteID`
+  from the `tblUsers` INSERT. `tblUsers` has no `siteID` column; multi-
+  site assignment is via `tblUserSites` (already inserted on the next
+  statement).
+- **Bulk user import** — `web/public_html/admin/users/import.php:156`
+  had the identical `tblUsers.siteID` bug. Removed; `bind_param` updated.
+- **GDPR data export** — `web/public_html/auth/account/data-export.php`:
+  - `tblLinkedAccounts`: `createdAt` → `linkedAt`
+  - `tblWebAuthnCredentials`: `label` → `friendlyName`
+  - `tblExpenseClaims`: `submittedByID` → `userID`
+  Three columns the schema never had / had renamed — would have fatalled
+  every `/account/data-export` request.
+- **tblLocalAccounts schema drift** — runtime code (installer step 4 +
+  GDPR export) referenced `isVerified` and `createdAt` columns that no
+  migration ever added to `tblLocalAccounts`. Both clearly intended
+  (installer sets `isVerified = 1` for the admin; GDPR export reads
+  both). Added to `full_schema.sql` CREATE TABLE; new migration
+  `053_local_accounts_columns.sql` adds them to existing installs via
+  idempotent `ADD COLUMN IF NOT EXISTS`.
+
+The honest reason this slipped past the previous "thorough check": my
+audit prompts covered uncaught exceptions, schema-vs-migration drift,
+path drift, and CSRF/auth gates — but not "do runtime SQL column names
+exist on the named tables". Added that dimension to the audit
+playbook for the next sweep.
+
+
 ### Fixed — Codebase audit follow-ups
 
 - **Bootstrap critical-path mysqli exceptions** (#173, #174, #175) — wrapped

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -300,11 +300,16 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                 // dead code, but they keep the handler safe if a future
                 // change toggles mysqli_report back to silent.
                 try {
-                    // Insert admin user
+                    // Insert admin user. Note: tblUsers has NO siteID column —
+                    // multi-site assignment is via tblUserSites (inserted
+                    // below). An earlier version of this handler included
+                    // `siteID = 1` directly on tblUsers, which fatalled the
+                    // installer step 4 with "Unknown column 'siteID'" on every
+                    // fresh install. See issue #200.
                     $hash = password_hash($adminPass, PASSWORD_DEFAULT);
                     $stmt = $db->prepare(
-                        'INSERT INTO tblUsers (fullName, emailAddress, isAdmin, isRootAdmin, isActive, createdAt, siteID) '
-                        . 'VALUES (?, ?, 1, 1, 1, NOW(), 1)'
+                        'INSERT INTO tblUsers (fullName, emailAddress, isAdmin, isRootAdmin, isActive, createdAt) '
+                        . 'VALUES (?, ?, 1, 1, 1, NOW())'
                     );
                     if ($stmt === false) {
                         $error = 'Failed to prepare user insert: ' . $db->error;

--- a/web/_sql/053_local_accounts_columns.sql
+++ b/web/_sql/053_local_accounts_columns.sql
@@ -1,0 +1,35 @@
+-- =============================================================================
+-- Migration 053: tblLocalAccounts — add missing isVerified + createdAt columns
+-- =============================================================================
+-- The runtime code (installer step 4 admin-create, /account/data-export GDPR
+-- bundle) has referenced these columns since v0.1, but they were never added
+-- to the table by any prior migration. Existing installs need this ALTER;
+-- fresh installs pick them up from the updated CREATE TABLE in
+-- full_schema.sql at the same time.
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/198
+-- =============================================================================
+
+-- 🔑 Whether the local account's email was verified before activation.
+--    Defaults to 0 so existing-row backfill matches the historical "pending"
+--    state for accounts created before the columns existed; the runtime sets
+--    it to 1 on admin-created and installer-created accounts.
+ALTER TABLE `tblLocalAccounts`
+    ADD COLUMN IF NOT EXISTS `isVerified` TINYINT(1) NOT NULL DEFAULT 0
+        COMMENT 'Whether the email was verified before activation'
+        AFTER `passwordHash`;
+
+-- 📅 Local-account creation timestamp.
+--    Defaults to CURRENT_TIMESTAMP for new inserts; for backfilling existing
+--    rows we use the most recent `lastLogin` if present, else NOW(). This is
+--    an approximation — the original creation time wasn't recorded.
+ALTER TABLE `tblLocalAccounts`
+    ADD COLUMN IF NOT EXISTS `createdAt` DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP
+        AFTER `lastLogin`;
+
+-- 🗂️ Backfill createdAt for existing rows: prefer lastLogin if it's older
+--    than the new default, else leave as the freshly-defaulted NOW().
+UPDATE `tblLocalAccounts`
+SET    `createdAt` = `lastLogin`
+WHERE  `lastLogin` IS NOT NULL
+  AND  `createdAt` > `lastLogin`;

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -223,7 +223,10 @@ CREATE TABLE IF NOT EXISTS `tblLocalAccounts` (
     `username`     VARCHAR(50)  COLLATE utf8mb4_general_ci NOT NULL,
     `passwordHash` VARCHAR(255) COLLATE utf8mb4_general_ci NOT NULL
                    COMMENT 'bcrypt hash via password_hash()',
+    `isVerified`   TINYINT(1)   NOT NULL DEFAULT 0
+                   COMMENT 'Whether the email was verified before activation. Admins created via the installer are auto-verified (=1).',
     `lastLogin`    DATETIME     DEFAULT NULL,
+    `createdAt`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
     PRIMARY KEY (`localID`),
     UNIQUE KEY `username` (`username`),
     KEY `userID` (`userID`),
@@ -2356,6 +2359,9 @@ INSERT INTO `tblMigrations` (`filename`) VALUES ('051_email_templates.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblMigrations` (`filename`) VALUES ('052_bulk_importers.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('053_local_accounts_columns.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES

--- a/web/public_html/admin/users/import.php
+++ b/web/public_html/admin/users/import.php
@@ -152,9 +152,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $created = 0;
             $skipped = 0;
 
+            // Note: tblUsers has NO siteID column — multi-site assignment is
+            // via tblUserSites (inserted below). An earlier version of this
+            // statement included siteID directly on tblUsers, which fatalled
+            // the import with "Unknown column 'siteID'" the moment a non-
+            // admin first tried to use the importer. See issue #198.
             $insertStmt = $mysqli->prepare(
-                'INSERT INTO tblUsers (fullName, emailAddress, isAdmin, isActive, createdAt, siteID) '
-                . 'VALUES (?, ?, ?, 1, NOW(), ?)'
+                'INSERT INTO tblUsers (fullName, emailAddress, isAdmin, isActive, createdAt) '
+                . 'VALUES (?, ?, ?, 1, NOW())'
             );
             $siteStmt = $mysqli->prepare(
                 'INSERT INTO tblUserSites (userID, siteID, isActive) VALUES (?, ?, 1)'
@@ -168,7 +173,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         continue;
                     }
 
-                    $insertStmt->bind_param('ssii', $row['name'], $row['email'], $row['isAdmin'], $siteId);
+                    $insertStmt->bind_param('ssi', $row['name'], $row['email'], $row['isAdmin']);
 
                     try {
                         $insertStmt->execute();

--- a/web/public_html/auth/account/data-export.php
+++ b/web/public_html/auth/account/data-export.php
@@ -89,10 +89,12 @@ $payload = [
             'SELECT localID, userID, username, isVerified, createdAt FROM tblLocalAccounts WHERE userID = ? LIMIT 1'
         ),
         'linkedAccounts' => $fetchUserRows(
-            'SELECT linkID, userID, provider, providerEmail, createdAt FROM tblLinkedAccounts WHERE userID = ?'
+            // tblLinkedAccounts uses `linkedAt` not `createdAt`
+            'SELECT linkID, userID, provider, providerEmail, linkedAt FROM tblLinkedAccounts WHERE userID = ?'
         ),
         'webauthnCredentials' => $fetchUserRows(
-            'SELECT credentialID, userID, label, transports, createdAt, lastUsedAt FROM tblWebAuthnCredentials WHERE userID = ?'
+            // tblWebAuthnCredentials uses `friendlyName` not `label`
+            'SELECT credentialID, userID, friendlyName, transports, createdAt, lastUsedAt FROM tblWebAuthnCredentials WHERE userID = ?'
         ),
         'passwordResets' => $fetchUserRows(
             'SELECT resetID, userID, expiresAt, usedAt, createdAt, createdIP FROM tblPasswordResets WHERE userID = ?'
@@ -101,7 +103,8 @@ $payload = [
             'SELECT logID, activityType, activityDescription, visitorIP, timestamp FROM tblActivityLogs WHERE userID = ? ORDER BY timestamp DESC LIMIT 5000'
         ),
         'expenseClaims' => $fetchUserRows(
-            'SELECT * FROM tblExpenseClaims WHERE submittedByID = ?'
+            // tblExpenseClaims uses `userID` not `submittedByID`
+            'SELECT * FROM tblExpenseClaims WHERE userID = ?'
         ),
         'prayerRequests' => $fetchUserRows(
             'SELECT * FROM tblPrayerRequests WHERE submitterID = ?'


### PR DESCRIPTION
## Summary

Closes #198. **Unblocks step 4 of fresh installs** + fixes 5 more cascading column-name mismatches the user hadn't hit yet.

### Honest gap in the previous audit

The user is right to be frustrated. After the audit sweep in #197, the user hit step 4 of the installer with `Unknown column 'siteID' in 'field list'`. The previous audit covered four dimensions thoroughly (uncaught exceptions, schema-vs-migration drift, path drift, CSRF/auth gates) but **did not check whether runtime SQL column names actually exist on the named tables** — a separate, mechanical class of bug. Re-ran the audit with that dimension added; found 6 instances across 3 files.

### Bugs fixed

| # | File | Bug | Fix |
|---|------|-----|-----|
| 1 | `web/_install/index.php:306` | `INSERT INTO tblUsers (..., siteID)` — column doesn't exist | Removed `siteID` from column list + VALUES |
| 2 | `web/public_html/admin/users/import.php:156` | Same `tblUsers.siteID` bug — would fatal CSV import | Same fix; `bind_param` updated |
| 3 | `web/public_html/auth/account/data-export.php:92` | `tblLinkedAccounts.createdAt` — schema uses `linkedAt` | `createdAt` → `linkedAt` |
| 4 | `web/public_html/auth/account/data-export.php:95` | `tblWebAuthnCredentials.label` — schema renamed to `friendlyName` | `label` → `friendlyName` |
| 5 | `web/public_html/auth/account/data-export.php:104` | `tblExpenseClaims.submittedByID` — schema uses `userID` | `submittedByID` → `userID` |
| 6 | `web/_sql/full_schema.sql` (tblLocalAccounts) | `isVerified` + `createdAt` columns referenced by installer + GDPR export, never added by any migration | Added both to CREATE TABLE + new migration for existing installs |

Bug #1 is what the user hit. #2 was latent (next admin to use CSV import would have hit it). #3–#5 would fatal any `/account/data-export` request. #6 was the next bug that would have cascaded once #1 was fixed (installer step 4 would have hit `Unknown column 'isVerified'` on the `tblLocalAccounts` INSERT).

### Why my prior audit missed this class

The four agent prompts in the previous sweep asked specifically about:
1. Unguarded `mysqli` exceptions (the strict-mode 500 pattern)
2. `full_schema.sql` vs numbered migrations — but compared **schema files to schema files**, not schema vs runtime PHP
3. Hardcoded paths matching the renamed directory layout
4. Auth / CSRF / permission gates

None of those would catch "PHP code references column X but the table has column Y". Adding that dimension to the audit playbook for future sweeps.

### Files changed

- `web/_install/index.php` (-2 / +9) — siteID removed + explanatory comment
- `web/public_html/admin/users/import.php` (-3 / +8) — siteID removed + bind_param fixed
- `web/public_html/auth/account/data-export.php` (-3 / +6) — three column-name corrections
- `web/_sql/full_schema.sql` (-1 / +5) — tblLocalAccounts schema fix + 053 in tblMigrations seed
- `web/_sql/053_local_accounts_columns.sql` (new, 35 lines) — ALTER for existing installs + lastLogin-based backfill
- `CHANGELOG.md` (+35) — Unreleased / Fixed entry

### Test plan

- [ ] **Repro confirmed**: user's screenshot shows the exact error string captured in the issue body for step 4.
- [ ] Fresh install on empty DB: complete steps 1 → 6 cleanly. Admin row in `tblUsers`, `tblLocalAccounts` row with `isVerified=1`, `tblUserSites` row with `siteID=1`. Log in with the new credentials.
- [ ] Existing install: run migration 053 → confirm `tblLocalAccounts` gains the two columns; existing rows are backfilled (`createdAt = lastLogin` where present); no data loss.
- [ ] `/admin/users/import` against a small test CSV: bulk-create users without "Unknown column 'siteID'". Verify `tblUserSites` is populated correctly.
- [ ] `/account/data-export` for a user with at least one WebAuthn credential, one linked account, and one expense claim: download completes; JSON includes those sections without SQL errors.
- [x] `php -l` clean on all 3 touched PHP files.
- [x] Re-sweep grep: no remaining live `tblUsers.*siteID` / `tblLocalAccounts.*isVerified` / `label.*tblWebAuthn` / `submittedByID.*tblExpenseClaims` matches outside explanatory comments.

### Note on scope

A separate **broader audit follow-up** is sensible — there are likely more SQL column references across the codebase I haven't checked beyond the installer / import / data-export critical paths. Happy to spin up a focused sweep covering app handlers (`admin/`, `expenses/`, `calendar/`, etc.) if you want, but didn't include it in this PR to keep the diff scoped to the blocking issue + its known cascade.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_