### PR TITLE
ci(pr-security): suppress two repeated false positives (int casts + installer CSRF)

### DIFF
--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -169,14 +169,34 @@ jobs:
           add_section "SQL injection candidates (mysqli->query / mysqli_query with \$_GET/POST/REQUEST/COOKIE)" "$SQLI"
 
           # ---- 4) XSS heuristic -------------------------------------------
-          # echo or print of $_GET/POST/REQUEST/COOKIE without htmlspecialchars on the same line
+          # echo or print of $_GET/POST/REQUEST/COOKIE without sanitisation
+          # on the same line. Lines are EXCLUDED if they contain any of:
+          #
+          #   • htmlspecialchars / htmlentities / h(          — explicit escapers
+          #   • (int) / (integer) / (float) / (double) / (bool) / (boolean)
+          #     — PHP type casts that produce values incapable of carrying
+          #       markup (the matched bytes are guaranteed to be 0-9, -, .,
+          #       or empty for bool/int casts)
+          #   • intval( / floatval( / boolval(              — function equivalents
+          #
+          # These suppressions stop the heuristic firing on idioms like
+          # `value="<?php echo (int) ($_POST['db_port'] ?? 3306); ?>"`
+          # which are safe by construction.
           XSS=$(echo "$CHANGED" | xargs -r grep -nE '(echo|print)\s+[^;]*\$_(GET|POST|REQUEST|COOKIE)' 2>/dev/null \
-              | grep -v 'htmlspecialchars\|htmlentities\|h(' || true)
+              | grep -vE 'htmlspecialchars|htmlentities|h\(|\(int\)|\(integer\)|\(float\)|\(double\)|\(bool\)|\(boolean\)|intval\(|floatval\(|boolval\(' || true)
           add_section "Possible unescaped output of user input" "$XSS"
 
           # ---- 5) CSRF heuristic -----------------------------------------
-          # form method=post lacking a csrf_token hidden input within 30 lines
-          CSRF_FILES=$(echo "$CHANGED" | xargs -r grep -lE '<form[^>]*method\s*=\s*["'\'']?post' 2>/dev/null || true)
+          # form method=post lacking any csrf_token reference anywhere in
+          # the file.
+          #
+          # Files under web/_install/ are EXCLUDED — the installation
+          # wizard runs before bootstrap.php loads (no Auth::csrfToken()
+          # available), is single-use (locks itself with _auth_keys/.installed
+          # on completion), and is a documented architectural exception.
+          # Confirmed safe at PR #170 review.
+          CSRF_FILES=$(echo "$CHANGED" | xargs -r grep -lE '<form[^>]*method\s*=\s*["'\'']?post' 2>/dev/null \
+              | grep -vE '^web/_install/' || true)
           CSRF_MISSING=""
           for f in $CSRF_FILES; do
             if ! grep -qE 'csrf_token|csrf\b' "$f"; then


### PR DESCRIPTION
## Summary

Suppresses the two repeated false positives that have fired on **every** installer-touching PR (#168, #170, #197, #199) without ever flagging a real bug.

### Changes

**XSS heuristic (step 4):**
Added PHP type casts and the `intval`/`floatval`/`boolval` function calls to the same-line exclusion list alongside the existing `htmlspecialchars`/`htmlentities`/`h(` patterns. Casts produce values incapable of carrying markup — `(int) $_POST['x']` returns digits/sign only, so:

```php
value="<?php echo (int) ($_POST['db_port'] ?? 3306); ?>"
```

is safe by construction and no longer flagged.

**CSRF heuristic (step 5):**
Files under `web/_install/` are now excluded from the "POST forms without CSRF" check. The installer is a documented architectural exception:
- Runs before `bootstrap.php` loads → no `Auth::csrfToken()` available
- Single-use → locks itself with `_auth_keys/.installed` on completion
- Confirmed safe at PR #170 review; now codified instead of waved off manually each PR

### Verification (run locally before commit)

| Test case | Old | New |
|---|---|---|
| `echo (int) ($_POST['db_port'] ?? 3306)` | ❌ flagged (false positive) | ✅ suppressed |
| `echo $_GET["q"]` (real XSS) | ✅ flagged | ✅ still flagged |
| `web/_install/index.php` POST forms | ❌ flagged (false positive) | ✅ suppressed |
| `web/public_html/admin/users/edit.php` POST forms | ✅ flagged if no CSRF | ✅ still flagged |

### Test plan

- [x] Local heuristic dry-run confirms both false positives suppressed.
- [x] Local heuristic dry-run confirms real XSS / non-installer CSRF gaps still caught.
- [ ] Confirm on the next PR that touches the installer that no false-positive findings appear.
- [ ] Confirm on a synthetic test PR (deliberate `echo $_GET[...]` without escaping) that the XSS heuristic still fires.

### Files changed

- `.github/workflows/pr-security.yml` (-4 / +24)


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_