### PR TITLE
i18n: wrap user-facing hardcoded strings with t() (#209)

### DIFF
--- a/web/_lang/en.php
+++ b/web/_lang/en.php
@@ -258,10 +258,30 @@ return [
     'error.page_not_found_text'     => 'The page you are looking for does not exist or may have been moved.',
     'error.access_denied'           => 'Access Denied',
     'error.access_denied_text'      => 'You do not have permission to access this page. Please contact your administrator if you believe this is an error.',
+    'error.access_denied_inline'    => 'Access denied.',
     'error.server_error'            => 'Server Error',
     'error.something_wrong'         => 'Something Went Wrong',
     'error.server_error_text'       => 'An unexpected error occurred. The issue has been logged and our team will look into it. Please try again later.',
     'error.return_to_dashboard'     => 'Return to Dashboard',
+
+    // ───── Inline error messages (flash / form failure paths) — issue #209
+    'error.database'                       => 'Database error.',
+    'error.db_create_service_type'         => 'Database error creating service type.',
+    'error.db_create_session'              => 'Database error creating session.',
+    'error.db_update_session'              => 'Database error updating session.',
+    'error.db_create_user'                 => 'Database error creating user. Please try again.',
+    'error.db_save_template'               => 'Database error saving template.',
+    'error.db_save_preferences'            => 'Database error saving preferences.',
+    'error.db_update_setting'              => 'Database error updating setting.',
+    'error.db_add_setting'                 => 'Database error adding setting.',
+    'error.db_create_role'                 => 'Database error creating role.',
+    'error.db_import_prepare'              => 'Database error preparing insert.',
+    'error.db_with_detail'                 => 'Database error: :detail',
+    'error.csrf_failed'                    => 'CSRF check failed.',
+    'error.umbrella_admin_only'            => 'Access denied. Umbrella admin privileges required.',
+    'error.moderator_only'                 => 'Moderator access required.',
+    'prayer_requests.error.not_found'      => 'Prayer request not found.',
+    'prayer_requests.error.no_access'      => 'You do not have access to this prayer request.',
 
     // =========================================================================
     // 🔘 Common UI

--- a/web/public_html/admin/audit/index.php
+++ b/web/public_html/admin/audit/index.php
@@ -27,7 +27,7 @@ Auth::requireLogin();
 
 // 🛡️ Admin only
 if (App::isAdmin() !== true) {
-    $_SESSION['flash_msg']  = 'Access denied.';
+    $_SESSION['flash_msg']  = t('error.access_denied_inline');
     $_SESSION['flash_type'] = 'danger';
     header('Location: /dashboard');
     exit();

--- a/web/public_html/admin/email-templates/preview.php
+++ b/web/public_html/admin/email-templates/preview.php
@@ -45,7 +45,7 @@ if (App::isAdmin() === false) {
 }
 if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
     http_response_code(403);
-    echo 'CSRF check failed';
+    echo t('error.csrf_failed');
     exit();
 }
 

--- a/web/public_html/admin/email-templates/save.php
+++ b/web/public_html/admin/email-templates/save.php
@@ -106,7 +106,7 @@ $stmt = $mysqli->prepare(
 );
 if ($stmt === false) {
     Logger::errorPlatform('MySQL', 'Error', 'EMAIL_TEMPLATE_UPSERT_PREP', $mysqli->error, '');
-    $_SESSION['email_template_flash']      = 'Database error saving template.';
+    $_SESSION['email_template_flash']      = t('error.db_save_template');
     $_SESSION['email_template_flash_type'] = 'danger';
     header('Location: /admin/email-templates/edit?key=' . urlencode($key), true, 302);
     exit();

--- a/web/public_html/admin/reports/index.php
+++ b/web/public_html/admin/reports/index.php
@@ -28,7 +28,7 @@ Auth::requireLogin();
 
 // 🛡️ Admin only
 if (App::isAdmin() !== true) {
-    $_SESSION['flash_msg']  = 'Access denied.';
+    $_SESSION['flash_msg']  = t('error.access_denied_inline');
     $_SESSION['flash_type'] = 'danger';
     header('Location: /dashboard');
     exit();

--- a/web/public_html/admin/sites/index.php
+++ b/web/public_html/admin/sites/index.php
@@ -25,7 +25,7 @@ use Portal\Core\Site;
 // 🛡️ Umbrella admin only
 if (App::isUmbrellaAdmin() === false) {
     http_response_code(403);
-    echo 'Access denied. Umbrella admin privileges required.';
+    echo t('error.umbrella_admin_only');
     exit();
 }
 

--- a/web/public_html/admin/sites/save.php
+++ b/web/public_html/admin/sites/save.php
@@ -31,7 +31,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 // 🛡️ Umbrella admin only
 if (App::isUmbrellaAdmin() === false) {
     http_response_code(403);
-    echo 'Access denied.';
+    echo t('error.access_denied_inline');
     exit();
 }
 
@@ -91,7 +91,7 @@ if ($siteID > 0) {
         . 'WHERE siteID = ?'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg'] = 'Database error: ' . $db->error;
+        $_SESSION['flash_msg'] = t('error.db_with_detail', ['detail' => $db->error]);
         $_SESSION['flash_type'] = 'danger';
         header('Location: /admin/sites', true, 302);
         exit();
@@ -123,7 +123,7 @@ if ($siteID > 0) {
         . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg'] = 'Database error: ' . $db->error;
+        $_SESSION['flash_msg'] = t('error.db_with_detail', ['detail' => $db->error]);
         $_SESSION['flash_type'] = 'danger';
         header('Location: /admin/sites', true, 302);
         exit();

--- a/web/public_html/admin/sites/users.php
+++ b/web/public_html/admin/sites/users.php
@@ -26,7 +26,7 @@ use Portal\Core\Site;
 // 🛡️ Umbrella admin only
 if (App::isUmbrellaAdmin() === false) {
     http_response_code(403);
-    echo 'Access denied. Umbrella admin privileges required.';
+    echo t('error.umbrella_admin_only');
     exit();
 }
 
@@ -42,7 +42,7 @@ if ($siteId <= 0) {
 $siteStmt = $db->prepare('SELECT siteID, siteName, siteKey FROM tblSites WHERE siteID = ? LIMIT 1');
 if ($siteStmt === false) {
     http_response_code(500);
-    echo 'Database error.';
+    echo t('error.database');
     exit();
 }
 $siteStmt->bind_param('i', $siteId);

--- a/web/public_html/admin/users/save.php
+++ b/web/public_html/admin/users/save.php
@@ -155,7 +155,7 @@ if ($action === 'create') {
     } catch (\Throwable $ex) {
         App::rollback();
         Logger::exception($ex);
-        $_SESSION['flash_msg']  = 'Database error creating user. Please try again.';
+        $_SESSION['flash_msg']  = t('error.db_create_user');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /admin/users');
         exit();

--- a/web/public_html/admin/workflows/index.php
+++ b/web/public_html/admin/workflows/index.php
@@ -26,7 +26,7 @@ Auth::ensureSession();
 Auth::requireLogin();
 
 if (App::isAdmin() !== true) {
-    $_SESSION['flash_msg']  = 'Access denied.';
+    $_SESSION['flash_msg']  = t('error.access_denied_inline');
     $_SESSION['flash_type'] = 'danger';
     header('Location: /dashboard');
     exit();

--- a/web/public_html/admin/workflows/save.php
+++ b/web/public_html/admin/workflows/save.php
@@ -30,7 +30,7 @@ if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
 Auth::requireLogin();
 
 if (App::isAdmin() !== true) {
-    $_SESSION['flash_msg']  = 'Access denied.';
+    $_SESSION['flash_msg']  = t('error.access_denied_inline');
     $_SESSION['flash_type'] = 'danger';
     header('Location: /dashboard');
     exit();

--- a/web/public_html/attendance/manage/save.php
+++ b/web/public_html/attendance/manage/save.php
@@ -91,7 +91,7 @@ if ($action === 'create') {
         . 'VALUES (?, ?, ?, ?, ?, ?)'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error creating service type.';
+        $_SESSION['flash_msg']  = t('error.db_create_service_type');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /attendance/manage');
         exit();

--- a/web/public_html/attendance/record/save.php
+++ b/web/public_html/attendance/record/save.php
@@ -128,7 +128,7 @@ if ($action === 'create') {
     );
     if ($stmt === false) {
         $mysqli->rollback();
-        $_SESSION['flash_msg']  = 'Database error creating session.';
+        $_SESSION['flash_msg']  = t('error.db_create_session');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /attendance/record');
         exit();
@@ -188,7 +188,7 @@ if ($action === 'update') {
     );
     if ($stmt === false) {
         $mysqli->rollback();
-        $_SESSION['flash_msg']  = 'Database error updating session.';
+        $_SESSION['flash_msg']  = t('error.db_update_session');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /attendance');
         exit();

--- a/web/public_html/auth/2fa/setup.php
+++ b/web/public_html/auth/2fa/setup.php
@@ -33,7 +33,7 @@ $siteId = Site::id();
 // 🔍 Check if already enabled
 $userStmt = $mysqli->prepare('SELECT totpEnabled, emailAddress FROM tblUsers WHERE userID = ? LIMIT 1');
 if ($userStmt === false) {
-    $_SESSION['flash_msg']  = 'Database error.';
+    $_SESSION['flash_msg']  = t('error.database');
     $_SESSION['flash_type'] = 'danger';
     header('Location: /auth/account');
     exit();

--- a/web/public_html/auth/2fa/verify.php
+++ b/web/public_html/auth/2fa/verify.php
@@ -54,7 +54,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     // 🔍 Fetch user's TOTP secret
     $uStmt = $mysqli->prepare('SELECT totpSecret FROM tblUsers WHERE userID = ? AND totpEnabled = 1 LIMIT 1');
     if ($uStmt === false) {
-        $_SESSION['flash_msg']  = 'Database error.';
+        $_SESSION['flash_msg']  = t('error.database');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /auth/2fa/verify');
         exit();

--- a/web/public_html/auth/account/notifications-save.php
+++ b/web/public_html/auth/account/notifications-save.php
@@ -71,7 +71,7 @@ if ($json === false) {
 $stmt = $mysqli->prepare('UPDATE tblUsers SET notifyPrefs = ? WHERE userID = ?');
 if ($stmt === false) {
     Logger::errorPlatform('MySQL', 'Error', 'NOTIFY_PREFS_PREP', $mysqli->error, '');
-    $_SESSION['notifications_flash']      = 'Database error saving preferences.';
+    $_SESSION['notifications_flash']      = t('error.db_save_preferences');
     $_SESSION['notifications_flash_type'] = 'danger';
     header('Location: /account/notifications', true, 302);
     exit();

--- a/web/public_html/calendar/manage/import.php
+++ b/web/public_html/calendar/manage/import.php
@@ -207,7 +207,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
                 );
                 if ($stmt === false) {
-                    $error = 'Database error preparing insert.';
+                    $error = t('error.db_import_prepare');
                 } else {
                     $okCount = 0;
                     foreach ($rows as $r) {

--- a/web/public_html/calendar/manage/save.php
+++ b/web/public_html/calendar/manage/save.php
@@ -201,7 +201,7 @@ if ($action === 'create') {
     );
 
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error: ' . $mysqli->error;
+        $_SESSION['flash_msg']  = t('error.db_with_detail', ['detail' => $mysqli->error]);
         $_SESSION['flash_type'] = 'danger';
         header('Location: /calendar/manage');
         exit();

--- a/web/public_html/calendar/rsvp.php
+++ b/web/public_html/calendar/rsvp.php
@@ -58,7 +58,7 @@ $evStmt = $mysqli->prepare(
     'SELECT eventID, eventName, capacity FROM tblEvents WHERE eventID = ? AND siteID = ? AND isDeleted = 0 LIMIT 1'
 );
 if ($evStmt === false) {
-    $_SESSION['flash_msg']  = 'Database error.';
+    $_SESSION['flash_msg']  = t('error.database');
     $_SESSION['flash_type'] = 'danger';
     header('Location: ' . $redirect);
     exit();

--- a/web/public_html/leadership/manage/import.php
+++ b/web/public_html/leadership/manage/import.php
@@ -184,7 +184,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                     . 'VALUES (?, ?, ?, ?, ?, ?, 1)'
                 );
                 if ($stmt === false) {
-                    $error = 'Database error preparing insert.';
+                    $error = t('error.db_import_prepare');
                 } else {
                     $okCount = 0;
                     foreach ($rows as $r) {

--- a/web/public_html/leadership/manage/save.php
+++ b/web/public_html/leadership/manage/save.php
@@ -93,7 +93,7 @@ if ($action === 'create') {
         . 'VALUES (?, ?, ?, ?, ?)'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error creating role.';
+        $_SESSION['flash_msg']  = t('error.db_create_role');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /leadership/manage');
         exit();

--- a/web/public_html/leadership/save.php
+++ b/web/public_html/leadership/save.php
@@ -190,7 +190,7 @@ if ($action === 'create') {
         . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error.';
+        $_SESSION['flash_msg']  = t('error.database');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /leadership/assign?roleID=' . $roleID);
         exit();
@@ -239,7 +239,7 @@ if ($action === 'update') {
         . 'WHERE assignmentID = ? AND siteID = ?'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error.';
+        $_SESSION['flash_msg']  = t('error.database');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /leadership');
         exit();

--- a/web/public_html/prayer-requests/manage.php
+++ b/web/public_html/prayer-requests/manage.php
@@ -37,7 +37,9 @@ if (App::isAdmin() === false) {
     http_response_code(403);
     $pageTitle = 'Forbidden';
     require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
-    echo '<div class="alert alert-danger"><i class="fa-solid fa-lock me-1"></i>Moderator access required.</div>';
+    echo '<div class="alert alert-danger"><i class="fa-solid fa-lock me-1"></i>'
+        . htmlspecialchars(t('error.moderator_only'), ENT_QUOTES, 'UTF-8')
+        . '</div>';
     echo '<a href="/prayer-requests" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i> Back</a>';
     require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php';
     exit();

--- a/web/public_html/prayer-requests/view.php
+++ b/web/public_html/prayer-requests/view.php
@@ -70,7 +70,9 @@ if ($req === null) {
     http_response_code(404);
     $pageTitle = 'Not Found';
     require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
-    echo '<div class="alert alert-warning"><i class="fa-solid fa-circle-exclamation me-1"></i>Prayer request not found.</div>';
+    echo '<div class="alert alert-warning"><i class="fa-solid fa-circle-exclamation me-1"></i>'
+        . htmlspecialchars(t('prayer_requests.error.not_found'), ENT_QUOTES, 'UTF-8')
+        . '</div>';
     echo '<a href="/prayer-requests" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i> Back</a>';
     require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php';
     exit();
@@ -85,7 +87,9 @@ if ($isOwner === false && $isMod === false && $isCongregationVisible === false) 
     http_response_code(403);
     $pageTitle = 'Forbidden';
     require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
-    echo '<div class="alert alert-danger"><i class="fa-solid fa-lock me-1"></i>You do not have access to this prayer request.</div>';
+    echo '<div class="alert alert-danger"><i class="fa-solid fa-lock me-1"></i>'
+        . htmlspecialchars(t('prayer_requests.error.no_access'), ENT_QUOTES, 'UTF-8')
+        . '</div>';
     echo '<a href="/prayer-requests" class="btn btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i> Back</a>';
     require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php';
     exit();

--- a/web/public_html/settings/save.php
+++ b/web/public_html/settings/save.php
@@ -77,7 +77,7 @@ if ($settingId > 0) {
     // ✏️ Update existing
     $stmt = $mysqli->prepare('UPDATE tblSettings SET settingValue = ?, isSensitive = ?, updatedAt = NOW() WHERE settingID = ?');
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error updating setting.';
+        $_SESSION['flash_msg']  = t('error.db_update_setting');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /settings');
         exit();
@@ -109,7 +109,7 @@ if ($settingId > 0) {
         'INSERT INTO tblSettings (settingKey, settingValue, isSensitive, siteID, updatedAt) VALUES (?, ?, ?, ?, NOW())'
     );
     if ($stmt === false) {
-        $_SESSION['flash_msg']  = 'Database error adding setting.';
+        $_SESSION['flash_msg']  = t('error.db_add_setting');
         $_SESSION['flash_type'] = 'danger';
         header('Location: /settings');
         exit();

--- a/web/public_html/tasks/complete.php
+++ b/web/public_html/tasks/complete.php
@@ -52,7 +52,7 @@ $tStmt = $mysqli->prepare(
     'SELECT * FROM tblTasks WHERE taskID = ? AND siteID = ? AND isDeleted = 0 LIMIT 1'
 );
 if ($tStmt === false) {
-    $_SESSION['flash_msg']  = 'Database error.';
+    $_SESSION['flash_msg']  = t('error.database');
     $_SESSION['flash_type'] = 'danger';
     header('Location: /tasks');
     exit();


### PR DESCRIPTION
## Summary

Closes #209. Wraps **~30 user-facing hardcoded English strings** across admin, attendance, auth, calendar, leadership, prayer-requests, settings, and tasks handlers with `t()` calls. Adds 18 new keys under `error.*` and `prayer_requests.error.*` in `web/_lang/en.php`.

## What changed

**`web/_lang/en.php` (+18 keys)** — inline error namespace:

```php
'error.access_denied_inline'           => 'Access denied.',
'error.database'                       => 'Database error.',
'error.db_create_service_type'         => 'Database error creating service type.',
'error.db_create_session'              => 'Database error creating session.',
'error.db_update_session'              => 'Database error updating session.',
'error.db_create_user'                 => 'Database error creating user. Please try again.',
'error.db_save_template'               => 'Database error saving template.',
'error.db_save_preferences'            => 'Database error saving preferences.',
'error.db_update_setting'              => 'Database error updating setting.',
'error.db_add_setting'                 => 'Database error adding setting.',
'error.db_create_role'                 => 'Database error creating role.',
'error.db_import_prepare'              => 'Database error preparing insert.',
'error.db_with_detail'                 => 'Database error: :detail',
'error.csrf_failed'                    => 'CSRF check failed.',
'error.umbrella_admin_only'            => 'Access denied. Umbrella admin privileges required.',
'error.moderator_only'                 => 'Moderator access required.',
'prayer_requests.error.not_found'      => 'Prayer request not found.',
'prayer_requests.error.no_access'      => 'You do not have access to this prayer request.',
```

**25 PHP handlers** — hardcoded literals → `t()` calls. Examples:

- `$_SESSION['flash_msg'] = 'Database error.'` → `$_SESSION['flash_msg'] = t('error.database')`
- `echo 'Access denied. Umbrella admin privileges required.'` → `echo t('error.umbrella_admin_only')`
- `'Database error: ' . $db->error` → `t('error.db_with_detail', ['detail' => $db->error])` (parameterised)
- HTML alerts in `prayer-requests/view.php` + `manage.php` keep their `<div>` + icon HTML but wrap the inner text with `htmlspecialchars(t('…'), ENT_QUOTES, 'UTF-8')` per project style

## What's intentionally NOT touched

- **`ApiResponse::error('Database error', …)`** across `*/api/*.php` — these are API contract strings returned to JSON clients, not UI text. Translating would change the API surface.
- **`auth/login/webauthn.php`** JSON response (`echo json_encode([…])`) — same reason.
- **`expenses/{approve,treasury,withdraw}/save.php`** — also JSON-response paths.
- **`events/api/*`** — JSON.

## What's NOT in this PR (separate tracking)

- **`cy.php`** stays as-is — its partial-coverage status is the subject of #210 (next PR: add a partial-coverage indicator so Welsh users know what to expect, since I can't authentically translate without a native speaker).
- **201 orphan keys** in en.php — triaged separately; 48 dead, 157 reserved-for-future. Cleanup PR coming for #211.

## Test plan

- [x] `php -l` clean on all 25 PHP files + en.php
- [x] All `t()` keys used resolve to entries in en.php
- [ ] **Manual**: trigger one DB-error flash (e.g. try to save a setting on a stale connection) → see the translated message rendered, not the raw key string
- [ ] **Manual**: visit `/admin/sites` as a non-umbrella-admin → see `Access denied. Umbrella admin privileges required.`
- [ ] **Manual**: visit `/prayer-requests/manage` as a non-moderator → see `Moderator access required.` in the alert
- [ ] **Manual**: switch to Welsh locale → confirm English fallback for these new keys still renders correctly (per the existing `I18n::t()` missing-key fallback behaviour)

## Files changed

| File | Edit |
|---|---|
| `web/_lang/en.php` | +18 keys |
| `web/public_html/admin/audit/index.php` | access_denied_inline |
| `web/public_html/admin/email-templates/preview.php` | csrf_failed |
| `web/public_html/admin/email-templates/save.php` | db_save_template |
| `web/public_html/admin/reports/index.php` | access_denied_inline |
| `web/public_html/admin/sites/index.php` | umbrella_admin_only |
| `web/public_html/admin/sites/save.php` | access_denied_inline + 2x db_with_detail |
| `web/public_html/admin/sites/users.php` | umbrella_admin_only + database |
| `web/public_html/admin/users/save.php` | db_create_user |
| `web/public_html/admin/workflows/index.php` | access_denied_inline |
| `web/public_html/admin/workflows/save.php` | access_denied_inline |
| `web/public_html/attendance/manage/save.php` | db_create_service_type |
| `web/public_html/attendance/record/save.php` | 2x db session |
| `web/public_html/auth/2fa/setup.php` | database |
| `web/public_html/auth/2fa/verify.php` | database |
| `web/public_html/auth/account/notifications-save.php` | db_save_preferences |
| `web/public_html/calendar/manage/import.php` | db_import_prepare |
| `web/public_html/calendar/manage/save.php` | db_with_detail |
| `web/public_html/calendar/rsvp.php` | database |
| `web/public_html/leadership/manage/import.php` | db_import_prepare |
| `web/public_html/leadership/manage/save.php` | db_create_role |
| `web/public_html/leadership/save.php` | 2x database |
| `web/public_html/prayer-requests/manage.php` | moderator_only (HTML alert) |
| `web/public_html/prayer-requests/view.php` | 2x prayer_requests.error.* (HTML alerts) |
| `web/public_html/settings/save.php` | db_update_setting + db_add_setting |
| `web/public_html/tasks/complete.php` | database |


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_