### PR TITLE
ci: cross-source consistency checks in pr-security.yml + #213 fix

### DIFF
--- a/.github/workflows/pr-security.yml
+++ b/.github/workflows/pr-security.yml
@@ -20,9 +20,18 @@
 #   6. Hardcoded-paths sanity check                — absolute /Users / /home paths in code
 #   7. Dangerous PHP functions                     — eval, exec, shell_exec, system, passthru
 #   8. Server-managed dirs touched?                — flag if PR touches _auth_keys/_uploads/_backups
+#   9. SQL column-name mismatches                  — runtime INSERT col not in CREATE TABLE
+#  10. Route targetFile existence                  — tblRoutes.targetFile resolves to a file
+#  11. Settings key consistency                    — $SETTINGS reads vs tblSettings seed
 #
 # These are HEURISTICS — false positives are expected. Review the findings,
 # don't blindly fail the merge.
+#
+# Checks 9-11 (cross-source consistency) were added after a sequence of
+# missed-bug rounds (#169 → #171 → #198 → #201/202/204/205/206/207 →
+# #213): each was a category of "code references something that doesn't
+# exist in another source" — a class the prior heuristics didn't cover.
+# The scripts live in tools/audit-checks/ and are runnable locally.
 # =============================================================================
 
 name: PR Security Checks
@@ -196,6 +205,34 @@ jobs:
           # ---- 8) Server-managed dirs touched? ---------------------------
           SERVER_TOUCH=$(echo "$CHANGED" | grep -E '^web/(_auth_keys|_uploads|_backups)/' || true)
           add_section "PR touches server-managed dirs (_auth_keys / _uploads / _backups) — confirm this is intentional" "$SERVER_TOUCH"
+
+          # ---- 9-11) Cross-source consistency checks ---------------------
+          # These run regardless of changed-file scope because they validate
+          # the WHOLE repo state — e.g. a settings-key read could be in an
+          # unchanged file, but a tblSettings INSERT removal in this PR
+          # could orphan it. Each script exits 0 even on findings (we
+          # surface in the report; PHP lint remains the only hard gate).
+
+          # 9) SQL column-name mismatches (catches #198, #201, #213 classes)
+          SQL_COLS=$(python3 tools/audit-checks/check_sql_columns.py 2>&1 | tail -n +5 || true)
+          if echo "$SQL_COLS" | grep -q '•'; then
+            add_section "SQL column-name mismatches (runtime INSERT/SELECT references column not in schema)" "$SQL_COLS"
+          fi
+
+          # 10) Route targetFile existence (catches #202, #205 classes)
+          ROUTES=$(python3 tools/audit-checks/check_route_targets.py 2>&1 | tail -n +4 || true)
+          if echo "$ROUTES" | grep -q '•'; then
+            add_section "Route targetFile missing (tblRoutes points at a file that doesn't exist)" "$ROUTES"
+          fi
+
+          # 11) Settings key consistency (catches the class #203/#208 were
+          #     filed under; both turned out to be FP but this script
+          #     walks the entire schema so it won't repeat the agent's miss)
+          SETTINGS=$(python3 tools/audit-checks/check_settings_keys.py 2>&1 | tail -n +5 || true)
+          if echo "$SETTINGS" | grep -qE '•.*no fallback'; then
+            UNGUARDED=$(echo "$SETTINGS" | sed -n '/UNGUARDED/,/###\|^$/p')
+            add_section "Unseeded settings reads (UNGUARDED — null on missing key)" "$UNGUARDED"
+          fi
 
           echo "hits=$HITS" >> "$GITHUB_OUTPUT"
           echo "Total finding sections: $HITS"

