### PR TITLE
feat(install/upgrade): migration runner + state detection + maintenance mode + JSON backups (1.0.1 → 1.1.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,71 @@ Automated sections are appended by `.github/workflows/changelog.yml` per push
 to `alpha`, `beta`, and `main` using the heading format
 `## [VERSION] - YYYY-MM-DD (branch)`.
 
+## [1.1.0] - Unreleased
+
+### Added — Installer state detection + Drop-and-rebuild option (#220)
+
+The installer now probes the target database after credentials validate and classifies into one of:
+
+- `EMPTY` — fresh install (current path)
+- `PARTIAL` — tables exist, no `.installed` lock → render step 2.5 (Continue / Drop)
+- `INSTALLED_CURRENT` — same version → redirect to portal
+- `INSTALLED_UPGRADE` — older version → step 2.5 with upgrade messaging
+- `FRESH_REQUIRED` — installed below `fresh_required_below` policy threshold → step 2.5 with continue disabled
+
+Drop-and-rebuild is gated by a typed hostname confirmation (configurable via `portal.upgrade.require_hostname_confirm`).
+
+New files:
+- `web/_install/upgrade-policy.php` — static version-threshold + backup defaults
+- `web/_install/db_state.php` — `detectDbState()` helper (bootstrap-free)
+
+Installer modifications:
+- Step 2 calls `detectDbState()` after credentials validate
+- New step `2.5` renders the choice page with state-specific messaging
+- Step 3 honours `$_SESSION['install_action']` — `'drop'` triggers `DROP TABLE` of every `tbl*` table (FK_CHECKS off) before re-running schema
+- Step 5 writes `portal.installed_version = INSTALL_VERSION` and clears any leftover maintenance flag
+
+### Added — Auto-backup before upgrade migrations + JSON snapshot engine
+
+New `Portal\Core\DbBackup` class. Used by `/admin/upgrade`:
+
+- Snapshots every `tbl*` table to `web/_backups/upgrade-YYYYMMDD-HHMMSS/{tableName}.json` before any migration runs.
+- `_manifest.json` per snapshot with schema metadata, row counts, SHA-256 hashes.
+- JSON per-table format chosen for programmatic restore (the future per-migration "rescue script" path for Tier-3 breaking changes).
+- Retention: `portal.upgrade.backup.keep_last_n` (default 10) — pruned LIFO on each successful upgrade.
+- Can be disabled via `portal.upgrade.backup.enabled = 0` (not recommended).
+
+`DbBackup::restoreTable()` reads a snapshot and re-INSERTs in a transaction. The admin restore UI is a follow-up PR.
+
+### Added — Maintenance mode (auto on during upgrade, auto off when done)
+
+New `Portal\Core\Maintenance` class + front-controller gate:
+
+- Active when EITHER `portal.maintenance.active = '1'` OR `portal.installed_version < PORTAL_VERSION` (version drift).
+- Front controller (`public_html/index.php`) renders a themed 503 maintenance page (with `prefers-color-scheme`, auto-refresh every 60s) for non-admin / non-allow-listed requests.
+- Allow list: `/auth/login`, `/auth/logout`, `/admin/upgrade`, `/admin/maintenance`, `/assets/`, `/offline`. Admins always pass through.
+- `/admin/upgrade` flips the flag on at the start of migrations, updates `portal.installed_version` on success, flips the flag off. Both signals clear automatically.
+
+### Added — Migration 060 + tblSettings registrations
+
+`web/_sql/060_portal_versioning_and_maintenance.sql` seeds the new keys:
+- `portal.installed_version`
+- `portal.maintenance.active`, `portal.maintenance.message`
+- `portal.upgrade.backup.enabled`, `portal.upgrade.backup.keep_last_n`
+- `portal.upgrade.fresh_required_below`, `portal.upgrade.require_hostname_confirm`
+
+All idempotent. Fresh installs pick them up from `full_schema.sql`'s seed; stale-DB retries get them via the migration runner from #218 / PR #219.
+
+### Changed — Version bumped 1.0.1 → 1.1.0
+
+Net-new feature surface → minor bump per semver.
+
+### Not in this PR (follow-ups)
+
+- Admin UI for browsing / restoring snapshots (`/admin/maintenance/backup`). The `DbBackup` engine is in place; the UI is a separate PR.
+- Per-migration "rescue script" mechanism for Tier-3 breaking schema changes (needed when `fresh_required_below` is first bumped above `0.0.0`).
+- Existing `/admin/settings` UI already supports editing the new `portal.upgrade.*` and `portal.maintenance.*` keys (they're regular tblSettings rows).
+
 ## [1.0.1] - Unreleased
 
 ### Fixed — Installer is now resilient to schema drift across retries

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,72 @@ Automated sections are appended by `.github/workflows/changelog.yml` per push
 to `alpha`, `beta`, and `main` using the heading format
 `## [VERSION] - YYYY-MM-DD (branch)`.
 
+## [1.0.1] - Unreleased
+
+### Fixed — Installer is now resilient to schema drift across retries
+
+The installer's step 3 ran `full_schema.sql` and stopped there. Because
+`CREATE TABLE IF NOT EXISTS` is a no-op when a table already exists,
+any failed install that reached step 3 successfully locked the database
+into whatever shape the schema had at that moment. If a later code
+change added a column to one of those tables (via a numbered migration),
+the user's retry would still hit the old shape — and step 4's INSERTs,
+which assume the current shape, would fatal with
+`Unknown column '<colname>' in 'field list'`.
+
+This was the root cause of three consecutive support rounds:
+- `tblUsers.siteID` doesn't exist (#198 / PR #199 — fixed the schema
+   but stale DBs still fatalled)
+- `tblLocalAccounts.isVerified` doesn't exist (this round)
+
+The schema-vs-runtime audits the project ran in #197/#199/#212/#214
+were all looking at the wrong dimension — schema vs PHP code — when
+the actual breakage was schema-on-disk vs schema-in-this-DB.
+
+**Fix**: step 3 now runs `full_schema.sql` AND then runs every
+numbered migration in `web/_sql/0NN_*.sql` order. Every migration
+uses idempotent constructs (`ADD COLUMN IF NOT EXISTS`,
+`INSERT ... ON DUPLICATE KEY UPDATE`, `DELETE FROM ... WHERE`), so
+fresh installs see them as no-ops (`full_schema.sql` already has
+every column the migrations would add) and stale-DB retries pick up
+the missing columns. The installer doesn't go through
+`Portal\Core\Migrator` because (a) Migrator filters by
+`tblMigrations`, which `full_schema.sql` seeds as fully-applied, and
+(b) the installer is bootstrap-free.
+
+### Fixed — `tblTasks` SELECT uses non-existent `dueAt` column (#218)
+
+`web/public_html/tasks/api/list.php` issued a `SELECT taskID, title,
+description, dueAt, ...` against `tblTasks`. The schema column is
+`dueDate`, not `dueAt`. The `/api/tasks/list` endpoint would 500 on
+every call. Surfaced by the widened
+`tools/audit-checks/check_sql_columns.py` — see next entry.
+
+### Changed — `check_sql_columns.py` now scans UPDATE + SELECT, not just INSERT
+
+The CI consistency check added in #214 only walked `INSERT INTO tbl
+(col, col)` column lists. It missed bugs in `UPDATE tbl SET col = ?`
+clauses and `SELECT col, col FROM tbl` lists — which is how
+`tblTasks.dueAt` slipped past the previous "exhaustive" sweep.
+
+The widened check now matches:
+
+- `INSERT INTO tbl (cols…)` (already supported)
+- `UPDATE tbl SET col = …, col = …` — bounded so we don't span across
+  PHP-concatenated multi-statement strings or beyond `WHERE` / `ORDER`
+- `SELECT col, col FROM tbl` — only when the column list is simple
+  identifiers (no functions, joins, aliases, or `*`); skips pure
+  numeric "columns" so `SELECT 1 FROM tbl WHERE …` existence checks
+  don't false-positive
+
+Line-number reporting also fixed: under PHP string concatenation,
+`'INSERT (' . 'col1, col2)'` is reconstructed for matching, which
+collapses newlines and confused the previous offset lookup. We now
+compute line numbers against the reconstructed text, which keeps the
+report within a few lines of the actual SQL.
+
+### Changed — Version bumped to 1.0.1
+
 ## [Unreleased]
 
 ### Fixed — Audit follow-up #3: cross-source consistency

--- a/tools/audit-checks/check_sql_columns.py
+++ b/tools/audit-checks/check_sql_columns.py
@@ -58,6 +58,33 @@ INSERT_RE = re.compile(
     re.IGNORECASE,
 )
 
+# Match: UPDATE `tblX` SET col = ?, col = ?, ...  up to the FIRST of:
+#   WHERE / ORDER / LIMIT / closing quote / new statement / end-of-string.
+# Critically we DO NOT span across PHP string concatenation joiners
+# (which could otherwise pull in a later UPDATE statement's SET clause)
+# nor across `UPDATE` / `INSERT` / `DELETE` / `SELECT` keywords that
+# would start a new statement.
+UPDATE_RE = re.compile(
+    r"UPDATE\s+(?:IGNORE\s+)?`?(tbl\w+)`?\s+SET\s+"
+    r"(.*?)"
+    r"(?:\s+WHERE\b|\s+ORDER\b|\s+LIMIT\b"
+    r"|\s+(?:INSERT|UPDATE|DELETE|SELECT)\b"
+    r"|'\s*\)|\s*$)",
+    re.IGNORECASE | re.DOTALL,
+)
+# Inside the SET clause: `colName` = expr  or  colName = expr
+SET_ASSIGN_RE = re.compile(r"`?(\w+)`?\s*=")
+
+# Match: SELECT col, col FROM `tblX` (no JOINs, no aliases — keeps the check
+# precise but narrow). Skip SELECT * patterns.
+SELECT_RE = re.compile(
+    r"SELECT\s+(?!\*)([^\n]+?)\s+FROM\s+`?(tbl\w+)`?\s*"
+    r"(?:WHERE|ORDER|GROUP|LIMIT|;|\s*$|\)|\s+(?:LEFT|INNER|RIGHT|OUTER|JOIN))",
+    re.IGNORECASE,
+)
+# Inside the SELECT column list: identifier (possibly with AS alias)
+SELECT_COL_RE = re.compile(r"`?(\w+)`?(?:\s+AS\s+\w+)?")
+
 
 def build_schema_map() -> dict[str, set[str]]:
     """Return {tableName: {column, column, …}}."""
@@ -134,9 +161,9 @@ def strip_php_comments(text: str) -> str:
     return text
 
 
-def scan_php_inserts(schema: dict[str, set[str]]) -> list[tuple[Path, int, str, str]]:
-    """Return findings: (php_file, line_no, table, missing_column)."""
-    findings: list[tuple[Path, int, str, str]] = []
+def scan_php_inserts(schema: dict[str, set[str]]) -> list[tuple[Path, int, str, str, str]]:
+    """Return findings: (php_file, line_no, table, missing_column, statement_kind)."""
+    findings: list[tuple[Path, int, str, str, str]] = []
     for root in PHP_ROOTS:
         if not root.exists():
             continue
@@ -146,27 +173,70 @@ def scan_php_inserts(schema: dict[str, set[str]]) -> list[tuple[Path, int, str, 
             except OSError:
                 continue
             text = strip_php_comments(reconstruct_php_strings(raw))
+
+            # Line numbers are computed from `text` (reconstructed), not
+            # `raw`, because string-concatenation reconstruction collapses
+            # multi-line SQL onto fewer lines — using raw.find() against
+            # collapsed strings reports wildly wrong offsets.
+            # `strip_php_comments` preserves newline count so the reported
+            # line still points within a few lines of the actual SQL.
+
+            # ── INSERT column lists ──
             for m in INSERT_RE.finditer(text):
                 tbl = m.group(1)
-                col_list = m.group(2)
-                cols = [c.strip().strip("`") for c in col_list.split(",")]
+                cols = [c.strip().strip("`") for c in m.group(2).split(",")]
                 cols = [c for c in cols if c]
-                # Sanity guard against parser fragments — column names
-                # should be `\w+`. Skip anything that doesn't parse cleanly.
                 if not cols or not all(re.fullmatch(r"\w+", c) for c in cols):
                     continue
+                line_no = text[: m.start()].count("\n") + 1
                 if tbl not in schema:
-                    findings.append(
-                        (php, raw[: raw.find(m.group(0))].count("\n") + 1,
-                         tbl, "(unknown table)")
-                    )
+                    findings.append((php, line_no, tbl, "(unknown table)", "INSERT"))
                     continue
                 for c in cols:
                     if c not in schema[tbl]:
-                        line_no = raw[: raw.find(m.group(0))].count("\n") + 1
-                        if line_no <= 0:
-                            line_no = 1
-                        findings.append((php, line_no, tbl, c))
+                        findings.append((php, line_no, tbl, c, "INSERT"))
+
+            # ── UPDATE … SET col = … assignments ──
+            for m in UPDATE_RE.finditer(text):
+                tbl = m.group(1)
+                set_body = m.group(2)
+                line_no = text[: m.start()].count("\n") + 1
+                if tbl not in schema:
+                    findings.append((php, line_no, tbl, "(unknown table)", "UPDATE"))
+                    continue
+                for assign in SET_ASSIGN_RE.finditer(set_body):
+                    col = assign.group(1)
+                    # Skip SQL keywords that may match the regex (e.g. NOW)
+                    # and skip PHP-templated placeholders.
+                    if col.upper() in {"NOW", "NULL", "TRUE", "FALSE", "AND", "OR"}:
+                        continue
+                    if col not in schema[tbl]:
+                        findings.append((php, line_no, tbl, col, "UPDATE"))
+
+            # ── SELECT col-list FROM tbl ──
+            for m in SELECT_RE.finditer(text):
+                col_body = m.group(1)
+                tbl = m.group(2)
+                line_no = text[: m.start()].count("\n") + 1
+                if tbl not in schema:
+                    findings.append((php, line_no, tbl, "(unknown table)", "SELECT"))
+                    continue
+                # Skip if the SELECT list contains anything that's not a
+                # simple identifier (functions, expressions, aliases, joins).
+                # We're after exact column references only.
+                if any(sym in col_body for sym in ("(", ")", ".", " AS ", "*", "DISTINCT")):
+                    continue
+                cols = [c.strip().strip("`") for c in col_body.split(",")]
+                # Skip pure-numeric "columns" — these are SQL literals from
+                # existence-check patterns like `SELECT 1 FROM tbl WHERE …`.
+                cols = [
+                    c for c in cols
+                    if c and re.fullmatch(r"\w+", c) and not c.isdigit()
+                ]
+                for c in cols:
+                    if c not in schema[tbl]:
+                        findings.append((php, line_no, tbl, c, "SELECT"))
+
     return findings
 
 
@@ -174,19 +244,34 @@ def check() -> int:
     schema = build_schema_map()
     print(f"Tables inspected: {len(schema)}")
     findings = scan_php_inserts(schema)
-    print(f"Column-name mismatches: {len(findings)}")
+    print(f"Column-name mismatches (INSERT + UPDATE + SELECT): {len(findings)}")
     print()
     if findings:
-        print("### Column-name mismatches\n")
-        # Deduplicate (file, line, table, col).
-        seen: set[tuple[str, int, str, str]] = set()
-        for php, line_no, tbl, col in findings:
+        # Deduplicate (file, line, table, col, kind).
+        seen: set[tuple[str, int, str, str, str]] = set()
+        deduped: list[tuple[str, int, str, str, str]] = []
+        for php, line_no, tbl, col, kind in findings:
             rel = str(php.relative_to(REPO_ROOT))
-            key = (rel, line_no, tbl, col)
+            key = (rel, line_no, tbl, col, kind)
             if key in seen:
                 continue
             seen.add(key)
-            print(f"  • {rel}:{line_no} — INSERT INTO {tbl} references column `{col}`")
+            deduped.append(key)
+
+        # Group by statement kind for readable output.
+        by_kind: dict[str, list[tuple[str, int, str, str, str]]] = {}
+        for finding in deduped:
+            by_kind.setdefault(finding[4], []).append(finding)
+
+        for kind in ("INSERT", "UPDATE", "SELECT"):
+            rows = by_kind.get(kind, [])
+            if not rows:
+                continue
+            print(f"### {kind} column-name mismatches ({len(rows)})\n")
+            for rel, line_no, tbl, col, _ in rows:
+                print(f"  • {rel}:{line_no} — {kind} on {tbl} references column `{col}`")
+            print()
+
     strict = "--strict" in sys.argv
     if findings and strict:
         return 1

--- a/web/_core/DbBackup.php
+++ b/web/_core/DbBackup.php
@@ -1,0 +1,507 @@
+<?php
+// Path: _core/DbBackup.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — Database Backup & Restore 📦
+ * -----------------------------------------------------------------------------
+ * JSON-per-table snapshot engine. Used by:
+ *
+ *   • _install/upgrade.php — auto-backup BEFORE running migrations on
+ *     the upgrade path so the admin has a safety net if a migration
+ *     misbehaves.
+ *   • admin/maintenance/backup — list / inspect / restore historical
+ *     snapshots from the UI.
+ *
+ * Why JSON per-table (not single mysqldump-style file):
+ *   • Programmatically inspectable — a future per-migration "rescue
+ *     script" can read the affected table's JSON and re-insert under
+ *     a new schema without parsing SQL.
+ *   • Per-table granularity — admin can restore a single table without
+ *     touching others.
+ *   • Self-describing — each snapshot includes column metadata, row
+ *     count, snapshot timestamp, and a checksum.
+ *
+ * Layout:
+ *   web/_backups/upgrade-YYYYMMDD-HHMMSS/
+ *     ├── _manifest.json     # snapshot-wide metadata + table list
+ *     ├── tblUsers.json      # { meta: {columns, count, …}, rows: [...] }
+ *     ├── tblSettings.json
+ *     └── ...
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+use mysqli;
+use RuntimeException;
+
+class DbBackup
+{
+    private mysqli $db;
+    private string $backupsRoot;
+
+    public function __construct(mysqli $db, string $backupsRoot = '')
+    {
+        $this->db          = $db;
+        $this->backupsRoot = $backupsRoot !== ''
+            ? rtrim($backupsRoot, DIRECTORY_SEPARATOR)
+            : PORTAL_ROOT . DIRECTORY_SEPARATOR . '_backups';
+    }
+
+    /**
+     * Take a JSON-per-table snapshot of every `tbl*` table.
+     *
+     * @param string $reason  Short human-readable label embedded in the
+     *                        manifest (e.g. 'pre-upgrade-1.0.1-to-1.1.0').
+     *
+     * @return array{success: bool, directory: string, tables: int,
+     *                rows: int, error?: string}
+     */
+    public function snapshot(string $reason = ''): array
+    {
+        // 🗂️ Ensure the backups root exists.
+        if (is_dir($this->backupsRoot) === false) {
+            if (mkdir($this->backupsRoot, 0750, true) === false
+                && is_dir($this->backupsRoot) === false
+            ) {
+                return [
+                    'success'   => false,
+                    'directory' => '',
+                    'tables'    => 0,
+                    'rows'      => 0,
+                    'error'     => 'Could not create backups root: ' . $this->backupsRoot,
+                ];
+            }
+        }
+
+        $stamp = date('Ymd-His');
+        $dir   = $this->backupsRoot . DIRECTORY_SEPARATOR . 'upgrade-' . $stamp;
+        if (mkdir($dir, 0750, true) === false && is_dir($dir) === false) {
+            return [
+                'success'   => false,
+                'directory' => '',
+                'tables'    => 0,
+                'rows'      => 0,
+                'error'     => 'Could not create snapshot directory: ' . $dir,
+            ];
+        }
+
+        $manifest = [
+            'created_at'   => date('c'),
+            'reason'       => $reason,
+            'php_version'  => PHP_VERSION,
+            'mysql_server' => $this->db->server_info,
+            'tables'       => [],
+        ];
+        $totalRows = 0;
+
+        // 🔍 Enumerate portal tables.
+        try {
+            $rs = $this->db->query("SHOW TABLES LIKE 'tbl%'");
+        } catch (\mysqli_sql_exception $e) {
+            return [
+                'success'   => false,
+                'directory' => $dir,
+                'tables'    => 0,
+                'rows'      => 0,
+                'error'     => 'Table enumeration failed: ' . $e->getMessage(),
+            ];
+        }
+        if ($rs === false) {
+            return [
+                'success'   => false,
+                'directory' => $dir,
+                'tables'    => 0,
+                'rows'      => 0,
+                'error'     => 'SHOW TABLES returned false.',
+            ];
+        }
+
+        $tableCount = 0;
+        while (($row = $rs->fetch_array(MYSQLI_NUM)) !== null) {
+            $table = (string) $row[0];
+            $written = $this->dumpTable($dir, $table);
+            if ($written['success'] === false) {
+                $rs->free();
+                return [
+                    'success'   => false,
+                    'directory' => $dir,
+                    'tables'    => $tableCount,
+                    'rows'      => $totalRows,
+                    'error'     => 'Failed to dump ' . $table . ': ' . $written['error'],
+                ];
+            }
+            $manifest['tables'][$table] = [
+                'columns' => $written['columns'],
+                'rows'    => $written['rows'],
+                'sha256'  => $written['sha256'],
+            ];
+            $totalRows += $written['rows'];
+            $tableCount++;
+        }
+        $rs->free();
+
+        // 📝 Write manifest last so a half-finished snapshot is obvious
+        //    (manifest absent → snapshot incomplete).
+        $manifestJson = json_encode(
+            $manifest,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+        if ($manifestJson === false) {
+            return [
+                'success'   => false,
+                'directory' => $dir,
+                'tables'    => $tableCount,
+                'rows'      => $totalRows,
+                'error'     => 'Manifest serialisation failed.',
+            ];
+        }
+        $manifestPath = $dir . DIRECTORY_SEPARATOR . '_manifest.json';
+        if (file_put_contents($manifestPath, $manifestJson) === false) {
+            return [
+                'success'   => false,
+                'directory' => $dir,
+                'tables'    => $tableCount,
+                'rows'      => $totalRows,
+                'error'     => 'Could not write manifest.',
+            ];
+        }
+
+        return [
+            'success'   => true,
+            'directory' => $dir,
+            'tables'    => $tableCount,
+            'rows'      => $totalRows,
+        ];
+    }
+
+    /**
+     * Dump a single table to `{dir}/{table}.json`.
+     *
+     * @return array{success: bool, columns: string[], rows: int,
+     *                sha256: string, error?: string}
+     */
+    private function dumpTable(string $dir, string $table): array
+    {
+        // 🔍 Validate table identifier — we're about to inject it into
+        //    SQL; tighter than is strictly needed since SHOW TABLES gave
+        //    us the name, but defence-in-depth.
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $table) !== 1) {
+            return [
+                'success' => false,
+                'columns' => [],
+                'rows'    => 0,
+                'sha256'  => '',
+                'error'   => 'Invalid table identifier: ' . $table,
+            ];
+        }
+
+        try {
+            $rs = $this->db->query('SELECT * FROM `' . $table . '`');
+        } catch (\mysqli_sql_exception $e) {
+            return [
+                'success' => false,
+                'columns' => [],
+                'rows'    => 0,
+                'sha256'  => '',
+                'error'   => $e->getMessage(),
+            ];
+        }
+        if ($rs === false) {
+            return [
+                'success' => false,
+                'columns' => [],
+                'rows'    => 0,
+                'sha256'  => '',
+                'error'   => 'SELECT * FROM ' . $table . ' returned false.',
+            ];
+        }
+
+        $columns = [];
+        $fields  = $rs->fetch_fields();
+        foreach ($fields as $f) {
+            $columns[] = (string) $f->name;
+        }
+
+        $rows = [];
+        while (($row = $rs->fetch_assoc()) !== null) {
+            $rows[] = $row;
+        }
+        $rs->free();
+
+        $payload = [
+            'meta' => [
+                'table'      => $table,
+                'columns'    => $columns,
+                'row_count'  => count($rows),
+                'snapped_at' => date('c'),
+            ],
+            'rows' => $rows,
+        ];
+
+        $json = json_encode(
+            $payload,
+            JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES | JSON_UNESCAPED_UNICODE
+        );
+        if ($json === false) {
+            return [
+                'success' => false,
+                'columns' => $columns,
+                'rows'    => count($rows),
+                'sha256'  => '',
+                'error'   => 'JSON encode failed: ' . json_last_error_msg(),
+            ];
+        }
+
+        $file = $dir . DIRECTORY_SEPARATOR . $table . '.json';
+        if (file_put_contents($file, $json) === false) {
+            return [
+                'success' => false,
+                'columns' => $columns,
+                'rows'    => count($rows),
+                'sha256'  => '',
+                'error'   => 'Could not write ' . $file,
+            ];
+        }
+
+        return [
+            'success' => true,
+            'columns' => $columns,
+            'rows'    => count($rows),
+            'sha256'  => hash('sha256', $json),
+        ];
+    }
+
+    /**
+     * List all snapshot directories under the backups root, newest first.
+     *
+     * @return array<int, array{name: string, path: string,
+     *                          created_at: string, tables: int, rows: int,
+     *                          reason: string}>
+     */
+    public function listSnapshots(): array
+    {
+        if (is_dir($this->backupsRoot) === false) {
+            return [];
+        }
+        $entries = scandir($this->backupsRoot, SCANDIR_SORT_DESCENDING);
+        if ($entries === false) {
+            return [];
+        }
+        $snapshots = [];
+        foreach ($entries as $name) {
+            if ($name === '.' || $name === '..') {
+                continue;
+            }
+            $path = $this->backupsRoot . DIRECTORY_SEPARATOR . $name;
+            if (is_dir($path) === false) {
+                continue;
+            }
+            $manifestPath = $path . DIRECTORY_SEPARATOR . '_manifest.json';
+            if (is_readable($manifestPath) === false) {
+                // 🪞 No manifest → incomplete snapshot. Still list it so
+                //    the admin can decide whether to delete it.
+                $snapshots[] = [
+                    'name'       => $name,
+                    'path'       => $path,
+                    'created_at' => date('c', (int) filemtime($path)),
+                    'tables'     => 0,
+                    'rows'       => 0,
+                    'reason'     => '(incomplete — no manifest)',
+                ];
+                continue;
+            }
+            $raw = file_get_contents($manifestPath);
+            if ($raw === false) {
+                continue;
+            }
+            $manifest = json_decode($raw, true);
+            if (is_array($manifest) === false) {
+                continue;
+            }
+            $tableRows = 0;
+            foreach ((array) ($manifest['tables'] ?? []) as $t) {
+                $tableRows += (int) ($t['rows'] ?? 0);
+            }
+            $snapshots[] = [
+                'name'       => $name,
+                'path'       => $path,
+                'created_at' => (string) ($manifest['created_at'] ?? ''),
+                'tables'     => count((array) ($manifest['tables'] ?? [])),
+                'rows'       => $tableRows,
+                'reason'     => (string) ($manifest['reason'] ?? ''),
+            ];
+        }
+        return $snapshots;
+    }
+
+    /**
+     * Prune snapshots, keeping the most recent N. Pass 0 to disable.
+     *
+     * @return array{kept: int, pruned: int, errors: string[]}
+     */
+    public function prune(int $keep): array
+    {
+        if ($keep <= 0) {
+            return ['kept' => 0, 'pruned' => 0, 'errors' => []];
+        }
+        $snapshots = $this->listSnapshots();
+        $kept = 0;
+        $pruned = 0;
+        $errors = [];
+        foreach ($snapshots as $i => $snap) {
+            if ($i < $keep) {
+                $kept++;
+                continue;
+            }
+            // 🗑️ Recursive delete via our own helper to avoid pulling in
+            //    a vendor dependency.
+            if ($this->rmdirRecursive($snap['path']) === true) {
+                $pruned++;
+            } else {
+                $errors[] = 'Could not delete ' . $snap['path'];
+            }
+        }
+        return ['kept' => $kept, 'pruned' => $pruned, 'errors' => $errors];
+    }
+
+    /**
+     * Restore a single table from a snapshot. The table is TRUNCATEd
+     * first, then rows are re-INSERTed in the order they were dumped.
+     *
+     * @return array{success: bool, rows_restored: int, error?: string}
+     */
+    public function restoreTable(string $snapshotPath, string $table): array
+    {
+        $file = rtrim($snapshotPath, DIRECTORY_SEPARATOR)
+              . DIRECTORY_SEPARATOR . $table . '.json';
+        if (is_readable($file) === false) {
+            return [
+                'success'       => false,
+                'rows_restored' => 0,
+                'error'         => 'Snapshot file not found: ' . $file,
+            ];
+        }
+        $raw = file_get_contents($file);
+        if ($raw === false) {
+            return [
+                'success'       => false,
+                'rows_restored' => 0,
+                'error'         => 'Could not read ' . $file,
+            ];
+        }
+        $payload = json_decode($raw, true);
+        if (is_array($payload) === false
+            || isset($payload['rows']) === false
+            || is_array($payload['rows']) === false
+        ) {
+            return [
+                'success'       => false,
+                'rows_restored' => 0,
+                'error'         => 'Snapshot file malformed: ' . $file,
+            ];
+        }
+        if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $table) !== 1) {
+            return [
+                'success'       => false,
+                'rows_restored' => 0,
+                'error'         => 'Invalid table identifier: ' . $table,
+            ];
+        }
+
+        try {
+            $this->db->begin_transaction();
+            $this->db->query('TRUNCATE TABLE `' . $table . '`');
+
+            $rows = $payload['rows'];
+            $inserted = 0;
+            foreach ($rows as $row) {
+                if (is_array($row) === false || count($row) === 0) {
+                    continue;
+                }
+                $cols   = array_keys($row);
+                $values = array_values($row);
+                $colSql = implode(', ', array_map(
+                    static fn ($c) => '`' . $c . '`',
+                    $cols
+                ));
+                $placeholders = implode(', ', array_fill(0, count($values), '?'));
+                $stmt = $this->db->prepare(
+                    'INSERT INTO `' . $table . '` (' . $colSql . ') '
+                    . 'VALUES (' . $placeholders . ')'
+                );
+                if ($stmt === false) {
+                    $this->db->rollback();
+                    return [
+                        'success'       => false,
+                        'rows_restored' => $inserted,
+                        'error'         => 'Prepare failed for ' . $table,
+                    ];
+                }
+                // 🪶 Bind everything as strings — mysqli coerces to the
+                //    column type at INSERT time, and JSON->PHP gave us
+                //    primitives already (so nulls stay null).
+                $types = str_repeat('s', count($values));
+                $stmt->bind_param($types, ...array_map(
+                    static fn ($v) => is_scalar($v) || $v === null ? $v : json_encode($v),
+                    $values
+                ));
+                $stmt->execute();
+                $stmt->close();
+                $inserted++;
+            }
+            $this->db->commit();
+
+            return ['success' => true, 'rows_restored' => $inserted];
+        } catch (\mysqli_sql_exception $e) {
+            try {
+                $this->db->rollback();
+            } catch (\Throwable $ignored) {
+                // best effort
+            }
+            return [
+                'success'       => false,
+                'rows_restored' => 0,
+                'error'         => $e->getMessage(),
+            ];
+        }
+    }
+
+    /**
+     * @internal Recursive rmdir helper for snapshot pruning.
+     */
+    private function rmdirRecursive(string $dir): bool
+    {
+        if (is_dir($dir) === false) {
+            return true;
+        }
+        $entries = scandir($dir);
+        if ($entries === false) {
+            return false;
+        }
+        foreach ($entries as $e) {
+            if ($e === '.' || $e === '..') {
+                continue;
+            }
+            $path = $dir . DIRECTORY_SEPARATOR . $e;
+            if (is_dir($path) === true) {
+                if ($this->rmdirRecursive($path) === false) {
+                    return false;
+                }
+            } else {
+                if (unlink($path) === false) {
+                    return false;
+                }
+            }
+        }
+        return rmdir($dir);
+    }
+}

