### PR TITLE
feat(auth): authorised-use notice on the login screen (1.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,16 @@ Automated sections are appended by `.github/workflows/changelog.yml` per push
 to `alpha`, `beta`, and `main` using the heading format
 `## [VERSION] - YYYY-MM-DD (branch)`.
 
+## [1.1.1] - Unreleased
+
+### Added — Authorised-use notice on the login screen (#221)
+
+All sign-in paths (local, MS365, Google, passkey) land on `/auth/login`, so a single notice at the bottom of that page covers every entry point. The notice is mandatory and cannot be excluded — there's no opt-out toggle:
+
+> **Authorised use only.** {site_name} is a private intranet for staff and volunteers. All sign-ins, page views, and actions are logged and retained for audit purposes. By signing in you acknowledge that you are an authorised user and consent to monitoring of your activity.
+
+i18n keys: `auth.terms_notice_heading`, `auth.terms_notice` (with `:site_name` placeholder). English + Welsh translations supplied.
+
 ## [1.1.0] - Unreleased
 
 ### Added — Installer state detection + Drop-and-rebuild option (#220)

--- a/web/_core/version.php
+++ b/web/_core/version.php
@@ -29,11 +29,11 @@
  * @author    MWBM Partners Ltd (t/a MWservices)
  * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
  * @license   All Rights Reserved
- * @version   1.1.0
+ * @version   1.1.1
  * @link      https://github.com/MWBMPartners/WebMS-Intra
  * -----------------------------------------------------------------------------
  */
 
 declare(strict_types=1);
 
-return '1.1.0';
+return '1.1.1';

--- a/web/_lang/cy.php
+++ b/web/_lang/cy.php
@@ -56,6 +56,8 @@ return [
     'auth.sign_in_with_passkey'     => 'Mewngofnodi gyda Passkey',
     'auth.or'                       => 'neu',
     'auth.or_use_passkey'           => 'neu defnyddiwch passkey',
+    'auth.terms_notice_heading'     => 'Defnydd awdurdodedig yn unig.',
+    'auth.terms_notice'             => 'Mae :site_name yn fewnrwyd preifat ar gyfer staff a gwirfoddolwyr. Mae pob mewngofnodi, golwg tudalen, a gweithred yn cael eu cofnodi a\'u cadw at ddibenion archwilio. Drwy fewngofnodi rydych chi\'n cydnabod eich bod yn ddefnyddiwr awdurdodedig ac yn cydsynio i fonitro eich gweithgarwch.',
     'auth.password_reset_success'   => 'Mae eich cyfrinair wedi\'i ddiweddaru. Mewngofnodwch os gwelwch yn dda.',
     'auth.invalid_session_token'    => 'Tocyn sesiwn annilys. Ceisiwch eto.',
     'auth.captcha_failed'           => 'Methwyd dilysu captcha.',

--- a/web/_lang/en.php
+++ b/web/_lang/en.php
@@ -60,6 +60,8 @@ return [
     'auth.sign_in_with_passkey'     => 'Sign in with Passkey',
     'auth.or'                       => 'or',
     'auth.or_use_passkey'           => 'or use a passkey',
+    'auth.terms_notice_heading'     => 'Authorised use only.',
+    'auth.terms_notice'             => ':site_name is a private intranet for staff and volunteers. All sign-ins, page views, and actions are logged and retained for audit purposes. By signing in you acknowledge that you are an authorised user and consent to monitoring of your activity.',
     'auth.password_reset_success'   => 'Your password has been updated. Please sign in.',
     'auth.invalid_session_token'    => 'Invalid session token. Please try again.',
     'auth.captcha_failed'           => 'Captcha verification failed.',

--- a/web/public_html/auth/login/index.php
+++ b/web/public_html/auth/login/index.php
@@ -238,6 +238,22 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
         <div id="passkeyLoginStatus" class="small mt-2 text-center"></div>
     </div>
 
+    <!-- 📜 Authorised-use notice (#221). Implied-consent terms required for
+         all sign-in paths (local, MS365, Google, passkey) — every route
+         lands on this page, so the notice is enforced for everyone. -->
+    <div class="alert alert-secondary small mt-4 mb-0 py-2 px-3" role="note">
+        <strong><?php echo htmlspecialchars(t('auth.terms_notice_heading'), ENT_QUOTES, 'UTF-8'); ?></strong>
+        <span class="text-muted">
+            <?php echo htmlspecialchars(
+                t('auth.terms_notice', [
+                    'site_name' => $SETTINGS['site']['name'] ?? 'This portal',
+                ]),
+                ENT_QUOTES,
+                'UTF-8'
+            ); ?>
+        </span>
+    </div>
+
 </div>
 
 <!-- 📦 JavaScript (CDN with local fallback) -->


### PR DESCRIPTION
## What this PR does

Adds a mandatory authorised-use notice at the bottom of `/auth/login`. Every sign-in path (local username/password, MS365, Google, passkey) lands on that page, so a single notice covers all entry points.

The notice text uses the Option B wording you picked in chat:

> **Authorised use only.** {site_name} is a private intranet for staff and volunteers. All sign-ins, page views, and actions are logged and retained for audit purposes. By signing in you acknowledge that you are an authorised user and consent to monitoring of your activity.

## Implementation notes

- **No opt-out**. Per the requirement that this is mandatory for an intranet, there's no toggle, no setting, no per-site override. The notice always renders.
- **i18n-keyed**. Translatable via `auth.terms_notice_heading` + `auth.terms_notice` (with a `:site_name` placeholder). English supplied; Welsh supplied at the same formality register.
- **Placement**. Below the passkey block, styled with Bootstrap's `alert-secondary` (muted grey) so it doesn't compete with the sign-in CTA.
- **Implied consent**. The notice text uses "By signing in you acknowledge…" language — the act of submitting the sign-in form / completing SSO / using a passkey is the consent action. No additional checkbox.
- **Version bump**: 1.1.0 → 1.1.1 (patch — UI addition, no schema change).

## Files changed

| File | Change |
|---|---|
| `web/public_html/auth/login/index.php` | New `<div class="alert alert-secondary">` block after the passkey section |
| `web/_lang/en.php` | `auth.terms_notice_heading` + `auth.terms_notice` (English) |
| `web/_lang/cy.php` | Same keys (Welsh) |
| `web/_core/version.php` | 1.1.0 → 1.1.1 |
| `CHANGELOG.md` | New 1.1.1 entry |

## Test plan

- [ ] Visit `/auth/login` (signed out) — notice renders below the passkey button.
- [ ] `{site_name}` placeholder substitutes from `$SETTINGS['site']['name']` (or falls back to "This portal" if unset).
- [ ] Light + dark themes both readable (`alert-secondary` already adapts via Bootstrap).
- [ ] Welsh language pack (`/?lang=cy`) shows the Welsh version.
- [ ] CI: `pr-security.yml` returns 0 findings.

Closes #221


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_