--- a/tools/audit-checks/.gitignore
+++ b/tools/audit-checks/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/tools/audit-checks/check_route_targets.py
+++ b/tools/audit-checks/check_route_targets.py
@@ -1,0 +1,151 @@
+#!/usr/bin/env python3
+"""
+Route target-file existence check.
+
+Parses every `INSERT INTO tblRoutes (...) VALUES ('routeKey', 'targetFile', ...)`
+statement across the SQL files (full_schema.sql + numbered migrations) and
+verifies that each targetFile resolves to an actual file under
+web/public_html/.
+
+Catches the #202 / #205 class of bug (route registered but file missing,
+or route pointing at a path the front controller can't reach).
+
+Exit code:
+  0 — no findings (CI-green)
+  1 — at least one missing target (CI annotates but doesn't block merge
+      unless invoked with --strict)
+
+Usage:
+  python3 tools/audit-checks/check_route_targets.py [--strict]
+"""
+
+from __future__ import annotations
+
+import os
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SQL_DIR = REPO_ROOT / "web" / "_sql"
+APPS_DIR = REPO_ROOT / "web" / "public_html"
+
+# Match: INSERT INTO `tblRoutes` (..) VALUES ('key', 'target', ...)
+# Note: tolerate backticks, varying whitespace, multi-line VALUES.
+INSERT_RE = re.compile(
+    r"INSERT\s+INTO\s+`?tblRoutes`?\s*\([^)]+\)\s*VALUES\s*\(\s*"
+    r"'([^']+)'\s*,\s*'([^']+)'",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Match: VALUES ('key1', 'target1', ...), ('key2', 'target2', ...)
+# For the batch-INSERT form used in some migrations.
+BATCH_TUPLE_RE = re.compile(r"\(\s*'([^']+)'\s*,\s*'([^']+)'")
+
+# Routes EXCLUDED from the check — known intentional special cases.
+EXCLUDED_ROUTES: set[str] = {
+    # API routes are special-cased to ApiRouter::dispatch() — the
+    # targetFile in tblRoutes isn't used for them. (See #204 for the
+    # cleanup of the 5 spurious ones; this skip protects future
+    # api/* registrations that genuinely use the special case.)
+}
+
+# Path EXCLUSIONS — targets we know don't resolve to files under
+# public_html/ but are still valid (handled by the Router special
+# case or via a proxy).
+EXCLUDED_TARGET_PREFIXES: tuple[str, ...] = (
+    "../",  # any escape-out target is its own bug class — we already
+            # flag those, but don't double-report from this check.
+)
+
+
+def collect_route_inserts() -> list[tuple[str, str, Path, int]]:
+    """Return (routeKey, targetFile, sql_file, line_no) tuples."""
+    findings: list[tuple[str, str, Path, int]] = []
+    for sql in sorted(SQL_DIR.glob("*.sql")):
+        text = sql.read_text(encoding="utf-8", errors="ignore")
+        for m in INSERT_RE.finditer(text):
+            line_no = text[: m.start()].count("\n") + 1
+            # The first match captures (key, first_value) — but for
+            # batch inserts the second tuple onwards is in the same
+            # statement. Pick up additional tuples too.
+            findings.append((m.group(1), m.group(2), sql, line_no))
+            # Look ahead for additional tuples in the same VALUES batch.
+            tail = text[m.end() :]
+            # Stop at the trailing semicolon for this statement.
+            stop = tail.find(";")
+            batch = tail[:stop] if stop >= 0 else tail
+            for tup in BATCH_TUPLE_RE.finditer(batch):
+                findings.append((tup.group(1), tup.group(2), sql, line_no))
+    return findings
+
+
+def check() -> int:
+    inserts = collect_route_inserts()
+    if not inserts:
+        print("No tblRoutes INSERTs found — nothing to check.")
+        return 0
+
+    # 🪞 "Last write wins" model: ON DUPLICATE KEY UPDATE (used by every
+    #    tblRoutes INSERT in this codebase) means the most recently
+    #    encountered targetFile for a routeKey is the one that ends up
+    #    in the live table. Migrations apply in filename order, then
+    #    full_schema.sql runs once for fresh installs — so iteration
+    #    in SQL-file sort order gives the final state.
+    #
+    # We also note "rewrites" (routeKey whose target changed across
+    # files) as informational diff — not flagged as a bug because the
+    # last write is the intended truth. DELETE statements in later
+    # migrations remove a routeKey entirely; for those we'd want
+    # to track unsets, but the current schema only DELETEs via
+    # one-off migrations whose presence we trust.
+    final: dict[str, tuple[str, Path, int]] = {}
+    delete_re = re.compile(
+        r"DELETE\s+FROM\s+`?tblRoutes`?\s+WHERE\s+`?routeKey`?\s+(?:=\s*'([^']+)'|IN\s*\(([^)]+)\))",
+        re.IGNORECASE | re.DOTALL,
+    )
+
+    # First, accumulate INSERT-last-wins.
+    for route_key, target, sql, line_no in inserts:
+        if route_key in EXCLUDED_ROUTES:
+            continue
+        final[route_key] = (target, sql, line_no)
+
+    # Then apply DELETE statements in order (file sort order).
+    for sql in sorted(SQL_DIR.glob("*.sql")):
+        text = sql.read_text(encoding="utf-8", errors="ignore")
+        for m in delete_re.finditer(text):
+            if m.group(1):
+                final.pop(m.group(1), None)
+            elif m.group(2):
+                for k in re.findall(r"'([^']+)'", m.group(2)):
+                    final.pop(k, None)
+
+    missing: list[tuple[str, str, Path, int]] = []
+    for route_key, (target, sql, line_no) in final.items():
+        if target.startswith(EXCLUDED_TARGET_PREFIXES):
+            missing.append((route_key, target, sql, line_no))
+            continue
+        full = APPS_DIR / target
+        if not full.is_file():
+            missing.append((route_key, target, sql, line_no))
+
+    print(f"Routes inspected (final state): {len(final)}")
+    print(f"Missing target files: {len(missing)}")
+    print()
+
+    if missing:
+        print("### Routes referencing missing files (final state)\n")
+        for route_key, target, sql, line_no in missing:
+            rel = sql.relative_to(REPO_ROOT)
+            print(f"  • {route_key:40s} → {target:40s}  [last set in {rel}:{line_no}]")
+        print()
+
+    strict = "--strict" in sys.argv
+    if missing and strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check())