--- a/web/_core/Maintenance.php
+++ b/web/_core/Maintenance.php
@@ -1,0 +1,234 @@
+<?php
+// Path: _core/Maintenance.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — Maintenance Mode 🚧
+ * -----------------------------------------------------------------------------
+ * Gate that locks public portal access while an upgrade / migration / drop
+ * is in progress, then automatically releases when the work completes.
+ *
+ * Two state inputs combine to decide whether a request is gated:
+ *
+ *   1. portal.installed_version  (tblSettings, written by installer step 5
+ *      and by Migrator::runAll() on success). If LESS than the code version
+ *      from _core/version.php → "version drift" → gate on.
+ *
+ *   2. portal.maintenance.active (tblSettings, written by /admin/upgrade
+ *      while it's running, and by the installer's drop-and-rebuild path).
+ *      If '1' → gate on.
+ *
+ * Either input alone is sufficient to gate. Both clear automatically when
+ * the upgrade completes — version drift resolves when installed_version
+ * gets bumped; the explicit flag is cleared by whoever set it.
+ *
+ * Allow-list (always pass through, even when gated):
+ *   • /auth/login*           — admins need to sign in to fix it
+ *   • /admin/upgrade*        — the upgrader itself
+ *   • /admin/maintenance*    — backup / restore UI
+ *   • /assets/*              — CSS/JS for the maintenance page
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class Maintenance
+{
+    /**
+     * Routes that bypass the gate even when maintenance is active.
+     * Path prefixes — checked with `str_starts_with`.
+     */
+    private const ALLOW_LIST = [
+        'auth/login',
+        'auth/logout',
+        'admin/upgrade',
+        'admin/maintenance',
+        'assets/',
+        'offline',
+    ];
+
+    /**
+     * Is maintenance currently active? Combines version-drift detection
+     * with the explicit `portal.maintenance.active` flag.
+     */
+    public static function isActive(): bool
+    {
+        // 🆔 Explicit flag wins — if an admin (or the installer) flipped
+        //    it on, we're in maintenance regardless of versions.
+        $explicit = App::settings()['portal']['maintenance']['active'] ?? '0';
+        if ((string) $explicit === '1' || $explicit === true) {
+            return true;
+        }
+
+        // 🔢 Version-drift check. portal.installed_version is what's
+        //    actually in the DB; PORTAL_VERSION is what the code on
+        //    disk thinks. If the code is newer than the DB, an upgrade
+        //    is needed and we shouldn't let users in until it's run.
+        $installed = App::settings()['portal']['installed_version'] ?? '';
+        if (!is_string($installed) || $installed === '') {
+            // 🪞 Legacy install — never recorded a version. Don't gate
+            //    on a missing value; let the user in and let the next
+            //    explicit upgrade record the version.
+            return false;
+        }
+        if (defined('PORTAL_VERSION')
+            && version_compare($installed, (string) PORTAL_VERSION, '<')
+        ) {
+            return true;
+        }
+
+        return false;
+    }
+
+    /**
+     * Is the given request path allowed through even when maintenance
+     * is active? Pass the route key (without leading `/`).
+     */
+    public static function isAllowed(string $routeKey): bool
+    {
+        $routeKey = ltrim($routeKey, '/');
+        foreach (self::ALLOW_LIST as $prefix) {
+            if (str_starts_with($routeKey, $prefix)) {
+                return true;
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Is the current session an admin user? Admins can pass through
+     * the gate to access /admin/* routes (covered by ALLOW_LIST) and
+     * to fix the problem.
+     */
+    public static function currentUserCanBypass(): bool
+    {
+        // 🪞 `App::isAdmin()` is the canonical predicate; this wrapper
+        //    exists so future logic (e.g. "only root admins") can be
+        //    centralised without touching the front controller.
+        return App::isAdmin();
+    }
+
+    /**
+     * Flip the explicit maintenance flag on or off.
+     *
+     * @param bool $active true → enable maintenance; false → release.
+     */
+    public static function setActive(bool $active, ?string $message = null): bool
+    {
+        $db = App::db();
+        try {
+            $stmt = $db->prepare(
+                "INSERT INTO `tblSettings` "
+                . "(`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) "
+                . "VALUES (NULL, 'portal.maintenance.active', ?, '0', 0) "
+                . "ON DUPLICATE KEY UPDATE `settingValue` = VALUES(`settingValue`)"
+            );
+            if ($stmt === false) {
+                return false;
+            }
+            $value = $active === true ? '1' : '0';
+            $stmt->bind_param('s', $value);
+            $stmt->execute();
+            $stmt->close();
+
+            if ($message !== null) {
+                $stmt = $db->prepare(
+                    "INSERT INTO `tblSettings` "
+                    . "(`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) "
+                    . "VALUES (NULL, 'portal.maintenance.message', ?, '', 0) "
+                    . "ON DUPLICATE KEY UPDATE `settingValue` = VALUES(`settingValue`)"
+                );
+                if ($stmt !== false) {
+                    $stmt->bind_param('s', $message);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+            }
+            return true;
+        } catch (\mysqli_sql_exception $e) {
+            return false;
+        }
+    }
+
+    /**
+     * Render the standalone maintenance page (themed, no Bootstrap
+     * dependency since the rest of the framework might be mid-upgrade)
+     * and exit. Called by the front controller when a non-allowed
+     * non-admin request lands during maintenance.
+     */
+    public static function renderAndExit(): void
+    {
+        http_response_code(503);
+        header('Retry-After: 60');
+
+        $customMessage = App::settings()['portal']['maintenance']['message'] ?? '';
+        $messageHtml = '';
+        if (is_string($customMessage) && trim($customMessage) !== '') {
+            $messageHtml = '<p>' . htmlspecialchars(
+                trim($customMessage),
+                ENT_QUOTES,
+                'UTF-8'
+            ) . '</p>';
+        }
+
+        $portalName = htmlspecialchars(
+            (string) (App::settings()['site']['name'] ?? 'WebMS Intra'),
+            ENT_QUOTES,
+            'UTF-8'
+        );
+
+        // 🎨 Self-contained themed page — mirrors the installer's
+        //    "Already Installed" look so the user sees a consistent
+        //    brand even when the rest of the framework is mid-upgrade.
+        echo '<!doctype html><html lang="en"><head><title>Maintenance — '
+           . $portalName . '</title>'
+           . '<meta charset="utf-8">'
+           . '<meta name="viewport" content="width=device-width,initial-scale=1">'
+           . '<meta http-equiv="refresh" content="60">'
+           . '<style>'
+           . ':root{'
+           .   '--bg:#f7f8fa;--surface:#ffffff;--text:#1b2330;--muted:#6b7280;'
+           .   '--border:#e5e7eb;--primary:#5e6ad2;--primary-hover:#4f5bbf;'
+           . '}'
+           . '@media (prefers-color-scheme: dark){:root{'
+           .   '--bg:#0f1115;--surface:#161a22;--text:#e8eaf0;--muted:#9aa3b2;'
+           .   '--border:#2c3441;--primary:#7b86e8;--primary-hover:#8f99eb;'
+           . '}}'
+           . 'html,body{height:100%;}'
+           . 'body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;'
+           .   'background:var(--bg);color:var(--text);text-align:center;'
+           .   'padding:4rem 1.25rem;margin:0;line-height:1.55;}'
+           . '.card{max-width:560px;margin:0 auto;background:var(--surface);'
+           .   'border:1px solid var(--border);border-radius:.75rem;padding:2.5rem 2rem;'
+           .   'box-shadow:0 4px 6px -1px rgba(16,24,40,.08),0 2px 4px -2px rgba(16,24,40,.06);}'
+           . 'h1{margin:0 0 1rem;font-weight:600;letter-spacing:-.01em;}'
+           . 'p{margin:0 0 1rem;color:var(--muted);}'
+           . '.dot{display:inline-block;width:.5rem;height:.5rem;'
+           .   'background:var(--primary);border-radius:50%;margin:0 .25rem;'
+           .   'animation:bounce 1.4s infinite ease-in-out both;}'
+           . '.dot:nth-child(2){animation-delay:-.16s;}'
+           . '.dot:nth-child(3){animation-delay:-.32s;}'
+           . '@keyframes bounce{0%,80%,100%{transform:scale(0);}40%{transform:scale(1);}}'
+           . 'a{color:var(--primary);text-decoration:none;font-weight:500;}'
+           . 'a:hover,a:focus{color:var(--primary-hover);text-decoration:underline;}'
+           . '</style></head>'
+           . '<body><div class="card">'
+           . '<h1>Portal Maintenance</h1>'
+           . $messageHtml
+           . '<p>' . $portalName . ' is being upgraded. We\'ll be back shortly.</p>'
+           . '<p><span class="dot"></span><span class="dot"></span><span class="dot"></span></p>'
+           . '<p style="font-size:.85em;color:var(--muted);">'
+           . 'This page will reload automatically.<br>'
+           . 'Administrators can <a href="/auth/login">sign in</a> to complete the upgrade.'
+           . '</p>'
+           . '</div></body></html>';
+        exit();
+    }
+}

--- a/web/_core/version.php
+++ b/web/_core/version.php
@@ -29,11 +29,11 @@
  * @author    MWBM Partners Ltd (t/a MWservices)
  * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
  * @license   All Rights Reserved
- * @version   1.0.1
+ * @version   1.1.0
  * @link      https://github.com/MWBMPartners/WebMS-Intra
  * -----------------------------------------------------------------------------
  */
 
 declare(strict_types=1);
 
-return '1.0.1';
+return '1.1.0';

--- a/web/_core/version.php
+++ b/web/_core/version.php
@@ -29,11 +29,11 @@
  * @author    MWBM Partners Ltd (t/a MWservices)
  * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
  * @license   All Rights Reserved
- * @version   1.0.0
+ * @version   1.0.1
  * @link      https://github.com/MWBMPartners/WebMS-Intra
  * -----------------------------------------------------------------------------
  */
 
 declare(strict_types=1);
 
-return '1.0.0';
+return '1.0.1';

--- a/web/_install/db_state.php
+++ b/web/_install/db_state.php
@@ -1,0 +1,182 @@
+<?php
+// Path: _install/db_state.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — Database State Detection 🔍
+ * -----------------------------------------------------------------------------
+ * Bootstrap-free helper. Given a working mysqli connection (database
+ * already selected), report what the installer is looking at — empty
+ * DB, partial install, current install, or upgrade-needed install.
+ *
+ * The installer uses this in step 2 (after DB credentials validate)
+ * to route the user appropriately:
+ *
+ *   STATE_EMPTY              → step 3 (fresh schema install)
+ *   STATE_PARTIAL            → step 2.5 (continue vs drop-and-rebuild)
+ *   STATE_INSTALLED_CURRENT  → render "already installed" page
+ *   STATE_INSTALLED_UPGRADE  → step 2.5 with upgrade messaging
+ *   STATE_FRESH_REQUIRED     → step 2.5 with continue option DISABLED
+ *
+ * @package   Portal\Install
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+const DB_STATE_EMPTY             = 'empty';
+const DB_STATE_PARTIAL           = 'partial';
+const DB_STATE_INSTALLED_CURRENT = 'installed_current';
+const DB_STATE_INSTALLED_UPGRADE = 'installed_upgrade';
+const DB_STATE_FRESH_REQUIRED    = 'fresh_required';
+
+/**
+ * Probe a live mysqli connection and classify the database state.
+ *
+ * @param mysqli  $db              Live, database-selected connection.
+ * @param string  $codeVersion     Current code version (from version.php).
+ * @param array   $policy          The upgrade-policy.php array.
+ * @param bool    $lockFileExists  Whether _auth_keys/.installed exists.
+ *
+ * @return array{state: string, installed_version: ?string,
+ *                table_count: int, has_settings: bool, notes: string[]}
+ */
+function detectDbState(
+    mysqli $db,
+    string $codeVersion,
+    array $policy,
+    bool $lockFileExists
+): array {
+    $notes = [];
+
+    // 🔍 Count portal tables (tbl* prefix) — a freshly-created database
+    //    that hasn't seen any schema yet has zero.
+    $tableCount = 0;
+    try {
+        $rs = $db->query("SHOW TABLES LIKE 'tbl%'");
+        if ($rs !== false) {
+            $tableCount = $rs->num_rows;
+            $rs->free();
+        }
+    } catch (\mysqli_sql_exception $e) {
+        $notes[] = 'Table enumeration failed: ' . $e->getMessage();
+    }
+
+    // 📋 Does tblSettings exist? If not, no point trying to read it.
+    $hasSettings = false;
+    try {
+        $rs = $db->query("SHOW TABLES LIKE 'tblSettings'");
+        if ($rs !== false) {
+            $hasSettings = $rs->num_rows > 0;
+            $rs->free();
+        }
+    } catch (\mysqli_sql_exception $e) {
+        // Treat as no settings — we'll fall through to other heuristics.
+    }
+
+    // 🆔 Read portal.installed_version if available.
+    $installedVersion = null;
+    if ($hasSettings === true) {
+        try {
+            $stmt = $db->prepare(
+                "SELECT settingValue FROM tblSettings "
+                . "WHERE settingKey = 'portal.installed_version' "
+                . "  AND (siteID IS NULL OR siteID = 1) "
+                . "ORDER BY siteID DESC LIMIT 1"
+            );
+            if ($stmt !== false) {
+                $stmt->execute();
+                $row = $stmt->get_result()->fetch_assoc();
+                $stmt->close();
+                if ($row !== null && is_string($row['settingValue'])) {
+                    $val = trim($row['settingValue']);
+                    if ($val !== '') {
+                        $installedVersion = $val;
+                    }
+                }
+            }
+        } catch (\mysqli_sql_exception $e) {
+            $notes[] = 'Could not read portal.installed_version: ' . $e->getMessage();
+        }
+    }
+
+    // 🚏 Routing logic.
+    //
+    //    Empty DB                                          → fresh
+    //    Tables present, .installed exists                 → already installed
+    //         AND installed_version < code_version         → upgrade
+    //         AND installed_version < fresh_required_below → must reinstall
+    //         AND installed_version == code_version        → already installed
+    //    Tables present, .installed missing                → partial install
+    //         (user got into step 3 successfully but never reached step 5)
+    if ($tableCount === 0) {
+        return [
+            'state'             => DB_STATE_EMPTY,
+            'installed_version' => null,
+            'table_count'       => 0,
+            'has_settings'      => false,
+            'notes'             => $notes,
+        ];
+    }
+
+    $freshFloor = $policy['fresh_required_below'] ?? '0.0.0';
+
+    if ($lockFileExists === true) {
+        // Completed install. Compare versions.
+        if ($installedVersion !== null) {
+            if (version_compare($installedVersion, $freshFloor, '<')) {
+                return [
+                    'state'             => DB_STATE_FRESH_REQUIRED,
+                    'installed_version' => $installedVersion,
+                    'table_count'       => $tableCount,
+                    'has_settings'      => $hasSettings,
+                    'notes'             => $notes,
+                ];
+            }
+            if (version_compare($installedVersion, $codeVersion, '<')) {
+                return [
+                    'state'             => DB_STATE_INSTALLED_UPGRADE,
+                    'installed_version' => $installedVersion,
+                    'table_count'       => $tableCount,
+                    'has_settings'      => $hasSettings,
+                    'notes'             => $notes,
+                ];
+            }
+            // installed_version >= code_version → fully current.
+            return [
+                'state'             => DB_STATE_INSTALLED_CURRENT,
+                'installed_version' => $installedVersion,
+                'table_count'       => $tableCount,
+                'has_settings'      => $hasSettings,
+                'notes'             => $notes,
+            ];
+        }
+
+        // 🪞 Lock file present but no installed_version recorded — legacy
+        //    install from a build before we tracked the version. Treat
+        //    as current to avoid breaking existing deployments; the next
+        //    upgrade pass will record the version.
+        return [
+            'state'             => DB_STATE_INSTALLED_CURRENT,
+            'installed_version' => null,
+            'table_count'       => $tableCount,
+            'has_settings'      => $hasSettings,
+            'notes'             => array_merge($notes, [
+                'Lock file present but portal.installed_version not recorded — assuming legacy current.',
+            ]),
+        ];
+    }
+
+    // No lock file but tables exist → partial install (step 3 succeeded,
+    // step 5 never completed).
+    return [
+        'state'             => DB_STATE_PARTIAL,
+        'installed_version' => $installedVersion,
+        'table_count'       => $tableCount,
+        'has_settings'      => $hasSettings,
+        'notes'             => $notes,
+    ];
+}

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -101,14 +101,22 @@ if (session_status() !== PHP_SESSION_ACTIVE) {
 // ---------------------------------------------------------------------------
 // Determine current step
 // ---------------------------------------------------------------------------
-$step = (int) ($_GET['step'] ?? ($_POST['step'] ?? 1));
+// 🪞 Step is normally 1-6, but the "existing data" choice page lives at
+//    step '2.5' as a string so a fractional step is unambiguous in URLs.
+//    We track it separately to keep the integer comparisons elsewhere
+//    in the file intact.
+$rawStep = (string) ($_GET['step'] ?? ($_POST['step'] ?? '1'));
+$isChoiceStep = ($rawStep === '2.5');
+$step = $isChoiceStep ? 2 : (int) $rawStep;
 if ($step < 1 || $step > 6) {
     $step = 1;
+    $isChoiceStep = false;
 }
 
 // Enforce step progression — cannot skip ahead without completing prior steps
-if ($step >= 3 && isset($_SESSION['install_db']) === false) {
+if (($step >= 3 || $isChoiceStep) && isset($_SESSION['install_db']) === false) {
     $step = 2; // DB credentials not yet configured
+    $isChoiceStep = false;
 }
 if ($step === 6 && is_file(INSTALL_LOCK_FILE) === false) {
     $step = 5; // Finalization not yet completed
@@ -171,8 +179,43 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         'name' => $dbName,
                         'port' => $dbPort,
                     ];
+
+                    // 🔍 Probe DB state so we can route the user appropriately.
+                    //    See _install/db_state.php for the classification rules.
+                    require_once INSTALL_ROOT
+                        . DIRECTORY_SEPARATOR . '_install'
+                        . DIRECTORY_SEPARATOR . 'db_state.php';
+                    $policy = (array) (require INSTALL_ROOT
+                        . DIRECTORY_SEPARATOR . '_install'
+                        . DIRECTORY_SEPARATOR . 'upgrade-policy.php');
+                    $state = detectDbState(
+                        $testConn,
+                        INSTALL_VERSION,
+                        $policy,
+                        is_file(INSTALL_LOCK_FILE)
+                    );
+                    $_SESSION['install_db_state'] = $state;
                     $testConn->close();
-                    header('Location: ?step=3');
+
+                    if ($state['state'] === DB_STATE_EMPTY) {
+                        // Fresh install — straight to schema install.
+                        $_SESSION['install_action'] = 'fresh';
+                        header('Location: ?step=3');
+                        exit();
+                    }
+                    if ($state['state'] === DB_STATE_INSTALLED_CURRENT) {
+                        // Lock file + tables already at code version. The
+                        // top-of-file lockout would have caught the lock
+                        // file; this path means the lock was deleted but
+                        // the DB is already current. Re-write the lock
+                        // and redirect to portal.
+                        @touch(INSTALL_LOCK_FILE);
+                        header('Location: /');
+                        exit();
+                    }
+                    // PARTIAL, INSTALLED_UPGRADE, or FRESH_REQUIRED →
+                    // render the step-2.5 choice page.
+                    header('Location: ?step=2.5');
                     exit();
                 }
 
@@ -184,6 +227,48 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
     }
 
+    // Step 2.5: Existing-data choice (Continue vs Drop)
+    if ($action === 'install_action') {
+        $choice = (string) ($_POST['install_action_choice'] ?? '');
+        $state = $_SESSION['install_db_state'] ?? null;
+        $allowContinue = is_array($state)
+            && ($state['state'] ?? '') !== DB_STATE_FRESH_REQUIRED;
+
+        if ($choice !== 'continue' && $choice !== 'drop') {
+            $error = 'Please choose how to proceed.';
+            $isChoiceStep = true;
+        } elseif ($choice === 'continue' && $allowContinue === false) {
+            $error = 'Continue is not available — this installation predates the '
+                   . 'force-fresh threshold. You must drop and rebuild.';
+            $isChoiceStep = true;
+        } elseif ($choice === 'drop') {
+            // 🛡️ Destructive — require the user to confirm by typing
+            //    the configured hostname (or 'DROP' if no hostname is
+            //    enforced by policy).
+            $policy = (array) (require INSTALL_ROOT
+                . DIRECTORY_SEPARATOR . '_install'
+                . DIRECTORY_SEPARATOR . 'upgrade-policy.php');
+            $needHost = (bool) ($policy['require_hostname_confirmation_for_drop'] ?? true);
+            $expected = $needHost === true
+                ? ($_SERVER['HTTP_HOST'] ?? 'DROP')
+                : 'DROP';
+            $typed = (string) ($_POST['drop_confirm'] ?? '');
+            if (trim($typed) !== trim($expected)) {
+                $error = 'Confirmation text didn\'t match. Type exactly: '
+                       . htmlspecialchars($expected, ENT_QUOTES, 'UTF-8');
+                $isChoiceStep = true;
+            } else {
+                $_SESSION['install_action'] = 'drop';
+                header('Location: ?step=3');
+                exit();
+            }
+        } else {
+            $_SESSION['install_action'] = 'continue';
+            header('Location: ?step=3');
+            exit();
+        }
+    }
+
     // Step 3: Install schema
     if ($action === 'install_schema') {
         $db = installGetDb();
@@ -191,6 +276,35 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $error = 'Database connection lost. Please go back to Step 2.';
             $step = 2;
         } else {
+            // 🪦 Drop-and-rebuild path. If the user explicitly opted for
+            //    a fresh install from step 2.5, wipe every portal table
+            //    before running full_schema.sql. We disable FK checks
+            //    for the duration so dependent tables can drop in any
+            //    order. This intentionally destroys data — the choice
+            //    page has already confirmed the user's intent.
+            if (($_SESSION['install_action'] ?? '') === 'drop') {
+                try {
+                    $db->query('SET FOREIGN_KEY_CHECKS = 0');
+                    $rs = $db->query("SHOW TABLES LIKE 'tbl%'");
+                    if ($rs !== false) {
+                        while (($r = $rs->fetch_array(MYSQLI_NUM)) !== null) {
+                            $t = (string) $r[0];
+                            if (preg_match('/^[A-Za-z_][A-Za-z0-9_]*$/', $t) === 1) {
+                                $db->query('DROP TABLE IF EXISTS `' . $t . '`');
+                            }
+                        }
+                        $rs->free();
+                    }
+                    $db->query('SET FOREIGN_KEY_CHECKS = 1');
+                } catch (\mysqli_sql_exception $e) {
+                    $error = 'Drop-and-rebuild failed during table drop: '
+                           . $e->getMessage();
+                    $step = 3;
+                }
+                // 🪞 Step 5 will write portal.installed_version =
+                //    INSTALL_VERSION; no extra state to clear here.
+            }
+
             $schemaFile = INSTALL_SQL . DIRECTORY_SEPARATOR . 'full_schema.sql';
             if (is_readable($schemaFile) === false) {
                 $error = 'Schema file not found: _sql/full_schema.sql';
@@ -487,6 +601,41 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         }
 
         if ($error === '') {
+            // 🆔 Record the version this DB is now at, AND clear any
+            //    maintenance flag the upgrade flow might have left
+            //    behind. We reconnect with the credentials just written
+            //    rather than reuse the test connection (which has been
+            //    closed several steps ago).
+            $writeDb = installGetDb();
+            if ($writeDb !== null) {
+                try {
+                    $stmt = $writeDb->prepare(
+                        "INSERT INTO `tblSettings` "
+                        . "(`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) "
+                        . "VALUES (NULL, 'portal.installed_version', ?, '', 0) "
+                        . "ON DUPLICATE KEY UPDATE `settingValue` = VALUES(`settingValue`)"
+                    );
+                    if ($stmt !== false) {
+                        $stmt->bind_param('s', $v);
+                        $v = INSTALL_VERSION;
+                        $stmt->execute();
+                        $stmt->close();
+                    }
+                    // 🚧 Clear maintenance flag in case a drop-and-rebuild
+                    //    or interrupted upgrade left it on.
+                    $writeDb->query(
+                        "UPDATE `tblSettings` "
+                        . "SET `settingValue` = '0' "
+                        . "WHERE `settingKey` = 'portal.maintenance.active'"
+                    );
+                } catch (\mysqli_sql_exception $e) {
+                    // 🛡️ Non-fatal — the install completes either way;
+                    //    the maintenance gate just falls back to the
+                    //    "legacy install — assume current" default.
+                }
+                $writeDb->close();
+            }
+
             // Create lock file to prevent re-installation
             file_put_contents(INSTALL_LOCK_FILE, date('c') . "\n" . 'Installed by WebMS Intra installer v' . INSTALL_VERSION);
 
@@ -497,6 +646,8 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
 
             // Clear session install data
             unset($_SESSION['install_db']);
+            unset($_SESSION['install_action']);
+            unset($_SESSION['install_db_state']);
 
             header('Location: ?step=6');
             exit();
@@ -1317,6 +1468,119 @@ $pageTitle = 'Install — ' . ($stepTitles[$step] ?? 'WebMS Intra');
                 <div class="d-flex justify-content-between">
                     <a href="?step=1" class="btn btn-outline-secondary">&larr; Back</a>
                     <button type="submit" class="btn btn-primary">Test Connection &amp; Continue &rarr;</button>
+                </div>
+            </form>
+
+<?php elseif ($isChoiceStep === true): ?>
+            <!-- STEP 2.5: Existing-data choice -->
+            <?php
+            $stateInfo  = $_SESSION['install_db_state'] ?? ['state' => DB_STATE_PARTIAL];
+            $stateCode  = (string) ($stateInfo['state'] ?? DB_STATE_PARTIAL);
+            $tableCount = (int) ($stateInfo['table_count'] ?? 0);
+            $installedV = $stateInfo['installed_version'] ?? null;
+            $canContinue = ($stateCode !== DB_STATE_FRESH_REQUIRED);
+            $isUpgrade  = ($stateCode === DB_STATE_INSTALLED_UPGRADE);
+            $isPartial  = ($stateCode === DB_STATE_PARTIAL);
+            $isForce    = ($stateCode === DB_STATE_FRESH_REQUIRED);
+            $policyArr  = (array) (require INSTALL_ROOT
+                . DIRECTORY_SEPARATOR . '_install'
+                . DIRECTORY_SEPARATOR . 'upgrade-policy.php');
+            $confirmExpected = ((bool) ($policyArr['require_hostname_confirmation_for_drop'] ?? true))
+                ? ($_SERVER['HTTP_HOST'] ?? 'DROP')
+                : 'DROP';
+            ?>
+            <h2 class="h5 mb-3">Existing Database Detected</h2>
+
+            <?php if ($isUpgrade === true): ?>
+                <div class="alert alert-info">
+                    <strong>This portal is already installed</strong> at version
+                    <code><?php echo htmlspecialchars((string) $installedV, ENT_QUOTES, 'UTF-8'); ?></code>.
+                    The code on disk is at
+                    <code><?php echo htmlspecialchars(INSTALL_VERSION, ENT_QUOTES, 'UTF-8'); ?></code>
+                    — an upgrade is needed.
+                </div>
+            <?php elseif ($isPartial === true): ?>
+                <div class="alert alert-warning">
+                    <strong>A previous installation didn't complete.</strong>
+                    The database has <?php echo $tableCount; ?> portal tables
+                    but the installation lock file is missing.
+                    You can either continue from where you left off (your data
+                    will be preserved) or drop the existing tables and start fresh.
+                </div>
+            <?php elseif ($isForce === true): ?>
+                <div class="alert alert-danger">
+                    <strong>In-place upgrade not available.</strong>
+                    The installed version
+                    (<code><?php echo htmlspecialchars((string) $installedV, ENT_QUOTES, 'UTF-8'); ?></code>)
+                    is older than the upgrade policy's
+                    <code>fresh_required_below</code> threshold. You must drop
+                    and rebuild to install this version. Any data you wish to
+                    preserve should be backed up first.
+                </div>
+            <?php endif; ?>
+
+            <form method="post">
+                <input type="hidden" name="action" value="install_action">
+                <input type="hidden" name="step"   value="2.5">
+
+                <div class="install-card mb-3" style="padding:1rem;border:1px solid var(--bs-border-color);border-radius:.5rem;">
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio"
+                               name="install_action_choice" id="choice_continue"
+                               value="continue"
+                               <?php echo $canContinue === false ? 'disabled' : 'checked'; ?>>
+                        <label class="form-check-label" for="choice_continue">
+                            <strong>Continue with existing data</strong>
+                            <?php if ($isUpgrade === true): ?>
+                                <span class="badge bg-info text-dark ms-1">Upgrade</span>
+                            <?php elseif ($isPartial === true): ?>
+                                <span class="badge bg-success text-dark ms-1">Recommended</span>
+                            <?php endif; ?>
+                            <div class="text-muted small mt-1">
+                                <?php if ($isUpgrade === true): ?>
+                                    A full JSON backup of every table will be written to
+                                    <code>web/_backups/</code> before any migration runs.
+                                    Migrations are idempotent (additive) — no data is lost.
+                                <?php else: ?>
+                                    Existing tables will pick up any missing columns via
+                                    idempotent migrations. Your data is preserved.
+                                <?php endif; ?>
+                            </div>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="install-card mb-3" style="padding:1rem;border:1px solid var(--bs-border-color);border-radius:.5rem;">
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio"
+                               name="install_action_choice" id="choice_drop"
+                               value="drop"
+                               <?php echo $isForce === true ? 'checked' : ''; ?>>
+                        <label class="form-check-label" for="choice_drop">
+                            <strong>Drop existing tables and start fresh</strong>
+                            <span class="badge bg-danger ms-1">Destructive</span>
+                            <div class="text-muted small mt-1">
+                                Every portal table will be <code>DROP</code>ped,
+                                then recreated from scratch. <strong>All existing
+                                data will be lost.</strong> Type the portal
+                                hostname below to confirm.
+                            </div>
+                            <div class="mt-2">
+                                <label class="form-label small" for="drop_confirm">
+                                    Confirmation (type
+                                    <code><?php echo htmlspecialchars($confirmExpected, ENT_QUOTES, 'UTF-8'); ?></code>):
+                                </label>
+                                <input type="text" class="form-control form-control-sm"
+                                       id="drop_confirm" name="drop_confirm"
+                                       placeholder="Hostname or 'DROP'">
+                            </div>
+                        </label>
+                    </div>
+                </div>
+
+                <div class="d-flex justify-content-between">
+                    <a href="?step=2" class="btn btn-outline-secondary">&larr; Back</a>
+                    <button type="submit" class="btn btn-primary">Continue &rarr;</button>
                 </div>
             </form>
 

--- a/web/_install/index.php
+++ b/web/_install/index.php
@@ -230,9 +230,83 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
                         $error = 'Schema installation error: ' . $queryError;
                         $step = 3;
                     } else {
-                        $db->close();
-                        header('Location: ?step=4');
-                        exit();
+                        // 🪞 Apply all numbered migrations after full_schema.sql.
+                        //
+                        // Why this matters: full_schema.sql uses CREATE TABLE
+                        // IF NOT EXISTS, which is a no-op when a table already
+                        // exists. So if an earlier install attempt created
+                        // tblLocalAccounts (or any other table) under an
+                        // older shape — say without the `isVerified` column —
+                        // and then the schema was updated, the existing
+                        // table will NOT pick up the new column when the
+                        // user retries the installer. Subsequent steps
+                        // referencing that column fatal with
+                        // "Unknown column 'isVerified' in 'field list'".
+                        //
+                        // Every numbered migration uses idempotent
+                        // constructs (ADD COLUMN IF NOT EXISTS,
+                        // INSERT ... ON DUPLICATE KEY UPDATE,
+                        // DELETE FROM ... WHERE ...) — so on a true-fresh
+                        // install they're harmless no-ops (the CREATE
+                        // TABLE in full_schema.sql already contains every
+                        // column the migrations would add), but on a
+                        // stale DB they fill in the gaps and bring the
+                        // schema up to date.
+                        //
+                        // We multi_query each migration file directly
+                        // rather than going through Portal\Core\Migrator
+                        // because (a) Migrator's `pending()` filter is
+                        // tblMigrations-based, and full_schema.sql's seed
+                        // block marks every migration as already-applied
+                        // (so Migrator would see nothing pending on a
+                        // stale DB), and (b) the installer is bootstrap-
+                        // free — it can't autoload \Portal\Core\Migrator
+                        // without pulling in the rest of the framework.
+                        //
+                        // See: https://github.com/MWBMPartners/WebMS-Intra/issues/218
+                        $migrationFiles = glob(
+                            INSTALL_SQL . DIRECTORY_SEPARATOR . '[0-9][0-9][0-9]_*.sql'
+                        );
+                        if ($migrationFiles === false) {
+                            $migrationFiles = [];
+                        }
+                        sort($migrationFiles, SORT_STRING);
+                        $migError = '';
+                        foreach ($migrationFiles as $migFile) {
+                            $migSql = file_get_contents($migFile);
+                            if ($migSql === false || trim($migSql) === '') {
+                                continue;
+                            }
+                            try {
+                                $db->multi_query($migSql);
+                                do {
+                                    $r = $db->store_result();
+                                    if ($r !== false) {
+                                        $r->free();
+                                    }
+                                    if ($db->errno !== 0 && $migError === '') {
+                                        $migError = basename($migFile)
+                                            . ' — ' . $db->error;
+                                    }
+                                } while ($db->more_results() === true && $db->next_result());
+                            } catch (\mysqli_sql_exception $e) {
+                                $migError = basename($migFile)
+                                    . ' — ' . $e->getMessage();
+                                break;
+                            }
+                            if ($migError !== '') {
+                                break;
+                            }
+                        }
+
+                        if ($migError !== '') {
+                            $error = 'Migration error: ' . $migError;
+                            $step = 3;
+                        } else {
+                            $db->close();
+                            header('Location: ?step=4');
+                            exit();
+                        }
                     }
                 } catch (\mysqli_sql_exception $e) {
                     $error = 'Schema installation error: ' . $e->getMessage();

--- a/web/_install/upgrade-policy.php
+++ b/web/_install/upgrade-policy.php
@@ -1,0 +1,73 @@
+<?php
+// Path: _install/upgrade-policy.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — Upgrade Policy 🛡️
+ * -----------------------------------------------------------------------------
+ * Static, version-controlled policy that governs whether an existing
+ * installation can be upgraded in place or must be torn down and
+ * reinstalled. Read by:
+ *
+ *   • _install/db_state.php — to decide whether to offer the
+ *     "continue with existing data" option when a DB is detected.
+ *   • _install/index.php step 2.5 — to render the right choice page.
+ *   • _install/upgrade.php / Migrator — to gate migration runs that
+ *     can't be applied to old-enough installations.
+ *
+ * Each entry in `breaking_changes` documents WHY the threshold exists so
+ * future maintainers can verify the constraint is still real.
+ *
+ * @package   Portal\Install
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+return [
+    // 📌 Installations whose recorded portal.installed_version is BELOW
+    //    this threshold cannot be upgraded in place — the schema rewrite
+    //    cost (or missing data, or some other irrecoverable shape change)
+    //    makes a migration path impractical. The installer's step-2.5
+    //    choice page disables the "continue" option for these.
+    //
+    //    Set to '0.0.0' until we actually ship a breaking change. Bumping
+    //    this is a deliberate release-engineering action — not a routine
+    //    code change.
+    'fresh_required_below' => '0.0.0',
+
+    // 📋 Breaking changes — chronological list of versions where the
+    //    schema (or some other on-disk invariant) changed incompatibly.
+    //    Each entry should be self-explanatory enough that a future
+    //    maintainer can decide whether the threshold should be raised
+    //    above their migration target.
+    'breaking_changes' => [
+        // Example shape — uncomment / populate when a real breaking
+        // change ships:
+        //
+        // '0.99.0' => 'tblUsers PK rewrite — no automated migration; '
+        //             . 'see migrations/060_users_pk_rewrite.sql header '
+        //             . 'for the data-rescue mapping required.',
+    ],
+
+    // 🛡️ Always require an admin to type the portal hostname to confirm
+    //    a destructive drop-and-rebuild action. Set to false to skip
+    //    the confirmation (NOT recommended for production).
+    'require_hostname_confirmation_for_drop' => true,
+
+    // 📦 Backup configuration (used by Portal\Core\DbBackup)
+    'backup' => [
+        // 🪞 Always create a JSON snapshot of every portal table before
+        //    running upgrade-path migrations. Set false to skip (NOT
+        //    recommended).
+        'auto_backup_before_upgrade' => true,
+
+        // 🗄️ Maximum number of historical backup directories to keep
+        //    under web/_backups/. Older sets are pruned LIFO. Set to 0
+        //    to keep all backups indefinitely.
+        'keep_last_n' => 10,
+    ],
+];

--- a/web/_install/upgrade.php
+++ b/web/_install/upgrade.php
@@ -55,9 +55,77 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
     }
 
     $userId = (int) ($_SESSION['user_id'] ?? 0);
+
+    // 🚧 Maintenance gate: lock public access for the duration of the
+    //    migration run. Non-admin requests will see the maintenance page;
+    //    admins (and the routes on the allow-list) can still reach the
+    //    upgrader / backup UI. Clearing happens at the end of this block,
+    //    AND we update portal.installed_version on success so the
+    //    version-drift check also stops firing.
+    \Portal\Core\Maintenance::setActive(
+        true,
+        'Applying database migrations — please wait.'
+    );
+
+    // 📦 Auto-backup before running migrations. JSON per table, written
+    //    to web/_backups/upgrade-YYYYMMDD-HHMMSS/. See DbBackup.php.
+    //    Honoured per the portal.upgrade.backup.enabled setting (default
+    //    on); errors are surfaced but do not block the upgrade by
+    //    default — the admin should review the surfaced error and
+    //    decide whether to proceed.
+    $backupSetting = (string) (\Portal\Core\App::settings()['portal']['upgrade']['backup']['enabled'] ?? '1');
+    $backupResult  = null;
+    if ($backupSetting === '1') {
+        $backup = new \Portal\Core\DbBackup($mysqli);
+        $backupResult = $backup->snapshot('pre-upgrade-' . PORTAL_VERSION);
+        if ($backupResult['success'] === false) {
+            $_SESSION['flash_msg']  = 'Backup failed: ' . ($backupResult['error'] ?? 'unknown')
+                                    . ' — aborting upgrade. Set '
+                                    . 'portal.upgrade.backup.enabled = 0 to '
+                                    . 'force-run without a backup.';
+            $_SESSION['flash_type'] = 'danger';
+            \Portal\Core\Maintenance::setActive(false);
+            header('Location: /admin/upgrade');
+            exit();
+        }
+        // 🗄️ Prune old snapshots per retention policy.
+        $keepN = (int) (\Portal\Core\App::settings()['portal']['upgrade']['backup']['keep_last_n'] ?? 10);
+        $backup->prune($keepN);
+    }
+
     $results = $migrator->runAll($userId);
     $ranMigrations = true;
     $pending = $migrator->pending(); // Refresh pending list
+
+    // 🪞 Mark every migration as successful → record current version and
+    //    release maintenance. If any migration failed, keep maintenance
+    //    on so the admin's next request still routes here.
+    $allOk = true;
+    foreach ($results as $r) {
+        if (($r['success'] ?? false) === false) {
+            $allOk = false;
+            break;
+        }
+    }
+    if ($allOk === true) {
+        try {
+            $stmt = $mysqli->prepare(
+                "INSERT INTO `tblSettings` "
+                . "(`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) "
+                . "VALUES (NULL, 'portal.installed_version', ?, '', 0) "
+                . "ON DUPLICATE KEY UPDATE `settingValue` = VALUES(`settingValue`)"
+            );
+            if ($stmt !== false) {
+                $v = (string) PORTAL_VERSION;
+                $stmt->bind_param('s', $v);
+                $stmt->execute();
+                $stmt->close();
+            }
+        } catch (\mysqli_sql_exception $e) {
+            // Non-fatal — the gate will fire again until this gets fixed.
+        }
+        \Portal\Core\Maintenance::setActive(false);
+    }
 }
 
 // Get all executed migrations for display.

--- a/web/_sql/060_portal_versioning_and_maintenance.sql
+++ b/web/_sql/060_portal_versioning_and_maintenance.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- Migration 060: portal version tracking + maintenance-mode settings
+-- =============================================================================
+-- Adds three tblSettings keys used by the install/upgrade flow:
+--
+--   • portal.installed_version    — string. Set by the installer on step 5
+--     completion and by Migrator::runAll() / /admin/upgrade on success.
+--     The front-controller maintenance gate compares this to the
+--     PORTAL_VERSION constant from _core/version.php.
+--
+--   • portal.maintenance.active   — '0'/'1'. Flipped to '1' by /admin/upgrade
+--     while it's running, and by the installer's drop-and-rebuild path.
+--     When '1', non-allow-listed routes render the maintenance page to
+--     non-admin users.
+--
+--   • portal.maintenance.message  — optional custom message shown on the
+--     maintenance page. Falls back to a default if empty.
+--
+-- All three exist as INSERT … ON DUPLICATE KEY UPDATE — idempotent and
+-- safe to re-run.
+--
+-- @see https://github.com/MWBMPartners/WebMS-Intra/issues/220
+-- =============================================================================
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'portal.installed_version',     '',  '',  0),
+    (NULL, 'portal.maintenance.active',    '0', '0', 0),
+    (NULL, 'portal.maintenance.message',   '',  '',  0),
+    (NULL, 'portal.upgrade.backup.enabled',           '1',  '1',  0),
+    (NULL, 'portal.upgrade.backup.keep_last_n',       '10', '10', 0),
+    (NULL, 'portal.upgrade.fresh_required_below',     '',   '',   0),
+    (NULL, 'portal.upgrade.require_hostname_confirm', '1',  '1',  0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2390,6 +2390,22 @@ ON DUPLICATE KEY UPDATE `filename` = `filename`;
 INSERT INTO `tblMigrations` (`filename`) VALUES ('059_fix_api_expenses_delete_isSensitive.sql')
 ON DUPLICATE KEY UPDATE `filename` = `filename`;
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('060_portal_versioning_and_maintenance.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+-- 🔢 Portal version tracking + maintenance gate settings (matches migration 060).
+--    Seeded as empty here; the installer writes the actual `portal.installed_version`
+--    on step 5 finalisation, and /admin/upgrade updates it on successful migrate.
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'portal.installed_version',     '',  '',  0),
+    (NULL, 'portal.maintenance.active',    '0', '0', 0),
+    (NULL, 'portal.maintenance.message',   '',  '',  0),
+    (NULL, 'portal.upgrade.backup.enabled',           '1',  '1',  0),
+    (NULL, 'portal.upgrade.backup.keep_last_n',       '10', '10', 0),
+    (NULL, 'portal.upgrade.fresh_required_below',     '',   '',   0),
+    (NULL, 'portal.upgrade.require_hostname_confirm', '1',  '1',  0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('calendar/manage/import',    'calendar/manage/import.php',    1),
     ('leadership/manage/import',  'leadership/manage/import.php',  1)

--- a/web/public_html/index.php
+++ b/web/public_html/index.php
@@ -27,6 +27,21 @@ if (is_readable($authCredsPath) === false) {
 
 require_once dirname(__DIR__) . DIRECTORY_SEPARATOR . '_core' . DIRECTORY_SEPARATOR . 'bootstrap.php';
 
+use Portal\Core\Maintenance;
 use Portal\Core\Router;
+
+// 🚧 Maintenance gate (#220).
+//    If portal.maintenance.active = '1' OR the installed_version is
+//    behind PORTAL_VERSION (indicating new code was deployed but the
+//    DB hasn't been brought up yet), gate non-admin / non-allow-listed
+//    requests to a 503 maintenance page. Admins and routes on the
+//    allow list (auth/login, admin/upgrade, admin/maintenance, assets)
+//    pass through so admins can sign in and run the upgrade.
+if (Maintenance::isActive() === true
+    && Maintenance::isAllowed(Router::extractPath()) === false
+    && Maintenance::currentUserCanBypass() === false
+) {
+    Maintenance::renderAndExit();
+}
 
 Router::dispatch($mysqli);

--- a/web/public_html/tasks/api/list.php
+++ b/web/public_html/tasks/api/list.php
@@ -50,9 +50,12 @@ if ($status === 'open') {
     $conditions[] = 'completedAt IS NOT NULL';
 }
 
-$sql = 'SELECT taskID, title, description, dueAt, completedAt, createdAt '
+// Column names match the schema: `dueDate` (not `dueAt`) — an earlier
+// draft referenced `dueAt` which doesn't exist on tblTasks (#218 deep
+// audit found via check_sql_columns.py SELECT extension).
+$sql = 'SELECT taskID, title, description, dueDate, completedAt, createdAt '
      . 'FROM tblTasks WHERE ' . implode(' AND ', $conditions) . ' '
-     . 'ORDER BY (completedAt IS NULL) DESC, dueAt ASC, createdAt DESC '
+     . 'ORDER BY (completedAt IS NULL) DESC, dueDate ASC, createdAt DESC '
      . 'LIMIT ? OFFSET ?';
 $types   .= 'ii';
 $params[] = $limit;


### PR DESCRIPTION
## Consolidates PR #219 + PR #220

Per request: this PR now carries **both** the migration-runner fix (originally #219) and the state-detection/maintenance/backup feature (originally #220) in a single mergeable unit. PR #219 will be closed in favour of this one.

---

## Part 1 — Installer migration runner + audit widening (was PR #219, version 1.0.1)

### The honest diagnosis

Three consecutive support rounds ("Unknown column 'siteID'", "Unknown column 'isVerified'", and the next-in-line one) shared a single root cause that prior "exhaustive" audits didn't look at:

**Installer step 3 didn't run migrations.** `CREATE TABLE IF NOT EXISTS` is a no-op for tables that exist from earlier failed attempts. So:

1. You install, step 3 succeeds, step 4 fatals on a bug.
2. We ship a fix that adds a column via a new migration.
3. You retry. Step 3's `CREATE TABLE IF NOT EXISTS` skips your existing table → your table still has the old shape → step 4's INSERT references the new column → fatal.
4. Repeat.

Prior audits in #197 / #199 / #212 / #214 checked **schema-on-disk vs PHP code**. The actual breakage was **schema-on-disk vs schema-in-this-DB** — a different dimension entirely.

### What landed (5 changes, one umbrella)

**1. Installer step 3 now applies migrations after `full_schema.sql`**

```php
// after multi_query(full_schema.sql) succeeds:
$migrationFiles = glob(INSTALL_SQL . DIRECTORY_SEPARATOR . '[0-9][0-9][0-9]_*.sql');
sort($migrationFiles, SORT_STRING);
foreach ($migrationFiles as $migFile) {
    $db->multi_query(file_get_contents($migFile));
    // drain + capture first error
}
```

Every numbered migration uses idempotent constructs (`ADD COLUMN IF NOT EXISTS`, `INSERT … ON DUPLICATE KEY UPDATE`, `DELETE FROM … WHERE`):
- **Fresh install**: migrations are harmless no-ops.
- **Stale-DB retry**: migrations fill in missing columns. DB catches up.

**2. `check_sql_columns.py` widened to UPDATE + SELECT**

The CI consistency check from #214 only walked `INSERT INTO tbl (col, col)` column lists. It missed `UPDATE tbl SET col = ?` and `SELECT col, col FROM tbl`. Now catches all three.

**3. Line-number reporting in `check_sql_columns.py` fixed**

PHP string concatenation collapses multi-line SQL during regex matching. Previously `raw.find()` couldn't locate the collapsed match → reported line numbers were wildly wrong. Now uses offsets in the reconstructed text.

**4. `tblTasks.dueAt` → `dueDate` fix**

`web/public_html/tasks/api/list.php:53` issued `SELECT … dueAt … FROM tblTasks`. Schema column is `dueDate`. `/api/tasks/list` was 500-ing on every call. Found by the widened script.

**5. Version 1.0.0 → 1.0.1 + CHANGELOG entry**

---

## Part 2 — State detection + maintenance mode + JSON backups (was PR #220, version 1.1.0)

### Three asks layered over each other

1. **Detect existing DB on install, prompt user choice** (continue vs drop)
2. **Data preservation** — no loss, with auto-backup + restore for bigger upgrades
3. **Maintenance gate** — auto on during upgrade, auto off when done

All three landed together because they're tightly coupled (the version-tracking that powers the maintenance gate is the same setting the install-state probe reads; auto-backup is gated by the same maintenance flag).

### Component map

| Component | File | Role |
|---|---|---|
| State detector | `web/_install/db_state.php` (NEW) | Bootstrap-free `detectDbState()` — returns EMPTY / PARTIAL / INSTALLED_CURRENT / INSTALLED_UPGRADE / FRESH_REQUIRED |
| Static policy | `web/_install/upgrade-policy.php` (NEW) | Version threshold (`fresh_required_below`) + backup defaults + hostname-confirm flag |
| Step 2.5 UI | `web/_install/index.php` | New choice page with state-specific messaging + typed-hostname confirmation for drop |
| Drop-and-rebuild | `web/_install/index.php` step 3 | Respects `$_SESSION['install_action']`; DROPs every `tbl*` with FK_CHECKS off when `'drop'` |
| Version tracking | step 5 + migration 060 | Installer writes `portal.installed_version` on completion; migration 060 registers the setting |
| Backup engine | `web/_core/DbBackup.php` (NEW) | JSON-per-table snapshot + manifest; `snapshot()` / `listSnapshots()` / `prune()` / `restoreTable()` |
| Backup integration | `web/_install/upgrade.php` | Snapshots BEFORE migrations; prunes per `keep_last_n` AFTER successful run |
| Maintenance gate | `web/_core/Maintenance.php` (NEW) | `isActive()` (explicit flag OR version drift), allow-list, themed 503 page |
| Front-controller hook | `web/public_html/index.php` | Maintenance check before `Router::dispatch()` |
| Settings UI | (existing `/admin/settings`) | The new `portal.upgrade.*` and `portal.maintenance.*` rows show up automatically |
| Schema | `web/_sql/full_schema.sql` + `060_…sql` | Seeds the 7 new tblSettings keys |

### User-visible flows

**Flow A — Fresh install (empty DB)**: steps 1 → 2 → 3 → 4 → 5 → 6 (current behaviour). Step 5 writes `portal.installed_version = 1.1.0` and clears any maintenance flag.

**Flow B — Stale partial install (the blocker)**: step 2 detects `PARTIAL` → redirect to step 2.5 → "A previous installation didn't complete" + Continue (default) / Drop. Pick Continue → step 3 runs `full_schema.sql` + migrations (lossless catch-up).

**Flow C — Already installed, code is newer (upgrade needed)**: front controller sees version drift → renders maintenance page → admin signs in via `/auth/login` (allow-listed) → redirected to `/admin/upgrade` → takes JSON snapshot → runs migrations → updates `installed_version` → clears `maintenance.active` → gate releases.

**Flow D — Drop-and-rebuild (explicit wipe)**: step 2.5 → Drop + typed hostname → step 3 drops every `tbl*` with FK_CHECKS off, re-runs schema.

### Data preservation

- **Lossless by default**: Continue path uses idempotent migrations. Auto-backup runs before every upgrade migration sequence → `_backups/upgrade-YYYYMMDD-HHMMSS/` JSON snapshot of every table even if a migration goes wrong.
- **Drop path is explicit**: typed hostname confirmation; only triggered when admin wants a clean slate or `fresh_required_below` policy forces it.
- **Tier-3 (breaking rewrites) gated**: `upgrade-policy.php` declares `fresh_required_below`. Below threshold → no in-place upgrade. JSON backup format is programmatically restorable, so future per-migration "rescue scripts" can read backup + insert into new schema.

### Maintenance mode

Two triggers, single gate:
1. Explicit flag (`portal.maintenance.active = '1'`) — set by `/admin/upgrade` while running.
2. Version drift (`portal.installed_version < PORTAL_VERSION`).

Auto-clears when `/admin/upgrade` completes successfully or installer step 5 finalises. Non-admin users see themed 503 page (`prefers-color-scheme`, 60s auto-refresh, `/auth/login` link). Admins always bypass.

### Admin-editable settings (also asked)

All seven new `portal.*` settings are regular `tblSettings` rows — they show up automatically in `/admin/settings`:

| Setting | Default | Purpose |
|---|---|---|
| `portal.installed_version` | (empty) | Auto-managed; don't edit manually |
| `portal.maintenance.active` | `0` | Manual gate toggle |
| `portal.maintenance.message` | (empty) | Optional custom message |
| `portal.upgrade.backup.enabled` | `1` | Disable to skip auto-backup (NOT recommended) |
| `portal.upgrade.backup.keep_last_n` | `10` | Retention count |
| `portal.upgrade.fresh_required_below` | (empty) | Version threshold for forced fresh |
| `portal.upgrade.require_hostname_confirm` | `1` | Require typed hostname for drop |

---

## Verification

```
$ python3 tools/audit-checks/check_sql_columns.py
Tables inspected: 54
Column-name mismatches (INSERT + UPDATE + SELECT): 0

$ python3 tools/audit-checks/check_route_targets.py
Routes inspected (final state): 125
Missing target files: 0

$ python3 tools/audit-checks/check_settings_keys.py
Seeded settings keys: 165
Unseeded reads (unguarded — HIGHER risk): 0
Unseeded reads (guarded with ?? — lower risk): 0
```

All three scripts return **0 findings** against the post-fix tree.

## Test plan

- [ ] **The blocker (Flow B)**: retry the installer from your current stale DB. Step 2 detects PARTIAL → step 2.5 shows → pick Continue → migrations 053+ catch up tblLocalAccounts → step 4 succeeds.
- [ ] **Fresh install (Flow A)**: empty DB, no step 2.5 → completes normally → `tblSettings.portal.installed_version = '1.1.0'`.
- [ ] **Upgrade (Flow C)**: simulate version drift (`UPDATE tblSettings SET settingValue = '1.0.9' WHERE settingKey = 'portal.installed_version'`) → next request renders maintenance page → admin signs in → `/admin/upgrade` runs snapshot + migrations → gate releases.
- [ ] **Drop (Flow D)**: partial DB → step 2.5 → Drop + typed hostname → step 3 wipes + reinstalls.
- [ ] **Backup files**: after Flow C, `web/_backups/upgrade-YYYYMMDD-HHMMSS/` has `_manifest.json` + one `.json` per table.
- [ ] **/api/tasks/list** no longer 500s.
- [ ] **Settings UI**: `/admin/settings` lists the new `portal.upgrade.*` and `portal.maintenance.*` keys.
- [ ] CI: `check_sql_columns.py`, `check_route_targets.py`, `check_settings_keys.py` all return 0.

## Not in this PR (follow-ups)

- Admin UI for browsing / restoring snapshots (`/admin/maintenance/backup`). The `DbBackup` engine is in place; the UI is a separate PR.
- Per-migration "rescue script" mechanism for Tier-3 breaking changes (needed when `fresh_required_below` is first bumped above `0.0.0`).

Closes #218
Closes #220
Supersedes #219
