### PR TITLE
fix: cross-source consistency audit follow-up #3 (#201 #202 #204 #205 #206 #207)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,50 @@ to `alpha`, `beta`, and `main` using the heading format
 
 ## [Unreleased]
 
+### Fixed — Audit follow-up #3: cross-source consistency
+
+A four-dimension parallel audit (SQL ↔ schema, routes ↔ files, settings ↔
+code, i18n keys ↔ translations) surfaced 13 more findings. This entry
+covers the 6 actionable runtime bugs (#201, #202, #204, #205, #206, #207).
+Two settings findings (#203 + #208) were re-investigated and closed as
+false positives — both keys were seeded further down in
+`full_schema.sql` than the audit looked. The i18n findings (#209, #210,
+#211) are tracked separately for cleanup / triage.
+
+- **`tblEvents.deletedAt` missing column** (#201) — `events/api/delete.php`
+  sets `deletedAt = NOW()` alongside `isDeleted = 1` in its soft-delete
+  UPDATE, but the column was never added. Every admin event-delete
+  fatalled with `Unknown column 'deletedAt'`. Added to schema +
+  migration `054_events_deleted_at.sql`.
+- **`admin/upgrade` route had invalid targetFile** (#202) — pointed at
+  `../install/upgrade.php` (escapes `public_html/`, uses the
+  pre-rename `install/` name). Clicking the link 404'd. New proxy
+  file `web/public_html/admin/upgrade.php` `require`s the real handler
+  at `_install/upgrade.php`; route now points at the proxy. Migration
+  `055_admin_upgrade_route_fix.sql` repoints the route on existing
+  installs.
+- **Five redundant `api/*` routes** (#204) — migration 035 inserted
+  `api/announcements/list`, `api/attendance/list`, `api/events/detail`,
+  `api/events/list`, `api/users/list` against a routing shape the
+  router doesn't actually use (the `api/` prefix is special-cased to
+  `ApiRouter::dispatch()` which resolves `{app}/api/{action}.php`).
+  Pure dead config. Migration `056_remove_redundant_api_routes.sql`
+  DELETEs them on existing installs.
+- **Dead `account/linked-accounts` route** (#205) — target file
+  `auth/account/linked-accounts.php` was never created. Removed from
+  schema + migration `057_remove_dead_linked_accounts_route.sql`.
+- **`login/webauthn` route missing** (#206) — the WebAuthn AJAX
+  endpoint at `auth/login/webauthn.php` was called from the login
+  form via `fetch('/login/webauthn')` but had no route entry. Worked
+  via `.htaccess` fall-through until the v1.0 security hardening
+  tightened direct-PHP access; now needs the route. Added to schema +
+  migration `058_login_webauthn_route.sql`. `isProtected=0` (pre-auth).
+- **`api.expenses.delete.enabled` wrongly marked `isSensitive=1`**
+  (#207) — the value is the boolean flag `'false'`, not a credential.
+  Sensitive=1 makes the bootstrap loader try to libsodium-decrypt the
+  plaintext on every request. Flipped to 0 in schema + migration
+  `059_fix_api_expenses_delete_isSensitive.sql`.
+
 ### Fixed — Audit follow-up #2: SQL column-name mismatches (#198)
 
 A class of bug my prior audit didn't check for: runtime SQL statements

--- a/web/_sql/054_events_deleted_at.sql
+++ b/web/_sql/054_events_deleted_at.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration 054: tblEvents — add missing deletedAt column
+-- =============================================================================
+-- web/public_html/events/api/delete.php sets `deletedAt = NOW()` alongside
+-- `isDeleted = 1` in its soft-delete UPDATE, but the column was never added
+-- to tblEvents. Every admin attempt to delete an event hit
+-- "Unknown column 'deletedAt' in 'field list'".
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/201
+-- =============================================================================
+
+ALTER TABLE `tblEvents`
+    ADD COLUMN IF NOT EXISTS `deletedAt` DATETIME DEFAULT NULL
+        COMMENT 'Timestamp of soft-delete (set when isDeleted flips to 1)'
+        AFTER `isDeleted`;

--- a/web/_sql/055_admin_upgrade_route_fix.sql
+++ b/web/_sql/055_admin_upgrade_route_fix.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- Migration 055: Fix admin/upgrade route targetFile
+-- =============================================================================
+-- The original migration `025_install_upgrade_route.sql` registered:
+--     admin/upgrade  ->  ../install/upgrade.php
+-- That path uses `..` to escape `public_html/` (which the Router doesn't
+-- allow) AND references the old directory name `install/` (renamed to
+-- `_install/`). Clicking the link 404s.
+--
+-- The upgrade handler still lives at `web/_install/upgrade.php` (correctly,
+-- outside the web root). A new proxy file at
+-- `web/public_html/admin/upgrade.php` `require`s it; this migration
+-- repoints the route at the proxy.
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/202
+-- =============================================================================
+
+UPDATE `tblRoutes`
+SET    `targetFile` = 'admin/upgrade.php'
+WHERE  `routeKey` = 'admin/upgrade';

--- a/web/_sql/056_remove_redundant_api_routes.sql
+++ b/web/_sql/056_remove_redundant_api_routes.sql
@@ -1,0 +1,23 @@
+-- =============================================================================
+-- Migration 056: Remove redundant api/* routes from tblRoutes
+-- =============================================================================
+-- Migration 035 (api_expansion) inserted 5 routes following the pattern
+-- `api/{app}/{action}`. The current routing model (per migration 049 and
+-- the ApiRouter class) hard-codes a special case in Router::dispatch():
+--
+--     if (str_starts_with($path, 'api/')) { ApiRouter::dispatch($path); }
+--
+-- ApiRouter then resolves `{app}/api/{action}.php`, NOT the path stored
+-- in tblRoutes.targetFile. The 5 rows are unreachable — pure dead config
+-- that confuses anyone reading the routes table.
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/204
+-- =============================================================================
+
+DELETE FROM `tblRoutes` WHERE `routeKey` IN (
+    'api/announcements/list',
+    'api/attendance/list',
+    'api/events/detail',
+    'api/events/list',
+    'api/users/list'
+);

--- a/web/_sql/057_remove_dead_linked_accounts_route.sql
+++ b/web/_sql/057_remove_dead_linked_accounts_route.sql
@@ -1,0 +1,12 @@
+-- =============================================================================
+-- Migration 057: Remove dead account/linked-accounts route
+-- =============================================================================
+-- The route was registered with `targetFile = 'auth/account/linked-accounts.php'`
+-- but the file was never created — clicking it 404s. The page may be built
+-- in future; when it is, add the route back via a new migration with the
+-- correct targetFile.
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/205
+-- =============================================================================
+
+DELETE FROM `tblRoutes` WHERE `routeKey` = 'account/linked-accounts';

--- a/web/_sql/058_login_webauthn_route.sql
+++ b/web/_sql/058_login_webauthn_route.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- Migration 058: Register login/webauthn route
+-- =============================================================================
+-- web/public_html/auth/login/webauthn.php is called from the login form via
+-- `fetch('/login/webauthn')` but was not registered in tblRoutes. It used
+-- to work via direct .htaccess fall-through; the v1.0 security hardening
+-- tightened .htaccess to route all .php through the front controller, so
+-- this AJAX endpoint now 404s. Adding the route restores it.
+--
+-- isProtected = 0 because the endpoint runs during the login challenge
+-- (pre-auth).
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/206
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
+VALUES ('login/webauthn', 'auth/login/webauthn.php', 0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/_sql/059_fix_api_expenses_delete_isSensitive.sql
+++ b/web/_sql/059_fix_api_expenses_delete_isSensitive.sql
@@ -1,0 +1,18 @@
+-- =============================================================================
+-- Migration 059: Fix api.expenses.delete.enabled isSensitive flag
+-- =============================================================================
+-- The setting was seeded with `isSensitive = 1` but the value is the
+-- literal boolean flag 'false', not a credential. Sensitive=1 makes the
+-- bootstrap settings loader try to libsodium-decrypt the value on every
+-- request, which wastes cycles and (depending on the seed timing) can
+-- produce a "bad ciphertext" warning. Flipping to 0 is the safe fix.
+--
+-- The value itself is preserved.
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/207
+-- =============================================================================
+
+UPDATE `tblSettings`
+SET    `isSensitive` = 0
+WHERE  `settingKey` = 'api.expenses.delete.enabled'
+  AND  `isSensitive` = 1;

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -750,6 +750,7 @@ CREATE TABLE IF NOT EXISTS `tblEvents` (
     `isPublic`     TINYINT(1)   NOT NULL DEFAULT 1 COMMENT 'Visible on public calendar',
     `isFeatured`   TINYINT(1)   NOT NULL DEFAULT 0,
     `isDeleted`    TINYINT(1)   NOT NULL DEFAULT 0 COMMENT 'Soft delete flag',
+    `deletedAt`    DATETIME     DEFAULT NULL COMMENT 'Timestamp of soft-delete (set when isDeleted flips to 1)',
     `capacity`     INT          DEFAULT NULL COMMENT 'Max attendees (NULL = unlimited)',
 
     -- 🔢 Metadata
@@ -1670,7 +1671,7 @@ VALUES ('api.expenses.update-status.enabled', 'false', 0, 'false')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
 INSERT INTO `tblSettings` (`settingKey`, `settingValue`, `isSensitive`, `defaultValue`)
-VALUES ('api.expenses.delete.enabled', 'false', 1, 'false')
+VALUES ('api.expenses.delete.enabled', 'false', 0, 'false')
 ON DUPLICATE KEY UPDATE `settingKey` = `settingKey`;
 
 -- ─── Future app toggles (disabled by default) ────────────────────────────────
@@ -1816,8 +1817,15 @@ INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
 VALUES ('account/change-password', 'auth/account/change-password.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
+-- 🪦 account/linked-accounts route removed — target file was never
+--    created; clicking the link 404s. Removed from this schema and
+--    DELETEd on existing installs by migration 058. See issue #205.
+--    Re-add here AND remove the DELETE in 058 if/when the page is built.
+
+-- 🔐 WebAuthn AJAX endpoint (POSTed from the login form). isProtected=0
+--    because it runs during login (pre-auth). See issue #206.
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
-VALUES ('account/linked-accounts', 'auth/account/linked-accounts.php', 1)
+VALUES ('login/webauthn', 'auth/login/webauthn.php', 0)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
@@ -1880,7 +1888,7 @@ VALUES ('admin/integrations', 'admin/integrations/index.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`)
-VALUES ('admin/upgrade', '../install/upgrade.php', 1)
+VALUES ('admin/upgrade', 'admin/upgrade.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
 -- ─── Multi-site (from migration 015) ────────────────────────────────────────
@@ -2362,6 +2370,24 @@ INSERT INTO `tblMigrations` (`filename`) VALUES ('052_bulk_importers.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblMigrations` (`filename`) VALUES ('053_local_accounts_columns.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('054_events_deleted_at.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('055_admin_upgrade_route_fix.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('056_remove_redundant_api_routes.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('057_remove_dead_linked_accounts_route.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('058_login_webauthn_route.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('059_fix_api_expenses_delete_isSensitive.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES

--- a/web/public_html/admin/upgrade.php
+++ b/web/public_html/admin/upgrade.php
@@ -1,0 +1,31 @@
+<?php
+// Path: public_html/admin/upgrade.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin → Upgrade — front-controller proxy 🪞
+ * -----------------------------------------------------------------------------
+ * The actual upgrade handler lives at web/_install/upgrade.php (outside
+ * public_html/ so it isn't web-accessible directly). The Router serves
+ * routeKey `admin/upgrade` from this file; we require the real handler.
+ *
+ * Why the proxy: route targetFiles are resolved relative to PORTAL_APPS
+ * (web/public_html/), so they cannot reference paths outside that root.
+ * A 1-line proxy keeps the upgrade handler's "bootstrap + admin gate"
+ * logic in one place while still satisfying the routing model. The route
+ * was previously misconfigured with `targetFile = '../install/upgrade.php'`,
+ * which 404s on click — see issue #202.
+ *
+ * @package   Portal\App\Admin
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/202
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+// 🪞 Delegate to the bootstrap-aware upgrade handler in _install/.
+//    PORTAL_ROOT points at web/, so this resolves to web/_install/upgrade.php.
+require PORTAL_ROOT . DIRECTORY_SEPARATOR . '_install' . DIRECTORY_SEPARATOR . 'upgrade.php';


### PR DESCRIPTION
## Summary

Closes #201, #202, #204, #205, #206, #207 — the 6 actionable runtime bugs from the cross-source consistency audit.

Two settings findings (#203, #208) were re-investigated during fix prep and turned out to be **false positives from the audit agent** — both keys (`auth.rateLimit.maxAttemptsByUsername`, `branding.hidePoweredBy`) ARE seeded, just further down in `full_schema.sql` than the agent looked (lines 2507 and 2525 respectively). Will close those issues separately.

i18n findings (#209, #210, #211) are tracked as follow-up; not in this PR.

### Bugs fixed

| Issue | Change | Severity |
|---|---|---|
| **#201** | Add `deletedAt` column to `tblEvents` | CRITICAL — admin event-delete fatalled |
| **#202** | Add proxy file + repoint `admin/upgrade` route at correct target | HIGH — admin upgrade page 404'd |
| **#204** | Remove 5 redundant `api/*` rows from `tblRoutes` | MED — dead config |
| **#205** | Remove dead `account/linked-accounts` route | MED — 404 on click |
| **#206** | Register `login/webauthn` route | MED — WebAuthn login broken under tightened .htaccess |
| **#207** | Flip `api.expenses.delete.enabled` `isSensitive` 1→0 | LOW — wasted decrypt cycles |

### Files changed

| File | Change |
|---|---|
| `web/_sql/full_schema.sql` | tblEvents.deletedAt added, 2 route changes (1 added / 1 removed), 1 route updated, 1 setting fixed, tblMigrations seed extended |
| `web/public_html/admin/upgrade.php` (NEW) | Thin proxy `require`ing `_install/upgrade.php` |
| `web/_sql/054_events_deleted_at.sql` (NEW) | `ALTER TABLE tblEvents ADD COLUMN deletedAt` |
| `web/_sql/055_admin_upgrade_route_fix.sql` (NEW) | `UPDATE tblRoutes SET targetFile = …` |
| `web/_sql/056_remove_redundant_api_routes.sql` (NEW) | `DELETE FROM tblRoutes WHERE routeKey IN (…)` |
| `web/_sql/057_remove_dead_linked_accounts_route.sql` (NEW) | `DELETE` |
| `web/_sql/058_login_webauthn_route.sql` (NEW) | `INSERT` |
| `web/_sql/059_fix_api_expenses_delete_isSensitive.sql` (NEW) | `UPDATE … SET isSensitive = 0` |
| `CHANGELOG.md` | Unreleased entry |

All INSERTs use `ON DUPLICATE KEY UPDATE` and ALTERs use `ADD COLUMN IF NOT EXISTS` — re-runs on existing installs are safe.

### Test plan

- [x] `php -l web/public_html/admin/upgrade.php` clean
- [ ] **#201**: Fresh install → admin clicks "Delete" on an event → no `Unknown column 'deletedAt'`; row marked `isDeleted = 1` and `deletedAt = NOW()`.
- [ ] **#202**: After migration, visit `/admin/upgrade` → upgrade handler renders (was 404). Non-admin gets 403 (existing `App::isAdmin()` gate).
- [ ] **#204**: `SELECT routeKey FROM tblRoutes WHERE routeKey LIKE 'api/%'` returns nothing after migration. `/api/events/list` etc. still work (they go through `ApiRouter::dispatch()`, not `tblRoutes`).
- [ ] **#205**: `account/linked-accounts` gone from `tblRoutes`. No 404 link in nav / account UI.
- [ ] **#206**: WebAuthn login (passkey) from the login form completes successfully; no 404 on `POST /login/webauthn`.
- [ ] **#207**: `SELECT isSensitive FROM tblSettings WHERE settingKey = 'api.expenses.delete.enabled'` returns `0` after migration. Settings UI still displays the value correctly.

### Why this is a "follow-up #3"

- Audit #1 (#197): bootstrap try/catch, CI workflow paths, admin gates, schema port — 22 issues.
- Audit #2 (#199): SQL column-name mismatches the previous audit didn't check for — 6 issues.
- Audit #3 (this PR): cross-source consistency across 4 parallel dimensions — 6 actionable bugs + 2 false-positive closures + 3 i18n triage items still open.

Honest pattern: each audit round finds bugs the previous round didn't because the audit prompts were narrowly scoped. The CI-checks follow-up (separate PR, in flight) is meant to catch future regressions of these consistency classes at PR time so we stop discovering them in production.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_