--- a/tools/audit-checks/check_settings_keys.py
+++ b/tools/audit-checks/check_settings_keys.py
@@ -1,0 +1,177 @@
+#!/usr/bin/env python3
+"""
+Settings key consistency check.
+
+Builds the set of seeded `tblSettings.settingKey` values across
+full_schema.sql + numbered migrations. Then scans PHP for
+`$SETTINGS['x']['y'][...]` and `App::settings()['x']['y'][...]` reads,
+derives the implied dot-notation key, and verifies the key is in the
+seeded set.
+
+Distinguishes guarded reads (`?? 'default'`) from unguarded reads —
+unguarded reads on missing keys are higher severity (silent null).
+
+Catches the #203 / #208 class of bug — though both of those turned out
+to be false positives because the previous audit didn't walk the full
+schema. This check walks every INSERT into tblSettings across all SQL
+files, so it should be more reliable.
+
+Exit code:
+  0 — no findings
+  1 — at least one unguarded read of an unseeded key (CI annotates;
+      blocks if --strict)
+
+Usage:
+  python3 tools/audit-checks/check_settings_keys.py [--strict]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SQL_DIR = REPO_ROOT / "web" / "_sql"
+PHP_ROOTS = [
+    REPO_ROOT / "web" / "_install",
+    REPO_ROOT / "web" / "_core",
+    REPO_ROOT / "web" / "public_html",
+]
+
+# Match: INSERT INTO `tblSettings` (...settingKey…) VALUES (..., 'key', ...)
+# Handles both column-orderings used in this codebase:
+#   (settingKey, settingValue, isSensitive, defaultValue) VALUES ('k', ...)
+#   (siteID, settingKey, settingValue, defaultValue, isSensitive) VALUES (NULL, 'k', ...)
+INSERT_RE = re.compile(
+    r"INSERT\s+INTO\s+`?tblSettings`?\s*\(([^)]+)\)\s*VALUES",
+    re.IGNORECASE,
+)
+# Per-row pattern inside a VALUES batch: find the literal string in the
+# position of settingKey based on the column order.
+VALUES_TUPLE_RE = re.compile(r"\(([^)]*)\)", re.DOTALL)
+
+# Match $SETTINGS read paths — at least two array dereferences.
+SETTINGS_READ_RE = re.compile(
+    r"\$SETTINGS(\[(?:'[^']+'|\"[^\"]+\")\]){2,}"
+)
+APP_SETTINGS_RE = re.compile(
+    r"App::settings\(\)(\[(?:'[^']+'|\"[^\"]+\")\]){2,}"
+)
+# Capture each ['x'] segment for the path-extraction.
+SEG_RE = re.compile(r"\[(?:'([^']+)'|\"([^\"]+)\")\]")
+
+
+def collect_seeded_keys() -> set[str]:
+    """Parse every INSERT INTO tblSettings and collect settingKey values."""
+    keys: set[str] = set()
+    for sql in sorted(SQL_DIR.glob("*.sql")):
+        text = sql.read_text(encoding="utf-8", errors="ignore")
+        for m in INSERT_RE.finditer(text):
+            cols = [c.strip().strip("`") for c in m.group(1).split(",")]
+            try:
+                key_idx = cols.index("settingKey")
+            except ValueError:
+                continue
+            # Slice from the end of the matched INSERT to the trailing ;
+            tail = text[m.end() :]
+            stop = tail.find(";")
+            batch = tail[:stop] if stop >= 0 else tail
+            for tup in VALUES_TUPLE_RE.finditer(batch):
+                # Split tuple values respecting quotes — simple split
+                # by comma is OK because we don't allow commas in our
+                # settingKey values.
+                vals = [v.strip() for v in tup.group(1).split(",")]
+                if key_idx >= len(vals):
+                    continue
+                raw = vals[key_idx]
+                # Strip surrounding quotes.
+                if (raw.startswith("'") and raw.endswith("'")) or (
+                    raw.startswith('"') and raw.endswith('"')
+                ):
+                    keys.add(raw[1:-1])
+    return keys
+
+
+def derive_key(segments: list[str]) -> str:
+    return ".".join(segments)
+
+
+def strip_php_comments(text: str) -> str:
+    """Strip PHP comments while preserving line numbers (replace block
+    comments with the same number of newlines so reported line numbers
+    still match the original file)."""
+    text = re.sub(
+        r"/\*.*?\*/",
+        lambda m: "\n" * m.group(0).count("\n"),
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(r"//[^\n]*", "", text)
+    return text
+
+
+def scan_php_reads(seeded: set[str]) -> list[tuple[Path, int, str, bool]]:
+    """Return (file, line_no, key, is_guarded) findings."""
+    findings: list[tuple[Path, int, str, bool]] = []
+    for root in PHP_ROOTS:
+        if not root.exists():
+            continue
+        for php in root.rglob("*.php"):
+            try:
+                raw = php.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            text = strip_php_comments(raw)
+            for pattern in (SETTINGS_READ_RE, APP_SETTINGS_RE):
+                for m in pattern.finditer(text):
+                    full = m.group(0)
+                    segs: list[str] = []
+                    for s in SEG_RE.finditer(full):
+                        segs.append(s.group(1) or s.group(2))
+                    key = derive_key(segs)
+                    if key in seeded:
+                        continue
+                    line_no = text[: m.start()].count("\n") + 1
+                    # Heuristic for guarded reads — check whether the
+                    # surrounding 80 chars contains `?? `.
+                    window = text[max(0, m.start() - 5) : min(len(text), m.end() + 80)]
+                    guarded = "??" in window
+                    findings.append((php, line_no, key, guarded))
+    return findings
+
+
+def check() -> int:
+    seeded = collect_seeded_keys()
+    print(f"Seeded settings keys: {len(seeded)}")
+    findings = scan_php_reads(seeded)
+    # Dedupe.
+    deduped: dict[tuple[str, int, str], bool] = {}
+    for php, line_no, key, guarded in findings:
+        rel = str(php.relative_to(REPO_ROOT))
+        deduped[(rel, line_no, key)] = guarded
+    unguarded = [(p, ln, k) for (p, ln, k), g in deduped.items() if not g]
+    guarded = [(p, ln, k) for (p, ln, k), g in deduped.items() if g]
+
+    print(f"Unseeded reads (unguarded — HIGHER risk): {len(unguarded)}")
+    print(f"Unseeded reads (guarded with ?? — lower risk): {len(guarded)}")
+    print()
+    if unguarded:
+        print("### Unseeded settings reads — UNGUARDED\n")
+        for rel, line_no, key in unguarded:
+            print(f"  • {rel}:{line_no} — reads `{key}` with no fallback")
+        print()
+    if guarded:
+        print("### Unseeded settings reads — guarded (informational)\n")
+        for rel, line_no, key in guarded[:30]:  # cap at 30 for noise
+            print(f"  • {rel}:{line_no} — reads `{key}` (has ?? fallback)")
+        if len(guarded) > 30:
+            print(f"  ... and {len(guarded) - 30} more")
+    strict = "--strict" in sys.argv
+    if unguarded and strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check())

--- a/tools/audit-checks/check_sql_columns.py
+++ b/tools/audit-checks/check_sql_columns.py
@@ -1,0 +1,197 @@
+#!/usr/bin/env python3
+"""
+SQL column-name existence check.
+
+Builds a (table → columns) map from every `CREATE TABLE` in
+web/_sql/full_schema.sql plus every `ALTER TABLE … ADD COLUMN` across the
+numbered migrations. Then greps the PHP codebase for `INSERT INTO tblX (col, ...)
+VALUES` patterns and verifies every column appears in the map.
+
+Catches the #198 / #201 class of bug: runtime SQL references a column that
+doesn't exist on the named table.
+
+Exit code:
+  0 — no findings
+  1 — one or more mismatches (CI annotates but doesn't block unless --strict)
+
+Usage:
+  python3 tools/audit-checks/check_sql_columns.py [--strict]
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SQL_DIR = REPO_ROOT / "web" / "_sql"
+PHP_ROOTS = [
+    REPO_ROOT / "web" / "_install",
+    REPO_ROOT / "web" / "_core",
+    REPO_ROOT / "web" / "public_html",
+]
+
+# Match: CREATE TABLE IF NOT EXISTS `tblX` ( …columns… )
+CREATE_RE = re.compile(
+    r"CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?`?(tbl\w+)`?\s*\((.*?)\)\s*ENGINE",
+    re.IGNORECASE | re.DOTALL,
+)
+# Match a column definition inside a CREATE TABLE block — `colName` …
+COLUMN_RE = re.compile(r"^\s*`(\w+)`\s+", re.MULTILINE)
+
+# Match: ALTER TABLE `tblX` ADD COLUMN [IF NOT EXISTS] `colY` …
+ALTER_ADD_RE = re.compile(
+    r"ALTER\s+TABLE\s+`?(tbl\w+)`?\s+ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?`(\w+)`",
+    re.IGNORECASE,
+)
+# Also: ALTER TABLE `tblX` … `colY` (sometimes split across multiple
+# ADD COLUMN clauses in one ALTER statement). Greedy enough for our patterns.
+ALTER_ADD_MULTI_RE = re.compile(
+    r"ALTER\s+TABLE\s+`?(tbl\w+)`?\s+(.*?);",
+    re.IGNORECASE | re.DOTALL,
+)
+
+# Match: INSERT INTO `tblX` (col, col, col) — captures the column list.
+INSERT_RE = re.compile(
+    r"INSERT\s+(?:IGNORE\s+)?INTO\s+`?(tbl\w+)`?\s*\(([^)]+)\)",
+    re.IGNORECASE,
+)
+
+
+def build_schema_map() -> dict[str, set[str]]:
+    """Return {tableName: {column, column, …}}."""
+    schema: dict[str, set[str]] = {}
+
+    full = SQL_DIR / "full_schema.sql"
+    if full.is_file():
+        text = full.read_text(encoding="utf-8", errors="ignore")
+        for m in CREATE_RE.finditer(text):
+            tbl = m.group(1)
+            body = m.group(2)
+            cols = set(COLUMN_RE.findall(body))
+            schema.setdefault(tbl, set()).update(cols)
+
+    # Apply ALTER TABLE ADD COLUMN from migrations on top.
+    for sql in sorted(SQL_DIR.glob("*.sql")):
+        text = sql.read_text(encoding="utf-8", errors="ignore")
+        # Simple single-add ALTERs
+        for m in ALTER_ADD_RE.finditer(text):
+            schema.setdefault(m.group(1), set()).add(m.group(2))
+        # Multi-clause ALTERs: pick out every `colName` mentioned after
+        # an ADD COLUMN inside the statement body. Coarse but effective.
+        for m in ALTER_ADD_MULTI_RE.finditer(text):
+            tbl = m.group(1)
+            body = m.group(2)
+            if "ADD COLUMN" not in body.upper():
+                continue
+            for col_match in re.finditer(
+                r"ADD\s+COLUMN\s+(?:IF\s+NOT\s+EXISTS\s+)?`(\w+)`",
+                body, re.IGNORECASE,
+            ):
+                schema.setdefault(tbl, set()).add(col_match.group(1))
+
+    return schema
+
+
+def reconstruct_php_strings(text: str) -> str:
+    """
+    Reconstruct concatenated PHP single-quoted strings into a single
+    logical string so SQL split across multiple `'…' . '…'` lines parses
+    as one INSERT statement.
+
+    Specifically collapses sequences like:
+        'INSERT INTO tblX ('
+            . 'colA, '
+            . 'colB)'
+    into:
+        'INSERT INTO tblX (colA, colB)'
+
+    Single-pass, regex-driven — doesn't handle every edge of PHP
+    string syntax, but covers the patterns used in this codebase.
+    """
+    # Collapse '<chars>' . '<chars>' (with possible whitespace/newlines) into
+    # '<chars><chars>'. Run repeatedly until no more matches.
+    pattern = re.compile(r"'([^']*)'\s*\.\s*'([^']*)'")
+    while True:
+        new = pattern.sub(lambda m: "'" + m.group(1) + m.group(2) + "'", text)
+        if new == text:
+            return new
+        text = new
+
+
+def strip_php_comments(text: str) -> str:
+    """Strip PHP comments while preserving line numbers (replace block
+    comments with the same number of newlines so reported line numbers
+    still match the original file)."""
+    text = re.sub(
+        r"/\*.*?\*/",
+        lambda m: "\n" * m.group(0).count("\n"),
+        text,
+        flags=re.DOTALL,
+    )
+    text = re.sub(r"//[^\n]*", "", text)
+    return text
+
+
+def scan_php_inserts(schema: dict[str, set[str]]) -> list[tuple[Path, int, str, str]]:
+    """Return findings: (php_file, line_no, table, missing_column)."""
+    findings: list[tuple[Path, int, str, str]] = []
+    for root in PHP_ROOTS:
+        if not root.exists():
+            continue
+        for php in root.rglob("*.php"):
+            try:
+                raw = php.read_text(encoding="utf-8", errors="ignore")
+            except OSError:
+                continue
+            text = strip_php_comments(reconstruct_php_strings(raw))
+            for m in INSERT_RE.finditer(text):
+                tbl = m.group(1)
+                col_list = m.group(2)
+                cols = [c.strip().strip("`") for c in col_list.split(",")]
+                cols = [c for c in cols if c]
+                # Sanity guard against parser fragments — column names
+                # should be `\w+`. Skip anything that doesn't parse cleanly.
+                if not cols or not all(re.fullmatch(r"\w+", c) for c in cols):
+                    continue
+                if tbl not in schema:
+                    findings.append(
+                        (php, raw[: raw.find(m.group(0))].count("\n") + 1,
+                         tbl, "(unknown table)")
+                    )
+                    continue
+                for c in cols:
+                    if c not in schema[tbl]:
+                        line_no = raw[: raw.find(m.group(0))].count("\n") + 1
+                        if line_no <= 0:
+                            line_no = 1
+                        findings.append((php, line_no, tbl, c))
+    return findings
+
+
+def check() -> int:
+    schema = build_schema_map()
+    print(f"Tables inspected: {len(schema)}")
+    findings = scan_php_inserts(schema)
+    print(f"Column-name mismatches: {len(findings)}")
+    print()
+    if findings:
+        print("### Column-name mismatches\n")
+        # Deduplicate (file, line, table, col).
+        seen: set[tuple[str, int, str, str]] = set()
+        for php, line_no, tbl, col in findings:
+            rel = str(php.relative_to(REPO_ROOT))
+            key = (rel, line_no, tbl, col)
+            if key in seen:
+                continue
+            seen.add(key)
+            print(f"  • {rel}:{line_no} — INSERT INTO {tbl} references column `{col}`")
+    strict = "--strict" in sys.argv
+    if findings and strict:
+        return 1
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(check())

--- a/web/public_html/leadership/manage/import.php
+++ b/web/public_html/leadership/manage/import.php
@@ -173,9 +173,14 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             if (count($rows) === 0) {
                 $error = 'No preview data — re-upload the file.';
             } else {
+                // Column names match the schema (#213): `startDate`,
+                // `endDate`, `createdByID` — earlier draft used
+                // `assignedAt`, `endsAt`, `assignedByID` which don't
+                // exist on tblLeadershipAssignments. PHP variable names
+                // ($assigned, $endsAt) kept for source-code continuity.
                 $stmt = $mysqli->prepare(
                     'INSERT INTO tblLeadershipAssignments '
-                    . '(roleID, userID, siteID, assignedAt, endsAt, assignedByID, isActive) '
+                    . '(roleID, userID, siteID, startDate, endDate, createdByID, isActive) '
                     . 'VALUES (?, ?, ?, ?, ?, ?, 1)'
                 );
                 if ($stmt === false) {


### PR DESCRIPTION
## Summary

Closes #213. **Adds three permanent cross-source consistency checks** to `pr-security.yml` so the bug class that's cost us four PR rounds (#197 → #199 → #212 → and one more here) catches the next regression at PR time instead of in production.

### The bug class

Each of the recent rounds was a different flavour of **"runtime code references something that doesn't exist in another source of truth"**:

| Round | Class |
|---|---|
| #198 / PR #199 | SQL columns referenced by INSERT/SELECT but missing from `CREATE TABLE` |
| #201 / PR #212 | More of the same (tblEvents.deletedAt) |
| #202 / PR #212 | `tblRoutes.targetFile` pointing at files that don't exist |
| #205 / PR #212 | Route registered for a file that was never created |
| #213 (this PR) | **Three more SQL column mismatches the prior audits missed** |

The audit-agent sweeps caught most of these by inspection but kept missing entire files (#213's `leadership/manage/import.php` was visited by none of the four sub-agents in the last round). A mechanical scan can't miss a file.

### What's in this PR

#### `tools/audit-checks/check_sql_columns.py` (197 lines)
- Builds `{table: {columns…}}` map from every `CREATE TABLE` in `full_schema.sql` + every `ALTER TABLE ADD COLUMN` across the migrations.
- Walks every PHP file under `_install/`, `_core/`, `public_html/`.
- Reconstructs PHP-concatenated SQL strings (`'INSERT INTO foo (' . 'col1, col2)' . …`) before regex matching.
- Strips PHP comments while preserving line numbers (so reported `file:line` matches the source).
- Flags every `INSERT INTO tbl (col, …)` where a column isn't in the map.
- **Found #213 while I was building it** — 3 mismatches in `leadership/manage/import.php` that all prior audits missed.

#### `tools/audit-checks/check_route_targets.py` (151 lines)
- Parses every `INSERT INTO tblRoutes (…) VALUES ('key', 'target', …)` across all SQL files.
- Tracks last-write-wins per `routeKey` (mirrors `ON DUPLICATE KEY UPDATE` semantics) AND applies `DELETE FROM tblRoutes` statements from migrations.
- Verifies the final `targetFile` for every live route resolves to a file under `web/public_html/`.
- Returns 0 findings against post-PR-#212 main.

#### `tools/audit-checks/check_settings_keys.py` (177 lines)
- Parses every `INSERT INTO tblSettings (…)` to build the seeded-keys set (handles both column orderings used in the codebase).
- Scans PHP for `$SETTINGS['x']['y']` and `App::settings()['x']['y']` reads, derives the dot-notation key.
- Distinguishes **guarded reads** (`?? 'default'`) from **unguarded reads** — only unguarded reads of unseeded keys are flagged as bugs.
- Walks the WHOLE schema — won't make the audit agent's mistake of stopping at the first occurrence (which led to #203 and #208 false positives).

#### `.github/workflows/pr-security.yml` — checks 9-11 added
- Run after the existing heuristics.
- Non-blocking (same convention as existing heuristic checks).
- Findings appear in the per-PR security comment.

#### `web/public_html/leadership/manage/import.php` — #213 fix
- `assignedAt` → `startDate`
- `endsAt` → `endDate`
- `assignedByID` → `createdByID`
- PHP-side variable names left alone (they were already conceptually correct; only the SQL column names were wrong).

### Verification (local)

```
$ python3 tools/audit-checks/check_route_targets.py
Routes inspected (final state): 125
Missing target files: 0

$ python3 tools/audit-checks/check_sql_columns.py
Tables inspected: 54
Column-name mismatches: 0

$ python3 tools/audit-checks/check_settings_keys.py
Seeded settings keys: 158
Unseeded reads (unguarded — HIGHER risk): 0
Unseeded reads (guarded with ?? — lower risk): 0
```

All three return 0 findings against the post-#212 + post-#213-fix tree.

### Why this should land before another audit round

This PR's value isn't the #213 fix (one bug). The value is **the next time someone changes the schema or a SQL query, the broken column / missing route / unseeded key is flagged on the PR before merge**. We stop discovering this class of bug in production.

### Test plan

- [x] All 3 scripts return 0 findings on post-#212 main + the #213 fix.
- [x] Scripts compile clean (`python3 -m py_compile`).
- [x] `__pycache__` removed (force-pushed), `.gitignore` added.
- [ ] After merge, run a synthetic test PR that introduces a deliberate column mismatch — confirm `check_sql_columns.py` flags it in the PR comment.
- [ ] Same for a deliberate dead route — `check_route_targets.py`.
- [ ] Same for a deliberate unseeded settings read — `check_settings_keys.py`.

### Files changed

- `.github/workflows/pr-security.yml` — checks 9-11 + header comment
- `tools/audit-checks/check_sql_columns.py` (NEW)
- `tools/audit-checks/check_route_targets.py` (NEW)
- `tools/audit-checks/check_settings_keys.py` (NEW)
- `tools/audit-checks/.gitignore` (NEW)
- `web/public_html/leadership/manage/import.php` — column-name fix

### Related (not closed by this PR)

- #209, #210, #211 — i18n cleanup items still open; a follow-up check could be added later (`check_i18n_keys.py`).
- #200 — heuristic-tune PR (false-positive suppression) — still queued, orthogonal to this PR.


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_