### PR TITLE
2 apps + iCal feed + admin polish — 7 issues (#258, #261, #271, #251, #254, #253, #252)

### DIFF
--- a/web/_core/Asset.php
+++ b/web/_core/Asset.php
@@ -299,7 +299,11 @@ class Asset
              //    Loaded AFTER Bootstrap JS (which is required) and before
              //    custom page scripts so data-confirm form interception is
              //    in place by the time any handler binds.
-             . '<script src="/assets/js/portal-confirm.js" defer></script>';
+             . '<script src="/assets/js/portal-confirm.js" defer></script>'
+             . "\n"
+             // 🎯 Portal.Tour — "what's new" tour playback (#253). Auto-fetches
+             //    the active tour for the user on authenticated pages.
+             . '<script src="/assets/js/portal-tour.js" defer></script>';
     }
 
     // 🛡️ ===========================================================================

--- a/web/_core/Ical.php
+++ b/web/_core/Ical.php
@@ -1,0 +1,171 @@
+<?php
+// Path: _core/Ical.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — iCalendar emitter 🗓️
+ * -----------------------------------------------------------------------------
+ * Minimal RFC 5545-compliant iCalendar emitter for portal calendars.
+ *
+ * Why we don't vendor sabre/vobject: the use case here is read-only export
+ * of a small handful of event types. ~100 LOC of focused emission covers
+ * everything calendar clients (Google, Apple, Outlook) need. Vendor a
+ * library if/when bidirectional CalDAV becomes a requirement.
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/271
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class Ical
+{
+    /**
+     * Build a VCALENDAR string from a flat list of event arrays.
+     *
+     * @param array<int, array{
+     *     uid:string, summary:string, description?:string, location?:string,
+     *     startsAt:string, endsAt?:string, allDay?:bool,
+     *     sequence?:int, lastModified?:string, url?:string
+     * }> $events
+     */
+    public static function emit(string $calendarName, array $events, string $timezone = 'Europe/London'): string
+    {
+        $lines = [];
+        $lines[] = 'BEGIN:VCALENDAR';
+        $lines[] = 'VERSION:2.0';
+        $lines[] = 'PRODID:-//MWBM Partners//WebMS-Intra//EN';
+        $lines[] = 'CALSCALE:GREGORIAN';
+        $lines[] = 'METHOD:PUBLISH';
+        $lines[] = 'X-WR-CALNAME:' . self::escapeText($calendarName);
+        $lines[] = 'X-WR-TIMEZONE:' . self::escapeText($timezone);
+
+        foreach ($events as $e) {
+            $lines[] = 'BEGIN:VEVENT';
+            $lines[] = 'UID:' . self::escapeText((string) $e['uid']);
+            $lines[] = 'DTSTAMP:' . gmdate('Ymd\THis\Z');
+            $startsAt = (string) $e['startsAt'];
+            $allDay = ($e['allDay'] ?? false) === true;
+            if ($allDay === true) {
+                $lines[] = 'DTSTART;VALUE=DATE:' . gmdate('Ymd', strtotime($startsAt));
+                if (isset($e['endsAt']) === true && $e['endsAt'] !== null && $e['endsAt'] !== '') {
+                    $lines[] = 'DTEND;VALUE=DATE:' . gmdate('Ymd', strtotime((string) $e['endsAt']) + 86400);
+                }
+            } else {
+                $lines[] = 'DTSTART:' . gmdate('Ymd\THis\Z', strtotime($startsAt));
+                if (isset($e['endsAt']) === true && $e['endsAt'] !== null && $e['endsAt'] !== '') {
+                    $lines[] = 'DTEND:' . gmdate('Ymd\THis\Z', strtotime((string) $e['endsAt']));
+                }
+            }
+            $lines[] = 'SUMMARY:' . self::escapeText((string) $e['summary']);
+            if (isset($e['description']) === true && $e['description'] !== null && $e['description'] !== '') {
+                $lines[] = 'DESCRIPTION:' . self::escapeText((string) $e['description']);
+            }
+            if (isset($e['location']) === true && $e['location'] !== null && $e['location'] !== '') {
+                $lines[] = 'LOCATION:' . self::escapeText((string) $e['location']);
+            }
+            if (isset($e['url']) === true && $e['url'] !== null && $e['url'] !== '') {
+                $lines[] = 'URL:' . (string) $e['url'];
+            }
+            $lines[] = 'SEQUENCE:' . (int) ($e['sequence'] ?? 0);
+            if (isset($e['lastModified']) === true && $e['lastModified'] !== null) {
+                $lines[] = 'LAST-MODIFIED:' . gmdate('Ymd\THis\Z', strtotime((string) $e['lastModified']));
+            }
+            $lines[] = 'END:VEVENT';
+        }
+
+        $lines[] = 'END:VCALENDAR';
+        return implode("\r\n", array_map([self::class, 'fold'], $lines)) . "\r\n";
+    }
+
+    /**
+     * Generate or retrieve the per-user calendar token (RFC 4226-style
+     * random 32-byte hex, stored hashed in tblUsers).
+     *
+     * @return string The plaintext token (returned ONLY at generation;
+     *                from then on only the hash is retained).
+     */
+    public static function ensureUserToken(int $userId): string
+    {
+        $db = App::db();
+        $stmt = $db->prepare('SELECT calendarToken FROM tblUsers WHERE userID = ? LIMIT 1');
+        if ($stmt === false) {
+            throw new \RuntimeException('Could not load user');
+        }
+        $stmt->bind_param('i', $userId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+
+        if ($row !== null && $row['calendarToken'] !== null && $row['calendarToken'] !== '') {
+            // 🪞 Token exists but we don't have the plaintext anymore (it's
+            //    hashed). Regenerate so the user gets a fresh URL.
+        }
+
+        $plaintext = bin2hex(random_bytes(32));
+        $hash      = hash('sha256', $plaintext);
+        $stmt = $db->prepare('UPDATE tblUsers SET calendarToken = ? WHERE userID = ?');
+        if ($stmt === false) {
+            throw new \RuntimeException('Could not save token');
+        }
+        $stmt->bind_param('si', $hash, $userId);
+        $stmt->execute();
+        $stmt->close();
+        return $plaintext;
+    }
+
+    /**
+     * Resolve a plaintext token to a user ID. Returns 0 on no match.
+     */
+    public static function userIdForToken(string $plaintext): int
+    {
+        if (preg_match('/^[a-f0-9]{64}$/i', $plaintext) !== 1) {
+            return 0;
+        }
+        $hash = hash('sha256', $plaintext);
+        $db = App::db();
+        $stmt = $db->prepare('SELECT userID FROM tblUsers WHERE calendarToken = ? LIMIT 1');
+        if ($stmt === false) {
+            return 0;
+        }
+        $stmt->bind_param('s', $hash);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return (int) ($row['userID'] ?? 0);
+    }
+
+    private static function escapeText(string $text): string
+    {
+        // RFC 5545 §3.3.11: backslash, comma, semicolon, newline escaping.
+        $text = str_replace(['\\', "\r\n", "\n", "\r", ',', ';'], ['\\\\', '\\n', '\\n', '\\n', '\\,', '\\;'], $text);
+        return $text;
+    }
+
+    /**
+     * RFC 5545 §3.1: lines > 75 octets must be folded with CRLF + single
+     * leading whitespace on continuation lines.
+     */
+    private static function fold(string $line): string
+    {
+        if (strlen($line) <= 75) {
+            return $line;
+        }
+        $folded = substr($line, 0, 75);
+        $rest = substr($line, 75);
+        while (strlen($rest) > 74) {
+            $folded .= "\r\n " . substr($rest, 0, 74);
+            $rest = substr($rest, 74);
+        }
+        if ($rest !== '') {
+            $folded .= "\r\n " . $rest;
+        }
+        return $folded;
+    }
+}

--- a/web/_core/Mailer.php
+++ b/web/_core/Mailer.php
@@ -77,6 +77,14 @@ class Mailer
             ? $body
             : self::renderBase($body);
 
+        // 🪞 Plain-text alternative (#254). Auto-derive from the HTML if the
+        //    caller didn't supply one. This goes into the providers'
+        //    multipart/alternative bodies so clients that prefer (or only
+        //    accept) plain text get a readable version.
+        $plainBody = $looksLikeHtml === true
+            ? self::htmlToPlain($body)
+            : $body;
+
         // 🔀 Dispatch to the configured provider
         $provider = strtolower($SETTINGS['mail']['provider'] ?? 'ms365');
 
@@ -269,6 +277,49 @@ class Mailer
     }
 
     /** Build attachment array (<= 4MB each inline) */
+    /**
+     * Derive a plain-text alternative from an HTML body. Used for
+     * multipart/alternative emission (#254). Strips tags, decodes
+     * entities, collapses whitespace.
+     *
+     * Note: MS365 Graph's sendMail accepts HTML body and lets Microsoft
+     * generate the plain-text alternative server-side, so this helper
+     * is most useful for SMTP and any future provider that needs both
+     * parts on the wire.
+     */
+    public static function htmlToPlain(string $html): string
+    {
+        // Convert <br> / </p> / </div> / </li> to newlines BEFORE strip.
+        $intermediate = (string) preg_replace(
+            ['/<br\\s*\\/?>/i', '/<\\/(p|div|li|h[1-6]|tr)\\s*>/i'],
+            ["\n", "\n"],
+            $html
+        );
+        // Convert <a href="X">Y</a> → "Y (X)" so users on plain-text clients
+        // still see the URLs.
+        $intermediate = (string) preg_replace_callback(
+            '/<a[^>]+href="([^"]+)"[^>]*>(.*?)<\\/a>/i',
+            static function (array $m): string {
+                $text = trim(strip_tags($m[2]));
+                return $text !== '' && $text !== $m[1] ? $text . ' (' . $m[1] . ')' : $m[1];
+            },
+            $intermediate
+        );
+        $text = strip_tags($intermediate);
+        $text = html_entity_decode($text, ENT_QUOTES | ENT_HTML5, 'UTF-8');
+        // Collapse runs of blank lines and trim each line.
+        $lines = preg_split('/\\R/', $text);
+        $clean = [];
+        foreach ((array) $lines as $line) {
+            $line = trim((string) $line);
+            if ($line === '' && (count($clean) === 0 || end($clean) === '')) {
+                continue;
+            }
+            $clean[] = $line;
+        }
+        return trim(implode("\n", $clean));
+    }
+
     private static function attach(array $paths): array
     {
         $out = [];

--- a/web/_core/apps/directory.php
+++ b/web/_core/apps/directory.php
@@ -1,0 +1,16 @@
+<?php
+// Path: _core/apps/directory.php
+declare(strict_types=1);
+return [
+    'slug'        => 'directory',
+    'name'        => 'Member Directory',
+    'description' => 'Searchable directory of members with opt-in per-field visibility.',
+    'icon'        => 'fa-solid fa-address-book',
+    'color'       => '#0ea5e9',
+    'category'    => 'community',
+    'industries'  => ['church', 'community', 'small-business', 'nonprofit', 'membership-org', 'school'],
+    'route'       => 'directory',
+    'settingKey'  => 'directory.enabled',
+    'isCore'      => false,
+    'version'     => '1.0.0',
+];

--- a/web/_core/apps/visitors.php
+++ b/web/_core/apps/visitors.php
@@ -1,0 +1,16 @@
+<?php
+// Path: _core/apps/visitors.php
+declare(strict_types=1);
+return [
+    'slug'        => 'visitors',
+    'name'        => 'Visitor Tracking',
+    'description' => 'First-time visitor capture with follow-up cadence + kanban workflow.',
+    'icon'        => 'fa-solid fa-user-plus',
+    'color'       => '#06b6d4',
+    'category'    => 'community',
+    'industries'  => ['church', 'community', 'nonprofit', 'membership-org'],
+    'route'       => 'visitors',
+    'settingKey'  => 'visitors.enabled',
+    'isCore'      => false,
+    'version'     => '1.0.0',
+];

--- a/web/_core/templates/header.php
+++ b/web/_core/templates/header.php
@@ -157,7 +157,7 @@ header("Content-Security-Policy: default-src 'self'; script-src 'self' 'unsafe-i
     <link rel="stylesheet" href="/assets/css/print.css" media="print">
     <link rel="stylesheet" href="/assets/css/print.css" media="screen" onload="this.media='not all'" disabled>
 </head>
-<body data-portal-name="<?php echo htmlspecialchars((string) ($SETTINGS['site']['name'] ?? 'Portal'), ENT_QUOTES, 'UTF-8'); ?>" data-print-date="<?php echo htmlspecialchars(date('Y-m-d'), ENT_QUOTES, 'UTF-8'); ?>">
+<body data-portal-name="<?php echo htmlspecialchars((string) ($SETTINGS['site']['name'] ?? 'Portal'), ENT_QUOTES, 'UTF-8'); ?>" data-print-date="<?php echo htmlspecialchars(date('Y-m-d'), ENT_QUOTES, 'UTF-8'); ?>" data-portal-authenticated="<?php echo \Portal\Core\Auth::check() === true ? '1' : '0'; ?>">
 
 <!-- ⚠️ Global noscript banner — visible only when JS is disabled -->
 <noscript>

--- a/web/_sql/078_visitors.sql
+++ b/web/_sql/078_visitors.sql
@@ -1,0 +1,63 @@
+-- =============================================================================
+-- Migration 078: Visitor Tracking app (#258)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `tblVisitor` (
+    `visitorID`        INT          NOT NULL AUTO_INCREMENT,
+    `siteID`           INT          NOT NULL DEFAULT 1,
+    `fullName`         VARCHAR(255) NOT NULL,
+    `email`            VARCHAR(255) DEFAULT NULL,
+    `phone`            VARCHAR(50)  DEFAULT NULL,
+    `firstVisitedAt`   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `source`           ENUM('in-person','public-form','referral','website','other') NOT NULL DEFAULT 'in-person',
+    `assignedToID`     INT          DEFAULT NULL,
+    `status`           ENUM('new','in-touch','converted','lost') NOT NULL DEFAULT 'new',
+    `notes`            TEXT         DEFAULT NULL,
+    `convertedUserID`  INT          DEFAULT NULL COMMENT 'FK → tblUsers once they sign up',
+    `createdByID`      INT          DEFAULT NULL,
+    `createdAt`        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`visitorID`),
+    KEY `idx_visitor_site_status` (`siteID`, `status`),
+    KEY `idx_visitor_assignee` (`assignedToID`),
+    CONSTRAINT `fk_visitor_site` FOREIGN KEY (`siteID`) REFERENCES `tblSites` (`siteID`),
+    CONSTRAINT `fk_visitor_assignee` FOREIGN KEY (`assignedToID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_visitor_converted` FOREIGN KEY (`convertedUserID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_visitor_creator` FOREIGN KEY (`createdByID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblVisitorContact` (
+    `contactID`     INT      NOT NULL AUTO_INCREMENT,
+    `visitorID`     INT      NOT NULL,
+    `contactedByID` INT      NOT NULL,
+    `contactedAt`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `method`        ENUM('visit','call','email','text','other') NOT NULL DEFAULT 'call',
+    `summary`       TEXT     DEFAULT NULL,
+    `nextContactAt` DATE     DEFAULT NULL,
+    PRIMARY KEY (`contactID`),
+    KEY `idx_visitor_contact_visitor` (`visitorID`),
+    KEY `idx_visitor_contact_next` (`nextContactAt`),
+    CONSTRAINT `fk_visitor_contact_visitor` FOREIGN KEY (`visitorID`) REFERENCES `tblVisitor` (`visitorID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_visitor_contact_by` FOREIGN KEY (`contactedByID`) REFERENCES `tblUsers` (`userID`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('visitors',              'visitors/index.php',         1),
+    ('visitors/new',          'visitors/new.php',           1),
+    ('visitors/save',         'visitors/save.php',          1),
+    ('visitors/profile',      'visitors/profile.php',       1),
+    ('visitors/contact-save', 'visitors/contact-save.php',  1),
+    ('visitors/my-follow-ups','visitors/my-follow-ups.php', 1),
+    ('visit',                 'visitors/public-form.php',   0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'visitors.enabled',                   '0', '0', 0),
+    (NULL, 'visitors.coordinator_role',          'visitor_coordinator', 'visitor_coordinator', 0),
+    (NULL, 'visitors.followup_initial_days',     '7',  '7',  0),
+    (NULL, 'visitors.followup_followup_days',    '30', '30', 0),
+    (NULL, 'visitors.followup_final_days',       '90', '90', 0),
+    (NULL, 'visitors.public_capture_enabled',    '0',  '0',  0),
+    (NULL, 'visitors.displayName',               'Visitor Tracking', 'Visitor Tracking', 0),
+    (NULL, 'visitors.displayIcon',               'fa-solid fa-user-plus', 'fa-solid fa-user-plus', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/079_directory.sql
+++ b/web/_sql/079_directory.sql
@@ -1,0 +1,33 @@
+-- =============================================================================
+-- Migration 079: Member Directory app (#261)
+-- =============================================================================
+-- Extends tblUsers with directory-profile columns. Per-field visibility
+-- enums let each user opt in field-by-field. Defaults are conservative:
+-- name + role visible to members, contact details private.
+-- =============================================================================
+
+ALTER TABLE `tblUsers`
+    ADD COLUMN IF NOT EXISTS `displayBio`     TEXT         DEFAULT NULL  COMMENT 'Markdown bio (#261)',
+    ADD COLUMN IF NOT EXISTS `displayPhoto`   VARCHAR(500) DEFAULT NULL  COMMENT 'Path under _uploads/ to profile photo',
+    ADD COLUMN IF NOT EXISTS `displayPhone`   VARCHAR(50)  DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS `displayAddress` VARCHAR(500) DEFAULT NULL,
+    ADD COLUMN IF NOT EXISTS `visibilityName`    ENUM('private','team','members','public') NOT NULL DEFAULT 'members',
+    ADD COLUMN IF NOT EXISTS `visibilityRoles`   ENUM('private','team','members','public') NOT NULL DEFAULT 'members',
+    ADD COLUMN IF NOT EXISTS `visibilityEmail`   ENUM('private','team','members','public') NOT NULL DEFAULT 'private',
+    ADD COLUMN IF NOT EXISTS `visibilityPhone`   ENUM('private','team','members','public') NOT NULL DEFAULT 'private',
+    ADD COLUMN IF NOT EXISTS `visibilityAddress` ENUM('private','team','members','public') NOT NULL DEFAULT 'private',
+    ADD COLUMN IF NOT EXISTS `visibilityBio`     ENUM('private','team','members','public') NOT NULL DEFAULT 'members',
+    ADD COLUMN IF NOT EXISTS `visibilityPhoto`   ENUM('private','team','members','public') NOT NULL DEFAULT 'private';
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('directory',             'directory/index.php',   1),
+    ('directory/profile',     'directory/profile.php', 1),
+    ('directory/my-settings', 'directory/me.php',      1),
+    ('directory/save',        'directory/save.php',    1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'directory.enabled',     '0', '0', 0),
+    (NULL, 'directory.displayName', 'Member Directory', 'Member Directory', 0),
+    (NULL, 'directory.displayIcon', 'fa-solid fa-address-book', 'fa-solid fa-address-book', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/080_ical_feed.sql
+++ b/web/_sql/080_ical_feed.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration 080: iCal feed support (#271)
+-- =============================================================================
+
+ALTER TABLE `tblUsers`
+    ADD COLUMN IF NOT EXISTS `calendarToken` VARCHAR(64) DEFAULT NULL
+        COMMENT 'SHA-256 hash of the user-personal iCal token (#271)';
+
+ALTER TABLE `tblUsers`
+    ADD INDEX IF NOT EXISTS `idx_user_calendar_token` (`calendarToken`);
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('calendar.ics',           'calendar/feed.php',         0),
+    ('account/calendar-feed',  'calendar/account-feed.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/_sql/081_sabbath_admin.sql
+++ b/web/_sql/081_sabbath_admin.sql
@@ -1,0 +1,7 @@
+-- =============================================================================
+-- Migration 081: Sabbath admin sub-page route (#251)
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/settings/sabbath', 'admin/settings/sabbath/index.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/_sql/082_tour_playback.sql
+++ b/web/_sql/082_tour_playback.sql
@@ -1,0 +1,11 @@
+-- =============================================================================
+-- Migration 082: Tour playback API routes (#253)
+-- =============================================================================
+-- Completes the tour engine scaffolded in #237. Registers the two read/write
+-- API endpoints the playback JS calls.
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('api/tours/active',   'api/tours/active.php',   1),
+    ('api/tours/complete', 'api/tours/complete.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/_sql/083_settings_subpages.sql
+++ b/web/_sql/083_settings_subpages.sql
@@ -1,0 +1,15 @@
+-- =============================================================================
+-- Migration 083: Settings group sub-page routes (#252)
+-- =============================================================================
+-- Five friendly admin sub-pages for the grouped portal.* setting families,
+-- all served by one definition-driven controller (admin/settings/group.php),
+-- which derives the group from the matched route path.
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/settings/alerts',      'admin/settings/group.php', 1),
+    ('admin/settings/backups',     'admin/settings/group.php', 1),
+    ('admin/settings/headers',     'admin/settings/group.php', 1),
+    ('admin/settings/upgrade',     'admin/settings/group.php', 1),
+    ('admin/settings/maintenance', 'admin/settings/group.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2795,6 +2795,15 @@ INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('api/tours/complete', 'api/tours/complete.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
+-- 🎛️ Settings group sub-pages (matches migration 083 / #252)
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/settings/alerts',      'admin/settings/group.php', 1),
+    ('admin/settings/backups',     'admin/settings/group.php', 1),
+    ('admin/settings/headers',     'admin/settings/group.php', 1),
+    ('admin/settings/upgrade',     'admin/settings/group.php', 1),
+    ('admin/settings/maintenance', 'admin/settings/group.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('help/admin-first-steps', 'help/admin-first-steps.php', 1),
     ('admin/settings/dismiss-first-run', 'admin/settings/dismiss-first-run.php', 1)

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2637,6 +2637,20 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'directory.displayIcon', 'fa-solid fa-address-book', 'fa-solid fa-address-book', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('080_ical_feed.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+ALTER TABLE `tblUsers`
+    ADD COLUMN IF NOT EXISTS `calendarToken` VARCHAR(64) DEFAULT NULL;
+
+ALTER TABLE `tblUsers`
+    ADD INDEX IF NOT EXISTS `idx_user_calendar_token` (`calendarToken`);
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('calendar.ics',          'calendar/feed.php',         0),
+    ('account/calendar-feed', 'calendar/account-feed.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
 CREATE TABLE IF NOT EXISTS `tblRotaRoleType` (
     `roleTypeID`  INT          NOT NULL AUTO_INCREMENT,
     `siteID`      INT          NOT NULL DEFAULT 1,

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2789,6 +2789,12 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'portal.tours.welcome_active','1', '1', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
 
+-- 🎯 Tour playback API routes (matches migration 082 / #253)
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('api/tours/active',   'api/tours/active.php',   1),
+    ('api/tours/complete', 'api/tours/complete.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('help/admin-first-steps', 'help/admin-first-steps.php', 1),
     ('admin/settings/dismiss-first-run', 'admin/settings/dismiss-first-run.php', 1)

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2558,6 +2558,69 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'care.displayIcon',       'fa-solid fa-hand-holding-heart', 'fa-solid fa-hand-holding-heart', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('078_visitors.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+CREATE TABLE IF NOT EXISTS `tblVisitor` (
+    `visitorID`        INT          NOT NULL AUTO_INCREMENT,
+    `siteID`           INT          NOT NULL DEFAULT 1,
+    `fullName`         VARCHAR(255) NOT NULL,
+    `email`            VARCHAR(255) DEFAULT NULL,
+    `phone`            VARCHAR(50)  DEFAULT NULL,
+    `firstVisitedAt`   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `source`           ENUM('in-person','public-form','referral','website','other') NOT NULL DEFAULT 'in-person',
+    `assignedToID`     INT          DEFAULT NULL,
+    `status`           ENUM('new','in-touch','converted','lost') NOT NULL DEFAULT 'new',
+    `notes`            TEXT         DEFAULT NULL,
+    `convertedUserID`  INT          DEFAULT NULL,
+    `createdByID`      INT          DEFAULT NULL,
+    `createdAt`        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `updatedAt`        DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+    PRIMARY KEY (`visitorID`),
+    KEY `idx_visitor_site_status` (`siteID`, `status`),
+    KEY `idx_visitor_assignee` (`assignedToID`),
+    CONSTRAINT `fk_visitor_site` FOREIGN KEY (`siteID`) REFERENCES `tblSites` (`siteID`),
+    CONSTRAINT `fk_visitor_assignee` FOREIGN KEY (`assignedToID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_visitor_converted` FOREIGN KEY (`convertedUserID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_visitor_creator` FOREIGN KEY (`createdByID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblVisitorContact` (
+    `contactID`     INT      NOT NULL AUTO_INCREMENT,
+    `visitorID`     INT      NOT NULL,
+    `contactedByID` INT      NOT NULL,
+    `contactedAt`   DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `method`        ENUM('visit','call','email','text','other') NOT NULL DEFAULT 'call',
+    `summary`       TEXT     DEFAULT NULL,
+    `nextContactAt` DATE     DEFAULT NULL,
+    PRIMARY KEY (`contactID`),
+    KEY `idx_visitor_contact_visitor` (`visitorID`),
+    KEY `idx_visitor_contact_next` (`nextContactAt`),
+    CONSTRAINT `fk_visitor_contact_visitor` FOREIGN KEY (`visitorID`) REFERENCES `tblVisitor` (`visitorID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_visitor_contact_by` FOREIGN KEY (`contactedByID`) REFERENCES `tblUsers` (`userID`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('visitors',              'visitors/index.php',         1),
+    ('visitors/new',          'visitors/new.php',           1),
+    ('visitors/save',         'visitors/save.php',          1),
+    ('visitors/profile',      'visitors/profile.php',       1),
+    ('visitors/contact-save', 'visitors/contact-save.php',  1),
+    ('visitors/my-follow-ups','visitors/my-follow-ups.php', 1),
+    ('visit',                 'visitors/public-form.php',   0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'visitors.enabled',                   '0', '0', 0),
+    (NULL, 'visitors.coordinator_role',          'visitor_coordinator', 'visitor_coordinator', 0),
+    (NULL, 'visitors.followup_initial_days',     '7',  '7',  0),
+    (NULL, 'visitors.followup_followup_days',    '30', '30', 0),
+    (NULL, 'visitors.followup_final_days',       '90', '90', 0),
+    (NULL, 'visitors.public_capture_enabled',    '0',  '0',  0),
+    (NULL, 'visitors.displayName',               'Visitor Tracking', 'Visitor Tracking', 0),
+    (NULL, 'visitors.displayIcon',               'fa-solid fa-user-plus', 'fa-solid fa-user-plus', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
 CREATE TABLE IF NOT EXISTS `tblRotaRoleType` (
     `roleTypeID`  INT          NOT NULL AUTO_INCREMENT,
     `siteID`      INT          NOT NULL DEFAULT 1,

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2621,6 +2621,22 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'visitors.displayIcon',               'fa-solid fa-user-plus', 'fa-solid fa-user-plus', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('079_directory.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('directory',             'directory/index.php',   1),
+    ('directory/profile',     'directory/profile.php', 1),
+    ('directory/my-settings', 'directory/me.php',      1),
+    ('directory/save',        'directory/save.php',    1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'directory.enabled',     '0', '0', 0),
+    (NULL, 'directory.displayName', 'Member Directory', 'Member Directory', 0),
+    (NULL, 'directory.displayIcon', 'fa-solid fa-address-book', 'fa-solid fa-address-book', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
 CREATE TABLE IF NOT EXISTS `tblRotaRoleType` (
     `roleTypeID`  INT          NOT NULL AUTO_INCREMENT,
     `siteID`      INT          NOT NULL DEFAULT 1,

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -2651,6 +2651,13 @@ INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('account/calendar-feed', 'calendar/account-feed.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
 
+INSERT INTO `tblMigrations` (`filename`) VALUES ('081_sabbath_admin.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/settings/sabbath', 'admin/settings/sabbath/index.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
 CREATE TABLE IF NOT EXISTS `tblRotaRoleType` (
     `roleTypeID`  INT          NOT NULL AUTO_INCREMENT,
     `siteID`      INT          NOT NULL DEFAULT 1,

--- a/web/public_html/admin/settings/group.php
+++ b/web/public_html/admin/settings/group.php
@@ -1,0 +1,231 @@
+<?php
+// Path: public_html/admin/settings/group.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Settings group sub-pages 🎛️
+ * -----------------------------------------------------------------------------
+ * Definition-driven, friendly UI for the grouped portal.* setting families
+ * (alerts / backups / headers / upgrade / maintenance). One controller,
+ * five routes — the group is derived from the matched route path.
+ *
+ * Each field has a type (toggle / number / text / textarea / select), label,
+ * help text, and (for select) options. Renders proper inputs instead of the
+ * generic dot-notation editor, with inline explanations and validation.
+ *
+ * @package   Portal\Admin
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/252
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Router;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+// -----------------------------------------------------------------------------
+// 🗂️ Group definitions. Each field: key (full dot-notation setting key),
+//    type, label, help, and options (for select).
+// -----------------------------------------------------------------------------
+$groups = [
+    'alerts' => [
+        'title' => 'Critical-error alerting',
+        'icon'  => 'fa-solid fa-bell',
+        'intro' => 'Email alerts when the portal logs a Critical or Fatal error. Rate-limited per fingerprint so a runaway error does not spam you.',
+        'fields' => [
+            'portal.alerts.recipients'       => ['type' => 'textarea', 'label' => 'Recipient emails', 'help' => 'Comma-separated. Leave empty to disable alerting.'],
+            'portal.alerts.severities'       => ['type' => 'text', 'label' => 'Severities to alert on', 'help' => 'Comma-separated. Default: Critical,Fatal'],
+            'portal.alerts.cooldown_minutes' => ['type' => 'number', 'label' => 'Cooldown (minutes)', 'help' => 'Minimum gap between alerts for the same error fingerprint.', 'min' => 0],
+        ],
+    ],
+    'backups' => [
+        'title' => 'Backups',
+        'icon'  => 'fa-solid fa-box-archive',
+        'intro' => 'JSON snapshot retention + freshness alerting. The backup-freshness cron emails when the most recent snapshot is older than the threshold.',
+        'fields' => [
+            'portal.backups.max_age_hours'    => ['type' => 'number', 'label' => 'Max backup age (hours)', 'help' => 'Alert if no successful backup within this window. Default 36.', 'min' => 1],
+            'portal.backups.alert_recipients' => ['type' => 'textarea', 'label' => 'Alert recipients', 'help' => 'Comma-separated emails for stale-backup alerts.'],
+        ],
+    ],
+    'headers' => [
+        'title' => 'Security headers',
+        'icon'  => 'fa-solid fa-shield-halved',
+        'intro' => 'HTTP response headers sent on every request. Defaults match the Mozilla Observatory baseline. Set a value empty to suppress that header.',
+        'fields' => [
+            'portal.headers.strict_transport_security' => ['type' => 'text', 'label' => 'Strict-Transport-Security', 'help' => 'HSTS. Only sent over HTTPS. Default: max-age=31536000; includeSubDomains'],
+            'portal.headers.permissions_policy'        => ['type' => 'textarea', 'label' => 'Permissions-Policy', 'help' => 'Disables browser features the portal does not use.'],
+            'portal.headers.coop'                      => ['type' => 'text', 'label' => 'Cross-Origin-Opener-Policy', 'help' => 'Default: same-origin'],
+            'portal.headers.corp'                      => ['type' => 'text', 'label' => 'Cross-Origin-Resource-Policy', 'help' => 'Default: same-origin'],
+            'portal.headers.referrer_policy'           => ['type' => 'text', 'label' => 'Referrer-Policy', 'help' => 'Default: strict-origin-when-cross-origin'],
+            'portal.headers.x_frame_options'           => ['type' => 'select', 'label' => 'X-Frame-Options', 'help' => 'Clickjacking protection.', 'options' => ['SAMEORIGIN' => 'SAMEORIGIN', 'DENY' => 'DENY', '' => '(suppress)']],
+        ],
+    ],
+    'upgrade' => [
+        'title' => 'Upgrade policy',
+        'icon'  => 'fa-solid fa-arrow-up-right-dots',
+        'intro' => 'Controls the installer/upgrade gate and the auto-backup before migrations.',
+        'fields' => [
+            'portal.upgrade.fresh_required_below'     => ['type' => 'text', 'label' => 'Fresh-install required below version', 'help' => 'Installs older than this must drop-and-rebuild. Leave empty to always allow in-place upgrade.'],
+            'portal.upgrade.require_hostname_confirm' => ['type' => 'toggle', 'label' => 'Require hostname confirmation for drop-and-rebuild', 'help' => 'Admin must type the portal hostname before a destructive rebuild.'],
+        ],
+    ],
+    'maintenance' => [
+        'title' => 'Maintenance mode',
+        'icon'  => 'fa-solid fa-screwdriver-wrench',
+        'intro' => 'The public-access gate shown during upgrades. Admins always bypass it.',
+        'fields' => [
+            'portal.maintenance.active'  => ['type' => 'toggle', 'label' => 'Maintenance mode active', 'help' => 'When on, non-admins see the maintenance page. Normally toggled automatically during upgrades.'],
+            'portal.maintenance.message' => ['type' => 'textarea', 'label' => 'Custom message', 'help' => 'Optional message shown on the maintenance page.'],
+        ],
+    ],
+];
+
+// -----------------------------------------------------------------------------
+// 🚏 Determine the group from the matched route path.
+// -----------------------------------------------------------------------------
+$path = Router::extractPath(); // e.g. "admin/settings/headers"
+$parts = explode('/', trim($path, '/'));
+$groupKey = end($parts);
+if (isset($groups[$groupKey]) === false) {
+    http_response_code(404);
+    exit('Unknown settings group');
+}
+$group = $groups[$groupKey];
+
+// -----------------------------------------------------------------------------
+// 💾 Save handler.
+// -----------------------------------------------------------------------------
+$flash = '';
+$flashType = 'info';
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && Auth::verifyCsrf($_POST['csrf_token'] ?? '') === true) {
+    $db = App::db();
+    try {
+        foreach ($group['fields'] as $key => $def) {
+            // Field name in the form is the key with dots → underscores.
+            $formName = str_replace('.', '_', $key);
+            if ($def['type'] === 'toggle') {
+                $value = isset($_POST[$formName]) ? '1' : '0';
+            } else {
+                $value = trim((string) ($_POST[$formName] ?? ''));
+                if ($def['type'] === 'number') {
+                    $value = (string) ((int) $value);
+                }
+                if ($def['type'] === 'select' && isset($def['options'][$value]) === false) {
+                    // Reject values not in the option set.
+                    $value = (string) array_key_first($def['options']);
+                }
+            }
+            $stmt = $db->prepare(
+                'INSERT INTO tblSettings (siteID, settingKey, settingValue, defaultValue, isSensitive) '
+                . 'VALUES (NULL, ?, ?, ?, 0) '
+                . 'ON DUPLICATE KEY UPDATE settingValue = VALUES(settingValue)'
+            );
+            if ($stmt !== false) {
+                $stmt->bind_param('sss', $key, $value, $value);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+        $flash = $group['title'] . ' settings saved.';
+        $flashType = 'success';
+    } catch (\Throwable $e) {
+        $flash = 'Save failed: ' . $e->getMessage();
+        $flashType = 'danger';
+    }
+}
+
+// -----------------------------------------------------------------------------
+// 📖 Read current values via dot-notation traversal of App::settings().
+// -----------------------------------------------------------------------------
+$settings = App::settings();
+$currentValue = static function (string $key) use ($settings): string {
+    $value = $settings;
+    foreach (explode('.', $key) as $part) {
+        if (is_array($value) === false || isset($value[$part]) === false) {
+            return '';
+        }
+        $value = $value[$part];
+    }
+    return is_scalar($value) ? (string) $value : '';
+};
+
+$pageTitle   = $group['title'];
+$pageSection = 'admin';
+$breadcrumbs = ['Dashboard' => '/', 'Admin' => '/admin', 'Settings' => '/admin/settings', $group['title'] => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<h1 class="mb-1"><i class="<?php echo htmlspecialchars((string) $group['icon'], ENT_QUOTES, 'UTF-8'); ?> me-2"></i><?php echo htmlspecialchars((string) $group['title'], ENT_QUOTES, 'UTF-8'); ?></h1>
+<p class="text-muted"><?php echo htmlspecialchars((string) $group['intro'], ENT_QUOTES, 'UTF-8'); ?></p>
+
+<?php if ($flash !== ''): ?>
+    <div class="alert alert-<?php echo htmlspecialchars($flashType, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($flash, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php endif; ?>
+
+<form method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+    <div class="card">
+        <div class="card-body">
+            <?php foreach ($group['fields'] as $key => $def):
+                $formName = str_replace('.', '_', $key);
+                $val = $currentValue($key);
+            ?>
+                <div class="mb-3">
+                    <?php if ($def['type'] === 'toggle'): ?>
+                        <div class="form-check form-switch">
+                            <input class="form-check-input" type="checkbox" id="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>"
+                                   name="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>" <?php echo ($val === '1' || $val === 'true') ? 'checked' : ''; ?>>
+                            <label class="form-check-label" for="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>">
+                                <strong><?php echo htmlspecialchars((string) $def['label'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                            </label>
+                        </div>
+                    <?php else: ?>
+                        <label class="form-label" for="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>">
+                            <strong><?php echo htmlspecialchars((string) $def['label'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                        </label>
+                        <?php if ($def['type'] === 'textarea'): ?>
+                            <textarea class="form-control form-control-sm" id="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>"
+                                      name="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>" rows="2"><?php echo htmlspecialchars($val, ENT_QUOTES, 'UTF-8'); ?></textarea>
+                        <?php elseif ($def['type'] === 'select'): ?>
+                            <select class="form-select form-select-sm" id="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>"
+                                    name="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>">
+                                <?php foreach ((array) $def['options'] as $optVal => $optLabel): ?>
+                                    <option value="<?php echo htmlspecialchars((string) $optVal, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $val === (string) $optVal ? 'selected' : ''; ?>>
+                                        <?php echo htmlspecialchars((string) $optLabel, ENT_QUOTES, 'UTF-8'); ?>
+                                    </option>
+                                <?php endforeach; ?>
+                            </select>
+                        <?php else: ?>
+                            <input type="<?php echo $def['type'] === 'number' ? 'number' : 'text'; ?>"
+                                   <?php echo isset($def['min']) ? 'min="' . (int) $def['min'] . '"' : ''; ?>
+                                   class="form-control form-control-sm" id="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>"
+                                   name="<?php echo htmlspecialchars($formName, ENT_QUOTES, 'UTF-8'); ?>"
+                                   value="<?php echo htmlspecialchars($val, ENT_QUOTES, 'UTF-8'); ?>">
+                        <?php endif; ?>
+                    <?php endif; ?>
+                    <?php if (($def['help'] ?? '') !== ''): ?>
+                        <div class="form-text"><?php echo htmlspecialchars((string) $def['help'], ENT_QUOTES, 'UTF-8'); ?></div>
+                    <?php endif; ?>
+                    <div class="small text-muted"><code><?php echo htmlspecialchars($key, ENT_QUOTES, 'UTF-8'); ?></code></div>
+                </div>
+            <?php endforeach; ?>
+
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a href="/admin/settings" class="btn btn-outline-secondary">All settings</a>
+        </div>
+    </div>
+</form>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/admin/settings/sabbath/index.php
+++ b/web/public_html/admin/settings/sabbath/index.php
@@ -1,0 +1,183 @@
+<?php
+// Path: public_html/admin/settings/sabbath/index.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Sabbath quiet hours dedicated settings page 🕯️
+ * -----------------------------------------------------------------------------
+ * Friendlier UI for the 8 portal.sabbath.* settings shipped with #231.
+ *
+ * @package   Portal\Admin
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/251
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Sabbath;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$flash = '';
+$flashType = 'info';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && Auth::verifyCsrf($_POST['csrf_token'] ?? '') === true) {
+    $db = App::db();
+    $values = [
+        'portal.sabbath.enabled'              => isset($_POST['enabled']) ? '1' : '0',
+        'portal.sabbath.method'               => in_array($_POST['method'] ?? 'fixed', ['fixed','sunset_calc'], true) ? (string) $_POST['method'] : 'fixed',
+        'portal.sabbath.timezone'             => trim((string) ($_POST['timezone'] ?? 'Europe/London')),
+        'portal.sabbath.location_lat'         => (string) ((float) ($_POST['location_lat'] ?? 0)),
+        'portal.sabbath.location_lng'         => (string) ((float) ($_POST['location_lng'] ?? 0)),
+        'portal.sabbath.start_offset_minutes' => (string) ((int) ($_POST['start_offset_minutes'] ?? 0)),
+        'portal.sabbath.end_offset_minutes'   => (string) ((int) ($_POST['end_offset_minutes'] ?? 0)),
+        'portal.sabbath.bypass_critical'      => isset($_POST['bypass_critical']) ? '1' : '0',
+    ];
+    // Validate timezone string against known list
+    try {
+        new \DateTimeZone($values['portal.sabbath.timezone']);
+    } catch (\Throwable $e) {
+        $values['portal.sabbath.timezone'] = 'Europe/London';
+    }
+    try {
+        foreach ($values as $key => $val) {
+            $stmt = $db->prepare(
+                "INSERT INTO tblSettings (siteID, settingKey, settingValue, defaultValue, isSensitive) "
+                . "VALUES (NULL, ?, ?, ?, 0) "
+                . "ON DUPLICATE KEY UPDATE settingValue = VALUES(settingValue)"
+            );
+            if ($stmt !== false) {
+                $stmt->bind_param('sss', $key, $val, $val);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+        $flash = 'Sabbath settings saved.';
+        $flashType = 'success';
+    } catch (\Throwable $e) {
+        $flash = 'Save failed: ' . $e->getMessage();
+        $flashType = 'danger';
+    }
+}
+
+$settings = App::settings();
+$enabled       = (string) ($settings['portal']['sabbath']['enabled']              ?? '0') === '1';
+$method        = (string) ($settings['portal']['sabbath']['method']               ?? 'fixed');
+$timezone      = (string) ($settings['portal']['sabbath']['timezone']             ?? 'Europe/London');
+$lat           = (float)  ($settings['portal']['sabbath']['location_lat']         ?? 52.205);
+$lng           = (float)  ($settings['portal']['sabbath']['location_lng']         ?? 0.119);
+$startOffset   = (int)    ($settings['portal']['sabbath']['start_offset_minutes'] ?? 0);
+$endOffset     = (int)    ($settings['portal']['sabbath']['end_offset_minutes']   ?? 0);
+$bypassCritical = (string) ($settings['portal']['sabbath']['bypass_critical']     ?? '1') === '1';
+
+// 🪞 Preview: current/next window
+[$winStart, $winEnd] = Sabbath::computeWindow(time());
+
+$pageTitle   = 'Sabbath quiet hours';
+$pageSection = 'admin';
+$breadcrumbs = ['Dashboard' => '/', 'Admin' => '/admin', 'Settings' => '/admin/settings', 'Sabbath' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+
+// All IANA timezones the system knows about
+$allTimezones = \DateTimeZone::listIdentifiers();
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-moon me-2"></i>Sabbath quiet hours</h1>
+<p class="text-muted">Defer non-urgent emails / notifications between Friday and Saturday windows. Critical alerts can optionally bypass.</p>
+
+<?php if ($flash !== ''): ?>
+    <div class="alert alert-<?php echo htmlspecialchars($flashType, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($flash, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php endif; ?>
+
+<?php if ($enabled === true): ?>
+    <div class="alert alert-info">
+        <strong>Current window (your settings):</strong>
+        <?php echo htmlspecialchars(date('D j M H:i', $winStart), ENT_QUOTES, 'UTF-8'); ?>
+        → <?php echo htmlspecialchars(date('D j M H:i', $winEnd), ENT_QUOTES, 'UTF-8'); ?>
+        (<?php echo htmlspecialchars($timezone, ENT_QUOTES, 'UTF-8'); ?>)
+    </div>
+<?php endif; ?>
+
+<form method="post">
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="enabled" name="enabled" <?php echo $enabled === true ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="enabled"><strong>Enable Sabbath quiet hours</strong></label>
+            </div>
+            <p class="form-text">When enabled, non-critical email notifications scheduled during the window are deferred until after.</p>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <h2 class="h6">Window calculation</h2>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" id="m_fixed" name="method" value="fixed" <?php echo $method === 'fixed' ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="m_fixed">Fixed local time (Friday 18:00 → Saturday 18:00)</label>
+            </div>
+            <div class="form-check">
+                <input class="form-check-input" type="radio" id="m_sunset" name="method" value="sunset_calc" <?php echo $method === 'sunset_calc' ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="m_sunset">Sunset calculation from latitude / longitude</label>
+            </div>
+
+            <div class="row g-2 mt-3">
+                <div class="col-md-6">
+                    <label class="form-label small">Timezone</label>
+                    <select name="timezone" class="form-select form-select-sm">
+                        <?php foreach ($allTimezones as $tz): ?>
+                            <option value="<?php echo htmlspecialchars($tz, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $tz === $timezone ? 'selected' : ''; ?>>
+                                <?php echo htmlspecialchars($tz, ENT_QUOTES, 'UTF-8'); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small">Latitude</label>
+                    <input type="number" step="0.0001" name="location_lat" class="form-control form-control-sm" value="<?php echo htmlspecialchars((string) $lat, ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small">Longitude</label>
+                    <input type="number" step="0.0001" name="location_lng" class="form-control form-control-sm" value="<?php echo htmlspecialchars((string) $lng, ENT_QUOTES, 'UTF-8'); ?>">
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small">Start offset (mins)</label>
+                    <input type="number" name="start_offset_minutes" class="form-control form-control-sm" value="<?php echo (int) $startOffset; ?>">
+                    <div class="form-text">Negative = earlier than sunset</div>
+                </div>
+                <div class="col-md-3">
+                    <label class="form-label small">End offset (mins)</label>
+                    <input type="number" name="end_offset_minutes" class="form-control form-control-sm" value="<?php echo (int) $endOffset; ?>">
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <div class="form-check form-switch">
+                <input class="form-check-input" type="checkbox" id="bypass" name="bypass_critical" <?php echo $bypassCritical === true ? 'checked' : ''; ?>>
+                <label class="form-check-label" for="bypass"><strong>Critical alerts bypass quiet hours</strong></label>
+            </div>
+            <p class="form-text">When on, Critical/Fatal severity alerts (from #229) still fire during the window. Non-critical alerts always defer.</p>
+        </div>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="/admin/settings" class="btn btn-outline-secondary">Cancel</a>
+</form>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/api/tours/active.php
+++ b/web/public_html/api/tours/active.php
@@ -1,0 +1,108 @@
+<?php
+// Path: public_html/api/tours/active.php
+/**
+ * -----------------------------------------------------------------------------
+ * Tours API — Active tour for the current user 🎯
+ * -----------------------------------------------------------------------------
+ * Returns the single highest-priority tour the current user hasn't yet
+ * completed, or null. Drives the auto-trigger in portal-tour.js.
+ *
+ * Priority order:
+ *   1. The welcome tour (tourKey='welcome') if portal.tours.welcome_active
+ *      and not completed.
+ *   2. The newest whats_new_X.Y.Z tour (by version) not completed, whose
+ *      version is <= the running PORTAL_VERSION.
+ *
+ * Role-gated: a tour with a non-empty forRoles CSV only surfaces to users
+ * holding one of those roles.
+ *
+ * @package   Portal\API
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/253
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+
+ApiResponse::requireAuth();
+
+$db     = App::db();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+// 📋 Candidate tours: active, not yet completed by this user.
+$tours = [];
+try {
+    $stmt = $db->prepare(
+        'SELECT t.tourID, t.tourKey, t.version, t.title, t.steps, t.forRoles '
+        . 'FROM tblTours t '
+        . 'WHERE t.isActive = 1 '
+        . 'AND NOT EXISTS ('
+        . '  SELECT 1 FROM tblUserTours ut WHERE ut.tourID = t.tourID AND ut.userID = ? '
+        . ') '
+        . 'ORDER BY t.tourKey = \'welcome\' DESC, t.version DESC'
+    );
+    if ($stmt === false) {
+        ApiResponse::success(null);
+    }
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $tours[] = $r;
+    }
+    $stmt->close();
+} catch (\Throwable $e) {
+    // 🛡️ tblTours may not exist if migration 069 hasn't run — degrade
+    //    gracefully to "no tour".
+    ApiResponse::success(null);
+}
+
+if (count($tours) === 0) {
+    ApiResponse::success(null);
+}
+
+// 🪞 Welcome tour gated by its own setting.
+$welcomeActive = (string) (App::settings()['portal']['tours']['welcome_active'] ?? '1') === '1';
+
+foreach ($tours as $t) {
+    if ($t['tourKey'] === 'welcome' && $welcomeActive === false) {
+        continue;
+    }
+    // 🔐 Role gate.
+    $forRoles = trim((string) ($t['forRoles'] ?? ''));
+    if ($forRoles !== '') {
+        $roles = array_filter(array_map('trim', explode(',', $forRoles)));
+        $allowed = false;
+        foreach ($roles as $role) {
+            if (App::hasRole($role) === true || App::isAdmin() === true) {
+                $allowed = true;
+                break;
+            }
+        }
+        if ($allowed === false) {
+            continue;
+        }
+    }
+
+    // ✅ Decode the steps JSON; skip malformed.
+    $steps = json_decode((string) $t['steps'], true);
+    if (is_array($steps) === false || count($steps) === 0) {
+        continue;
+    }
+
+    ApiResponse::success([
+        'tourID'  => (int) $t['tourID'],
+        'tourKey' => (string) $t['tourKey'],
+        'version' => (string) $t['version'],
+        'title'   => (string) $t['title'],
+        'steps'   => $steps,
+    ]);
+}
+
+ApiResponse::success(null);

--- a/web/public_html/api/tours/complete.php
+++ b/web/public_html/api/tours/complete.php
@@ -1,0 +1,58 @@
+<?php
+// Path: public_html/api/tours/complete.php
+/**
+ * -----------------------------------------------------------------------------
+ * Tours API — Mark a tour completed for the current user ✅
+ * -----------------------------------------------------------------------------
+ * POST { tourID } (+ csrf_token). Inserts a tblUserTours row (idempotent
+ * via the uq_user_tour unique key). Called when the user finishes OR skips
+ * a tour so it doesn't pester them again.
+ *
+ * @package   Portal\API
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/253
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+ApiResponse::requireAuth();
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    ApiResponse::error('Invalid CSRF token', 403);
+}
+
+$db     = App::db();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$tourId = (int) ($_POST['tourID'] ?? 0);
+
+if ($tourId <= 0) {
+    ApiResponse::error('tourID required', 400);
+}
+
+try {
+    $stmt = $db->prepare(
+        'INSERT INTO tblUserTours (userID, tourID) VALUES (?, ?) '
+        . 'ON DUPLICATE KEY UPDATE completedAt = completedAt'
+    );
+    if ($stmt === false) {
+        ApiResponse::error('Database error', 500);
+    }
+    $stmt->bind_param('ii', $userId, $tourId);
+    $stmt->execute();
+    $stmt->close();
+} catch (\Throwable $e) {
+    ApiResponse::error('Could not record completion', 500);
+}
+
+ApiResponse::success(['completed' => true]);

--- a/web/public_html/assets/css/portal.css
+++ b/web/public_html/assets/css/portal.css
@@ -2143,3 +2143,77 @@ a:focus > .app-card {
         display: none;
     }
 }
+
+/* =============================================================================
+ * Portal.Tour — "what's new" tour overlay (#253)
+ * ============================================================================= */
+.portal-tour-overlay {
+    position: fixed;
+    inset: 0;
+    z-index: 1080;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    background: rgba(16, 24, 40, 0.55);
+    padding: 1rem;
+}
+.portal-tour-card {
+    position: relative;
+    max-width: 420px;
+    width: 100%;
+    background: var(--bs-body-bg, #fff);
+    color: var(--bs-body-color, #1b2330);
+    border: 1px solid var(--bs-border-color, #e5e7eb);
+    border-radius: 0.75rem;
+    box-shadow: 0 12px 32px rgba(16, 24, 40, 0.25);
+    padding: 1.5rem;
+}
+.portal-tour-skip {
+    position: absolute;
+    top: 0.5rem;
+    right: 0.75rem;
+    background: none;
+    border: none;
+    font-size: 1.5rem;
+    line-height: 1;
+    color: var(--bs-secondary-color, #6b7280);
+    cursor: pointer;
+}
+.portal-tour-card-title {
+    font-size: 1.125rem;
+    font-weight: 600;
+    margin: 0 0 0.5rem;
+}
+.portal-tour-card-body {
+    color: var(--bs-secondary-color, #6b7280);
+    margin-bottom: 1.25rem;
+}
+.portal-tour-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 0.5rem;
+}
+.portal-tour-indicator {
+    font-size: 0.8125rem;
+    color: var(--bs-secondary-color, #6b7280);
+}
+.portal-tour-actions {
+    display: flex;
+    gap: 0.5rem;
+}
+.portal-tour-highlight {
+    position: relative;
+    z-index: 1081;
+    outline: 3px solid var(--bs-primary, #5e6ad2);
+    outline-offset: 3px;
+    border-radius: 0.375rem;
+    animation: portal-tour-pulse 1.5s ease-in-out infinite;
+}
+@keyframes portal-tour-pulse {
+    0%, 100% { outline-color: var(--bs-primary, #5e6ad2); }
+    50% { outline-color: rgba(94, 106, 210, 0.4); }
+}
+@media print {
+    .portal-tour-overlay { display: none !important; }
+}

--- a/web/public_html/assets/js/portal-tour.js
+++ b/web/public_html/assets/js/portal-tour.js
@@ -1,0 +1,226 @@
+/* =============================================================================
+ * WebMS Intra — Portal.Tour 🎯
+ * =============================================================================
+ * "What's new" tour playback. Completes the engine scaffolded in #237.
+ *
+ * On every authenticated page load (where the body carries the tour mount
+ * marker) it asks /api/tours/active for the highest-priority tour the user
+ * hasn't completed. If one comes back, it renders a centred modal stepper:
+ * title, body, step indicator, Skip / Back / Next / Done. On finish OR skip
+ * it POSTs /api/tours/complete so the tour doesn't reappear.
+ *
+ * Each step may carry a `selector` — if the element exists, the page scrolls
+ * to it and a pulsing highlight ring is drawn around it.
+ *
+ * Mobile: swipe left/right advances/retreats. Desktop: arrow keys.
+ *
+ * No framework — vanilla JS + Bootstrap modal markup (Bootstrap JS optional;
+ * falls back to a manually-toggled overlay if bootstrap.Modal is absent).
+ *
+ * @see   https://github.com/MWBMPartners/WebMS-Intra/issues/253
+ * ============================================================================= */
+(function () {
+    'use strict';
+
+    if (typeof window === 'undefined' || typeof document === 'undefined') {
+        return;
+    }
+    window.Portal = window.Portal || {};
+
+    // CSRF token is exposed on a <meta name="csrf-token"> tag by header.php.
+    function csrfToken() {
+        var el = document.querySelector('meta[name="csrf-token"]');
+        return el !== null ? el.getAttribute('content') || '' : '';
+    }
+
+    var state = {
+        tour: null,
+        index: 0,
+        overlay: null,
+        highlightEl: null,
+    };
+
+    function clearHighlight() {
+        if (state.highlightEl !== null) {
+            state.highlightEl.classList.remove('portal-tour-highlight');
+            state.highlightEl = null;
+        }
+    }
+
+    function highlightStep(step) {
+        clearHighlight();
+        if (typeof step.selector !== 'string' || step.selector === '') {
+            return;
+        }
+        var target = null;
+        try {
+            target = document.querySelector(step.selector);
+        } catch (e) {
+            target = null;
+        }
+        if (target === null) {
+            return;
+        }
+        target.classList.add('portal-tour-highlight');
+        state.highlightEl = target;
+        target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+    }
+
+    function render() {
+        if (state.tour === null) {
+            return;
+        }
+        var steps = state.tour.steps;
+        var step = steps[state.index];
+        var total = steps.length;
+
+        if (state.overlay === null) {
+            buildOverlay();
+        }
+
+        var titleEl = state.overlay.querySelector('[data-tour-title]');
+        var bodyEl = state.overlay.querySelector('[data-tour-body]');
+        var indEl = state.overlay.querySelector('[data-tour-indicator]');
+        var backBtn = state.overlay.querySelector('[data-tour-back]');
+        var nextBtn = state.overlay.querySelector('[data-tour-next]');
+
+        titleEl.textContent = step.title || state.tour.title || '';
+        bodyEl.textContent = step.body || '';
+        indEl.textContent = (state.index + 1) + ' of ' + total;
+        backBtn.style.visibility = state.index === 0 ? 'hidden' : 'visible';
+        nextBtn.textContent = state.index === total - 1 ? 'Done' : 'Next';
+
+        highlightStep(step);
+    }
+
+    function buildOverlay() {
+        var o = document.createElement('div');
+        o.className = 'portal-tour-overlay';
+        o.setAttribute('role', 'dialog');
+        o.setAttribute('aria-modal', 'true');
+        o.setAttribute('aria-label', 'Feature tour');
+        o.innerHTML =
+            '<div class="portal-tour-card" role="document">' +
+                '<button type="button" class="portal-tour-skip" data-tour-skip aria-label="Skip tour">&times;</button>' +
+                '<h2 class="portal-tour-card-title" data-tour-title></h2>' +
+                '<p class="portal-tour-card-body" data-tour-body></p>' +
+                '<div class="portal-tour-footer">' +
+                    '<span class="portal-tour-indicator" data-tour-indicator></span>' +
+                    '<div class="portal-tour-actions">' +
+                        '<button type="button" class="btn btn-sm btn-outline-secondary" data-tour-back>Back</button>' +
+                        '<button type="button" class="btn btn-sm btn-primary" data-tour-next>Next</button>' +
+                    '</div>' +
+                '</div>' +
+            '</div>';
+        document.body.appendChild(o);
+        state.overlay = o;
+
+        o.querySelector('[data-tour-skip]').addEventListener('click', complete);
+        o.querySelector('[data-tour-back]').addEventListener('click', function () {
+            if (state.index > 0) { state.index--; render(); }
+        });
+        o.querySelector('[data-tour-next]').addEventListener('click', function () {
+            if (state.index < state.tour.steps.length - 1) {
+                state.index++;
+                render();
+            } else {
+                complete();
+            }
+        });
+
+        // Keyboard: arrows + Esc.
+        document.addEventListener('keydown', onKeydown);
+
+        // Touch swipe.
+        var touchStartX = null;
+        o.addEventListener('touchstart', function (e) {
+            touchStartX = e.changedTouches[0].screenX;
+        }, { passive: true });
+        o.addEventListener('touchend', function (e) {
+            if (touchStartX === null) { return; }
+            var dx = e.changedTouches[0].screenX - touchStartX;
+            if (Math.abs(dx) < 50) { return; }
+            if (dx < 0 && state.index < state.tour.steps.length - 1) {
+                state.index++; render();
+            } else if (dx > 0 && state.index > 0) {
+                state.index--; render();
+            }
+            touchStartX = null;
+        }, { passive: true });
+    }
+
+    function onKeydown(e) {
+        if (state.tour === null) { return; }
+        if (e.key === 'Escape') { complete(); }
+        else if (e.key === 'ArrowRight') {
+            if (state.index < state.tour.steps.length - 1) { state.index++; render(); }
+            else { complete(); }
+        } else if (e.key === 'ArrowLeft') {
+            if (state.index > 0) { state.index--; render(); }
+        }
+    }
+
+    function complete() {
+        clearHighlight();
+        if (state.overlay !== null) {
+            state.overlay.remove();
+            state.overlay = null;
+        }
+        document.removeEventListener('keydown', onKeydown);
+
+        var tour = state.tour;
+        state.tour = null;
+        state.index = 0;
+        if (tour === null) { return; }
+
+        // Persist completion (best-effort).
+        var fd = new FormData();
+        fd.append('csrf_token', csrfToken());
+        fd.append('tourID', String(tour.tourID));
+        fetch('/api/tours/complete', { method: 'POST', body: fd, credentials: 'same-origin' })
+            .catch(function () { /* best-effort */ });
+    }
+
+    function startTour(tour) {
+        if (tour === null || !tour.steps || tour.steps.length === 0) {
+            return;
+        }
+        state.tour = tour;
+        state.index = 0;
+        render();
+    }
+
+    // Public API for the "replay" button on /account.
+    window.Portal.Tour = {
+        start: startTour,
+        fetchAndStart: fetchActive,
+    };
+
+    function fetchActive() {
+        fetch('/api/tours/active', { credentials: 'same-origin', headers: { 'Accept': 'application/json' } })
+            .then(function (r) { return r.ok ? r.json() : null; })
+            .then(function (json) {
+                // ApiResponse wraps payload as { success, data }.
+                var tour = json && json.data ? json.data : null;
+                if (tour !== null) {
+                    startTour(tour);
+                }
+            })
+            .catch(function () { /* silent — tours are non-critical */ });
+    }
+
+    // Auto-trigger on authenticated pages (body carries the marker set by
+    // header.php). Skip on the login screen and public pages.
+    function init() {
+        if (document.body.getAttribute('data-portal-authenticated') !== '1') {
+            return;
+        }
+        fetchActive();
+    }
+
+    if (document.readyState === 'loading') {
+        document.addEventListener('DOMContentLoaded', init);
+    } else {
+        init();
+    }
+})();

--- a/web/public_html/calendar/account-feed.php
+++ b/web/public_html/calendar/account-feed.php
@@ -1,0 +1,115 @@
+<?php
+// Path: public_html/calendar/account-feed.php
+/**
+ * Account-level page: user generates / regenerates / revokes their
+ * personal iCal token + sees the subscription URL.
+ *
+ * @package   Portal\Calendar
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/271
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Ical;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+$newToken = null;
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && Auth::verifyCsrf($_POST['csrf_token'] ?? '') === true) {
+    $action = (string) ($_POST['action'] ?? '');
+    if ($action === 'regenerate') {
+        $newToken = Ical::ensureUserToken($userId);
+    } elseif ($action === 'revoke') {
+        $stmt = $db->prepare('UPDATE tblUsers SET calendarToken = NULL WHERE userID = ?');
+        if ($stmt !== false) {
+            $stmt->bind_param('i', $userId);
+            $stmt->execute();
+            $stmt->close();
+        }
+    }
+}
+
+// Has any token been generated previously?
+$hasToken = false;
+$stmt = $db->prepare('SELECT calendarToken FROM tblUsers WHERE userID = ? LIMIT 1');
+if ($stmt !== false) {
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    $hasToken = $row !== null && $row['calendarToken'] !== null && $row['calendarToken'] !== '';
+}
+
+$pageTitle   = 'Calendar feed';
+$pageSection = 'auth';
+$breadcrumbs = ['Dashboard' => '/', 'Account' => '/account', 'Calendar feed' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+$host = $_SERVER['HTTP_HOST'] ?? 'portal';
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-calendar-arrow-down me-2"></i>Calendar feed</h1>
+<p class="text-muted">Subscribe to a personal calendar feed in Google Calendar, Apple Calendar, or Outlook. The feed includes published portal events + your rota duties.</p>
+
+<?php if ($newToken !== null): ?>
+    <div class="alert alert-success">
+        <strong>Your feed URL (save this — it won't be shown again):</strong>
+        <div class="mt-2">
+            <code style="word-break:break-all;">
+                https://<?php echo htmlspecialchars($host, ENT_QUOTES, 'UTF-8'); ?>/calendar.ics?token=<?php echo htmlspecialchars($newToken, ENT_QUOTES, 'UTF-8'); ?>
+            </code>
+        </div>
+        <p class="mt-2 small mb-0">
+            <strong>To use it:</strong> copy the URL above, then in your calendar app add a new subscription / iCal feed using this URL.
+        </p>
+    </div>
+<?php endif; ?>
+
+<div class="card">
+    <div class="card-body">
+        <h2 class="h5">Your feed</h2>
+        <?php if ($hasToken === true && $newToken === null): ?>
+            <p>You have a feed URL active. If you've lost it, regenerate (this will invalidate the old one).</p>
+        <?php else: ?>
+            <p>You don't have an active feed URL.</p>
+        <?php endif; ?>
+        <form method="post" class="d-inline">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <input type="hidden" name="action" value="regenerate">
+            <button type="submit" class="btn btn-primary btn-sm">
+                <?php echo $hasToken === true ? 'Regenerate feed URL' : 'Generate feed URL'; ?>
+            </button>
+        </form>
+        <?php if ($hasToken === true): ?>
+            <form method="post" class="d-inline ms-2">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="action" value="revoke">
+                <button type="submit" class="btn btn-outline-danger btn-sm"
+                        data-confirm="Revoke your calendar feed URL? Any calendar app subscribed to it will stop syncing." data-confirm-destructive="true">
+                    Revoke
+                </button>
+            </form>
+        <?php endif; ?>
+    </div>
+</div>
+
+<div class="card mt-3">
+    <div class="card-body">
+        <h2 class="h6">How to add the feed</h2>
+        <ul class="small text-muted mb-0">
+            <li><strong>Google Calendar:</strong> Settings → Add calendar → "From URL" → paste.</li>
+            <li><strong>Apple Calendar (Mac):</strong> File → New Calendar Subscription → paste.</li>
+            <li><strong>Outlook:</strong> Add calendar → Subscribe from web → paste.</li>
+            <li>Calendars refresh every few hours — events show up shortly after they're added in the portal.</li>
+        </ul>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/calendar/feed.php
+++ b/web/public_html/calendar/feed.php
@@ -1,0 +1,119 @@
+<?php
+// Path: public_html/calendar/feed.php
+/**
+ * iCalendar feed endpoint.
+ *
+ * URLs:
+ *   /calendar.ics?token=PERSONAL_TOKEN          — user's full visible calendar
+ *   /calendar.ics?token=PERSONAL_TOKEN&days=90  — bounded window
+ *
+ * Returns text/calendar with a 15-minute cache hint so well-behaved
+ * clients don't hammer the server.
+ *
+ * @package   Portal\Calendar
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/271
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Ical;
+use Portal\Core\Site;
+
+$token = (string) ($_GET['token'] ?? '');
+$userId = Ical::userIdForToken($token);
+if ($userId <= 0) {
+    http_response_code(403);
+    header('Content-Type: text/plain');
+    exit('Invalid token.');
+}
+
+$db = App::db();
+
+// 🪞 Resolve the user's site for scoping. Multi-site users are not
+//    currently supported in the feed — picks their primary.
+$siteId = 1;
+$stmt = $db->prepare('SELECT siteID FROM tblUsers WHERE userID = ? LIMIT 1');
+if ($stmt !== false) {
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if ($row !== null && (int) $row['siteID'] > 0) {
+        $siteId = (int) $row['siteID'];
+    }
+}
+
+$daysFwd = max(7, min(365, (int) ($_GET['days'] ?? 365)));
+$fromDate = date('Y-m-d', strtotime('-30 days'));
+$toDate   = date('Y-m-d', strtotime('+' . $daysFwd . ' days'));
+
+$events = [];
+
+// 📅 Standard calendar events.
+$stmt = $db->prepare(
+    'SELECT eventID, eventName, description, startDateTime, endDateTime, isAllDay, '
+    . '       timezone, locationName, locationAddress, eventSlug, updatedAt '
+    . 'FROM tblEvents '
+    . 'WHERE siteID = ? AND startDateTime >= ? AND startDateTime <= ? '
+    . 'ORDER BY startDateTime'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('iss', $siteId, $fromDate, $toDate);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $location = trim((string) ($r['locationName'] ?? '') . ' ' . (string) ($r['locationAddress'] ?? ''));
+        $events[] = [
+            'uid'          => 'event-' . $r['eventID'] . '@portal.webms-intra',
+            'summary'      => (string) $r['eventName'],
+            'description'  => (string) ($r['description'] ?? ''),
+            'location'     => $location !== '' ? $location : null,
+            'startsAt'     => (string) $r['startDateTime'],
+            'endsAt'       => (string) ($r['endDateTime'] ?? ''),
+            'allDay'       => (int) $r['isAllDay'] === 1,
+            'lastModified' => (string) ($r['updatedAt'] ?? ''),
+        ];
+    }
+    $stmt->close();
+}
+
+// 🗓️ User's rota duties (if rota app is enabled).
+try {
+    $stmt = $db->prepare(
+        'SELECT s.slotID, s.slotDate, s.startTime, s.endTime, r.name AS roleName '
+        . 'FROM tblRotaSlot s JOIN tblRotaRoleType r ON r.roleTypeID = s.roleTypeID '
+        . 'WHERE s.siteID = ? AND s.assignedToID = ? AND s.slotDate >= ? AND s.slotDate <= ? '
+        . 'ORDER BY s.slotDate'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('iiss', $siteId, $userId, $fromDate, $toDate);
+        $stmt->execute();
+        $rs = $stmt->get_result();
+        while ($r = $rs->fetch_assoc()) {
+            $allDay = $r['startTime'] === null;
+            $start = (string) $r['slotDate'] . ($allDay ? '' : ' ' . substr((string) $r['startTime'], 0, 5));
+            $end   = $allDay
+                ? (string) $r['slotDate']
+                : (string) $r['slotDate'] . ' ' . substr((string) ($r['endTime'] ?? $r['startTime']), 0, 5);
+            $events[] = [
+                'uid'      => 'rota-' . $r['slotID'] . '@portal.webms-intra',
+                'summary'  => 'Duty: ' . (string) $r['roleName'],
+                'startsAt' => $start,
+                'endsAt'   => $end,
+                'allDay'   => $allDay,
+            ];
+        }
+        $stmt->close();
+    }
+} catch (\Throwable $ignored) {
+    // 🛡️ Rota tables may not exist if the app isn't installed — silent.
+}
+
+$siteName = (string) (App::settings()['site']['name'] ?? 'Portal');
+$ics = Ical::emit($siteName . ' — My Calendar', $events);
+
+header('Content-Type: text/calendar; charset=utf-8');
+header('Cache-Control: private, max-age=900');
+header('Content-Disposition: inline; filename="portal-calendar.ics"');
+echo $ics;

--- a/web/public_html/directory/index.php
+++ b/web/public_html/directory/index.php
@@ -1,0 +1,116 @@
+<?php
+// Path: public_html/directory/index.php
+/**
+ * Member Directory — searchable list with per-field visibility filtering.
+ *
+ * @package   Portal\Directory
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/261
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$isAdmin = App::isAdmin();
+
+$q = trim((string) ($_GET['q'] ?? ''));
+
+// 🔍 Search — name LIKE only (privacy by default). Result rows respect
+//    per-field visibility at display time.
+$users = [];
+$sql = 'SELECT userID, fullName, displayBio, displayPhone, email, displayAddress, displayPhoto, '
+     . '       visibilityName, visibilityRoles, visibilityEmail, visibilityPhone, visibilityAddress, '
+     . '       visibilityBio, visibilityPhoto '
+     . 'FROM tblUsers WHERE siteID = ? AND isActive = 1';
+$types = 'i';
+$params = [$siteId];
+if ($q !== '') {
+    $sql .= ' AND fullName LIKE ?';
+    $types .= 's';
+    $params[] = '%' . $q . '%';
+}
+$sql .= " AND (visibilityName IN ('members','public') OR userID = ?)";
+$types .= 'i';
+$params[] = $userId;
+$sql .= ' ORDER BY fullName LIMIT 200';
+
+$stmt = $db->prepare($sql);
+if ($stmt !== false) {
+    $stmt->bind_param($types, ...$params);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $users[] = $r;
+    }
+    $stmt->close();
+}
+
+/**
+ * Returns true if the given visibility level grants the current viewer access.
+ * Owner + admins always see everything.
+ */
+$can = function (string $level, int $ownerID) use ($userId, $isAdmin): bool {
+    if ($ownerID === $userId || $isAdmin === true) {
+        return true;
+    }
+    return $level === 'members' || $level === 'public';
+};
+
+$pageTitle   = 'Member Directory';
+$pageSection = 'directory';
+$breadcrumbs = ['Dashboard' => '/', 'Directory' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-address-book me-2"></i>Member Directory</h1>
+        <p class="text-secondary mb-0">Find members and their roles. You control what others see about you.</p>
+    </div>
+    <a href="/directory/my-settings" class="btn btn-outline-primary btn-sm">My profile</a>
+</div>
+
+<form method="get" class="mb-3">
+    <div class="input-group">
+        <input type="text" name="q" class="form-control" placeholder="Search by name…" value="<?php echo htmlspecialchars($q, ENT_QUOTES, 'UTF-8'); ?>">
+        <button type="submit" class="btn btn-primary"><i class="fa-solid fa-magnifying-glass"></i></button>
+    </div>
+</form>
+
+<?php if (count($users) === 0): ?>
+    <div class="alert alert-info">No members match.</div>
+<?php else: ?>
+    <div class="row g-3">
+        <?php foreach ($users as $u):
+            $uid = (int) $u['userID'];
+        ?>
+            <div class="col-md-4">
+                <div class="card h-100">
+                    <div class="card-body">
+                        <h2 class="h6 mb-1">
+                            <a href="/directory/profile?id=<?php echo $uid; ?>" class="text-decoration-none">
+                                <?php echo htmlspecialchars((string) $u['fullName'], ENT_QUOTES, 'UTF-8'); ?>
+                            </a>
+                        </h2>
+                        <?php if ($can($u['visibilityEmail'], $uid) === true && $u['email'] !== null): ?>
+                            <p class="small text-muted mb-1"><i class="fa-solid fa-envelope me-1"></i><?php echo htmlspecialchars((string) $u['email'], ENT_QUOTES, 'UTF-8'); ?></p>
+                        <?php endif; ?>
+                        <?php if ($can($u['visibilityPhone'], $uid) === true && $u['displayPhone'] !== null): ?>
+                            <p class="small text-muted mb-1"><i class="fa-solid fa-phone me-1"></i><?php echo htmlspecialchars((string) $u['displayPhone'], ENT_QUOTES, 'UTF-8'); ?></p>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/directory/me.php
+++ b/web/public_html/directory/me.php
@@ -1,0 +1,98 @@
+<?php
+// Path: public_html/directory/me.php
+/**
+ * Member Directory — user edits own profile + per-field visibility.
+ *
+ * @package   Portal\Directory
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/261
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+$u = null;
+$stmt = $db->prepare(
+    'SELECT displayBio, displayPhone, displayAddress, '
+    . '       visibilityName, visibilityRoles, visibilityEmail, visibilityPhone, visibilityAddress, '
+    . '       visibilityBio, visibilityPhoto '
+    . 'FROM tblUsers WHERE userID = ? AND siteID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $userId, $siteId);
+    $stmt->execute();
+    $u = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+$pageTitle   = 'My directory profile';
+$pageSection = 'directory';
+$breadcrumbs = ['Dashboard' => '/', 'Directory' => '/directory', 'My profile' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+
+$visRow = function (string $field, string $label, string $current, string $help = '') use ($csrf): void {
+    $opts = ['private' => 'Private (just me + admins)', 'team' => 'Team-mates', 'members' => 'All members', 'public' => 'Public (no login)'];
+    echo '<div class="row mb-2 align-items-center"><div class="col-md-4"><label class="form-label small">' . htmlspecialchars($label, ENT_QUOTES, 'UTF-8') . '</label></div>'
+       . '<div class="col-md-5"><select name="' . htmlspecialchars($field, ENT_QUOTES, 'UTF-8') . '" class="form-select form-select-sm">';
+    foreach ($opts as $val => $optLabel) {
+        $sel = $val === $current ? ' selected' : '';
+        echo '<option value="' . htmlspecialchars($val, ENT_QUOTES, 'UTF-8') . '"' . $sel . '>' . htmlspecialchars($optLabel, ENT_QUOTES, 'UTF-8') . '</option>';
+    }
+    echo '</select></div>';
+    if ($help !== '') {
+        echo '<div class="col-md-3 small text-muted">' . htmlspecialchars($help, ENT_QUOTES, 'UTF-8') . '</div>';
+    }
+    echo '</div>';
+};
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-user-pen me-2"></i>My directory profile</h1>
+<p class="text-muted">Update what you share and who sees it.</p>
+
+<form method="post" action="/directory/save">
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <h2 class="h6">About me</h2>
+            <div class="mb-2"><label class="form-label small">Short bio (markdown supported)</label>
+                <textarea name="displayBio" class="form-control form-control-sm" rows="3"><?php echo htmlspecialchars((string) ($u['displayBio'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></textarea>
+            </div>
+            <div class="mb-2"><label class="form-label small">Phone</label>
+                <input type="tel" name="displayPhone" class="form-control form-control-sm" maxlength="50" value="<?php echo htmlspecialchars((string) ($u['displayPhone'] ?? ''), ENT_QUOTES, 'UTF-8'); ?>">
+            </div>
+            <div class="mb-2"><label class="form-label small">Address</label>
+                <textarea name="displayAddress" class="form-control form-control-sm" rows="2"><?php echo htmlspecialchars((string) ($u['displayAddress'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></textarea>
+            </div>
+        </div>
+    </div>
+
+    <div class="card mb-3">
+        <div class="card-body">
+            <h2 class="h6">Who sees what</h2>
+            <?php
+            $visRow('visibilityName',    'Name',              (string) ($u['visibilityName']    ?? 'members'));
+            $visRow('visibilityEmail',   'Email',             (string) ($u['visibilityEmail']   ?? 'private'));
+            $visRow('visibilityPhone',   'Phone',             (string) ($u['visibilityPhone']   ?? 'private'));
+            $visRow('visibilityAddress', 'Address',           (string) ($u['visibilityAddress'] ?? 'private'));
+            $visRow('visibilityBio',     'Bio',               (string) ($u['visibilityBio']     ?? 'members'));
+            $visRow('visibilityRoles',   'Roles / leadership',(string) ($u['visibilityRoles']   ?? 'members'));
+            ?>
+        </div>
+    </div>
+
+    <button type="submit" class="btn btn-primary">Save</button>
+    <a href="/directory" class="btn btn-outline-secondary">Cancel</a>
+</form>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/directory/profile.php
+++ b/web/public_html/directory/profile.php
@@ -1,0 +1,93 @@
+<?php
+// Path: public_html/directory/profile.php
+/**
+ * Member Directory — single profile, respecting per-field visibility.
+ *
+ * @package   Portal\Directory
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/261
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Markdown;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$viewer = (int) ($_SESSION['user_id'] ?? 0);
+$isAdmin = App::isAdmin();
+$id = (int) ($_GET['id'] ?? 0);
+if ($id <= 0) {
+    header('Location: /directory');
+    exit();
+}
+
+$u = null;
+$stmt = $db->prepare(
+    'SELECT userID, fullName, email, displayBio, displayPhone, displayAddress, displayPhoto, '
+    . '       visibilityName, visibilityRoles, visibilityEmail, visibilityPhone, visibilityAddress, '
+    . '       visibilityBio, visibilityPhoto '
+    . 'FROM tblUsers WHERE userID = ? AND siteID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $id, $siteId);
+    $stmt->execute();
+    $u = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+if ($u === null) {
+    http_response_code(404);
+    exit('Not found');
+}
+
+$can = static function (string $level) use ($viewer, $id, $isAdmin): bool {
+    if ($viewer === $id || $isAdmin === true) {
+        return true;
+    }
+    return $level === 'members' || $level === 'public';
+};
+
+if ($can($u['visibilityName']) === false) {
+    http_response_code(403);
+    exit('Profile is private.');
+}
+
+$pageTitle   = $u['fullName'];
+$pageSection = 'directory';
+$breadcrumbs = ['Dashboard' => '/', 'Directory' => '/directory', $u['fullName'] => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<h1 class="mb-3"><?php echo htmlspecialchars((string) $u['fullName'], ENT_QUOTES, 'UTF-8'); ?></h1>
+
+<div class="card">
+    <div class="card-body">
+        <?php if ($can($u['visibilityBio']) === true && trim((string) $u['displayBio']) !== ''): ?>
+            <div class="portal-markdown mb-3"><?php echo Markdown::render((string) $u['displayBio'], ['allow_links' => true]); ?></div>
+        <?php endif; ?>
+        <dl class="row small mb-0">
+            <?php if ($can($u['visibilityEmail']) === true && $u['email'] !== null): ?>
+                <dt class="col-sm-3">Email</dt>
+                <dd class="col-sm-9"><a href="mailto:<?php echo htmlspecialchars((string) $u['email'], ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars((string) $u['email'], ENT_QUOTES, 'UTF-8'); ?></a></dd>
+            <?php endif; ?>
+            <?php if ($can($u['visibilityPhone']) === true && $u['displayPhone'] !== null): ?>
+                <dt class="col-sm-3">Phone</dt>
+                <dd class="col-sm-9"><?php echo htmlspecialchars((string) $u['displayPhone'], ENT_QUOTES, 'UTF-8'); ?></dd>
+            <?php endif; ?>
+            <?php if ($can($u['visibilityAddress']) === true && $u['displayAddress'] !== null): ?>
+                <dt class="col-sm-3">Address</dt>
+                <dd class="col-sm-9"><?php echo nl2br(htmlspecialchars((string) $u['displayAddress'], ENT_QUOTES, 'UTF-8')); ?></dd>
+            <?php endif; ?>
+        </dl>
+        <?php if ($viewer === $id): ?>
+            <a href="/directory/my-settings" class="btn btn-outline-primary btn-sm mt-2">Edit my profile</a>
+        <?php endif; ?>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/directory/save.php
+++ b/web/public_html/directory/save.php
@@ -1,0 +1,56 @@
+<?php
+// Path: public_html/directory/save.php
+/**
+ * Member Directory — POST handler for own profile save.
+ *
+ * @package   Portal\Directory
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/261
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db     = App::db();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+$validVisibility = static fn (string $v): string =>
+    in_array($v, ['private','team','members','public'], true) ? $v : 'private';
+
+$bio     = trim((string) ($_POST['displayBio'] ?? ''));
+$phone   = trim((string) ($_POST['displayPhone'] ?? ''));
+$address = trim((string) ($_POST['displayAddress'] ?? ''));
+$vName    = $validVisibility((string) ($_POST['visibilityName']    ?? 'members'));
+$vEmail   = $validVisibility((string) ($_POST['visibilityEmail']   ?? 'private'));
+$vPhone   = $validVisibility((string) ($_POST['visibilityPhone']   ?? 'private'));
+$vAddress = $validVisibility((string) ($_POST['visibilityAddress'] ?? 'private'));
+$vBio     = $validVisibility((string) ($_POST['visibilityBio']     ?? 'members'));
+$vRoles   = $validVisibility((string) ($_POST['visibilityRoles']   ?? 'members'));
+
+try {
+    $stmt = $db->prepare(
+        'UPDATE tblUsers SET '
+        . 'displayBio = ?, displayPhone = ?, displayAddress = ?, '
+        . 'visibilityName = ?, visibilityEmail = ?, visibilityPhone = ?, '
+        . 'visibilityAddress = ?, visibilityBio = ?, visibilityRoles = ? '
+        . 'WHERE userID = ?'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('sssssssssi', $bio, $phone, $address, $vName, $vEmail, $vPhone, $vAddress, $vBio, $vRoles, $userId);
+        $stmt->execute();
+        $stmt->close();
+    }
+} catch (\Throwable $e) {
+    \Portal\Core\Logger::errorPlatform('Directory', 'Warning', 'SAVE', $e->getMessage(), '');
+}
+
+header('Location: /directory/my-settings');
+exit();

--- a/web/public_html/visitors/contact-save.php
+++ b/web/public_html/visitors/contact-save.php
@@ -1,0 +1,65 @@
+<?php
+// Path: public_html/visitors/contact-save.php
+/**
+ * Visitor Tracking — POST handler for recording a contact on a visitor.
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$id     = (int) ($_POST['visitorID'] ?? 0);
+$method = (string) ($_POST['method'] ?? 'call');
+$summary = trim((string) ($_POST['summary'] ?? ''));
+$next   = trim((string) ($_POST['nextContactAt'] ?? ''));
+
+if (in_array($method, ['visit','call','email','text','other'], true) === false) {
+    $method = 'other';
+}
+$nextDate = ($next !== '' && strtotime($next) !== false) ? $next : null;
+
+// 🛡️ Confirm visitor exists in this site
+$stmt = $db->prepare('SELECT 1 FROM tblVisitor WHERE visitorID = ? AND siteID = ?');
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $id, $siteId);
+    $stmt->execute();
+    $ok = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+    if ($ok === false) {
+        http_response_code(404);
+        exit('Visitor not found');
+    }
+}
+
+try {
+    $stmt = $db->prepare(
+        'INSERT INTO tblVisitorContact (visitorID, contactedByID, method, summary, nextContactAt) VALUES (?, ?, ?, ?, ?)'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('iisss', $id, $userId, $method, $summary, $nextDate);
+        $stmt->execute();
+        $stmt->close();
+    }
+    // 🪞 Auto-bump status from 'new' to 'in-touch' on first contact.
+    $db->query("UPDATE tblVisitor SET status = 'in-touch' WHERE visitorID = " . $id . " AND status = 'new'");
+} catch (\Throwable $e) {
+    \Portal\Core\Logger::errorPlatform('Visitors', 'Warning', 'CONTACT_SAVE', $e->getMessage(), '');
+}
+
+header('Location: /visitors/profile?id=' . $id);
+exit();

--- a/web/public_html/visitors/index.php
+++ b/web/public_html/visitors/index.php
@@ -1,0 +1,92 @@
+<?php
+// Path: public_html/visitors/index.php
+/**
+ * Visitor Tracking — kanban-style board grouping visitors by status.
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+
+$columns = ['new' => [], 'in-touch' => [], 'converted' => [], 'lost' => []];
+$rs = $db->query(
+    "SELECT v.visitorID, v.fullName, v.email, v.phone, v.status, v.firstVisitedAt, "
+    . "       u.fullName AS assigneeName, "
+    . "       (SELECT MAX(c.contactedAt) FROM tblVisitorContact c WHERE c.visitorID = v.visitorID) AS lastContactedAt "
+    . "FROM tblVisitor v "
+    . "LEFT JOIN tblUsers u ON u.userID = v.assignedToID "
+    . "WHERE v.siteID = " . $siteId . " "
+    . "ORDER BY v.status, v.firstVisitedAt DESC"
+);
+if ($rs !== false) {
+    while ($r = $rs->fetch_assoc()) {
+        $columns[$r['status']][] = $r;
+    }
+    $rs->free();
+}
+
+$pageTitle   = 'Visitor Tracking';
+$pageSection = 'visitors';
+$breadcrumbs = ['Dashboard' => '/', 'Visitors' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+$statusMeta = [
+    'new'       => ['label' => 'New',         'class' => 'primary'],
+    'in-touch'  => ['label' => 'In touch',    'class' => 'info'],
+    'converted' => ['label' => 'Converted',   'class' => 'success'],
+    'lost'      => ['label' => 'Lost contact','class' => 'secondary'],
+];
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-user-plus me-2"></i>Visitor Tracking</h1>
+        <p class="text-secondary mb-0">First-time visitors + their follow-up status.</p>
+    </div>
+    <div>
+        <a href="/visitors/my-follow-ups" class="btn btn-outline-primary btn-sm me-1">My follow-ups</a>
+        <a href="/visitors/new" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus me-1"></i>Add visitor</a>
+    </div>
+</div>
+
+<div class="row g-3">
+    <?php foreach ($columns as $status => $visitors): $m = $statusMeta[$status]; ?>
+        <div class="col-md-3">
+            <div class="card h-100">
+                <div class="card-header bg-<?php echo $m['class']; ?> text-white">
+                    <strong><?php echo htmlspecialchars($m['label'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                    <span class="badge bg-light text-dark ms-1"><?php echo count($visitors); ?></span>
+                </div>
+                <div class="card-body p-2" style="max-height:600px;overflow-y:auto;">
+                    <?php if (count($visitors) === 0): ?>
+                        <p class="small text-muted text-center my-3">No visitors here.</p>
+                    <?php else: foreach ($visitors as $v): ?>
+                        <a href="/visitors/profile?id=<?php echo (int) $v['visitorID']; ?>"
+                           class="d-block text-decoration-none text-reset card mb-2 p-2 small">
+                            <strong><?php echo htmlspecialchars((string) $v['fullName'], ENT_QUOTES, 'UTF-8'); ?></strong><br>
+                            <span class="text-muted">Visited <?php echo htmlspecialchars(date('j M', strtotime((string) $v['firstVisitedAt'])), ENT_QUOTES, 'UTF-8'); ?></span><br>
+                            <?php if ($v['assigneeName'] !== null): ?>
+                                <span class="badge bg-light text-dark mt-1">→ <?php echo htmlspecialchars((string) $v['assigneeName'], ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php else: ?>
+                                <span class="badge bg-warning text-dark mt-1">Unassigned</span>
+                            <?php endif; ?>
+                        </a>
+                    <?php endforeach; endif; ?>
+                </div>
+            </div>
+        </div>
+    <?php endforeach; ?>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/visitors/my-follow-ups.php
+++ b/web/public_html/visitors/my-follow-ups.php
@@ -1,0 +1,95 @@
+<?php
+// Path: public_html/visitors/my-follow-ups.php
+/**
+ * Visitor Tracking — my assigned visitors with overdue highlights.
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+$rows = [];
+$stmt = $db->prepare(
+    'SELECT v.visitorID, v.fullName, v.email, v.phone, v.status, v.firstVisitedAt, '
+    . '       (SELECT MAX(c.contactedAt) FROM tblVisitorContact c WHERE c.visitorID = v.visitorID) AS lastContactedAt, '
+    . '       (SELECT MIN(c.nextContactAt) FROM tblVisitorContact c WHERE c.visitorID = v.visitorID AND c.nextContactAt >= CURDATE()) AS nextContactAt '
+    . 'FROM tblVisitor v '
+    . 'WHERE v.siteID = ? AND v.assignedToID = ? AND v.status IN (\'new\',\'in-touch\') '
+    . 'ORDER BY nextContactAt IS NULL DESC, nextContactAt ASC, v.firstVisitedAt'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $siteId, $userId);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $rows[] = $r;
+    }
+    $stmt->close();
+}
+
+$initialDays = (int) (App::settings()['visitors']['followup_initial_days'] ?? 7);
+$today = time();
+
+$pageTitle   = 'My visitor follow-ups';
+$pageSection = 'visitors';
+$breadcrumbs = ['Dashboard' => '/', 'Visitors' => '/visitors', 'My follow-ups' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-list-check me-2"></i>My follow-ups</h1>
+
+<?php if (count($rows) === 0): ?>
+    <div class="alert alert-info">No active visitors assigned to you.</div>
+<?php else: ?>
+    <div class="card">
+        <div class="card-body">
+            <div class="portal-data-list">
+                <?php foreach ($rows as $r):
+                    $lastContact = $r['lastContactedAt'] !== null ? strtotime((string) $r['lastContactedAt']) : null;
+                    $firstVisit  = strtotime((string) $r['firstVisitedAt']);
+                    $overdue = false;
+                    if ($lastContact === null) {
+                        $daysSinceVisit = (int) (($today - $firstVisit) / 86400);
+                        $overdue = $daysSinceVisit > $initialDays;
+                    }
+                ?>
+                    <div class="row py-2 border-bottom align-items-center">
+                        <div class="col-md-3"><a href="/visitors/profile?id=<?php echo (int) $r['visitorID']; ?>"><strong><?php echo htmlspecialchars((string) $r['fullName'], ENT_QUOTES, 'UTF-8'); ?></strong></a></div>
+                        <div class="col-md-2"><span class="badge bg-info text-dark"><?php echo htmlspecialchars((string) $r['status'], ENT_QUOTES, 'UTF-8'); ?></span></div>
+                        <div class="col-md-3 small text-muted">
+                            <?php
+                            if ($r['lastContactedAt'] !== null) {
+                                echo 'Last: ' . htmlspecialchars(date('j M', $lastContact ?: 0), ENT_QUOTES, 'UTF-8');
+                            } else {
+                                echo 'Never contacted';
+                            }
+                            ?>
+                        </div>
+                        <div class="col-md-4 text-end">
+                            <?php if ($r['nextContactAt'] !== null): ?>
+                                <span class="badge bg-warning text-dark me-2">Due: <?php echo htmlspecialchars(date('j M', strtotime((string) $r['nextContactAt'])), ENT_QUOTES, 'UTF-8'); ?></span>
+                            <?php endif; ?>
+                            <?php if ($overdue === true): ?>
+                                <span class="badge bg-danger">Overdue first contact</span>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/visitors/new.php
+++ b/web/public_html/visitors/new.php
@@ -1,0 +1,81 @@
+<?php
+// Path: public_html/visitors/new.php
+/**
+ * Visitor Tracking — manual capture form (admin / coordinator).
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+
+// Coordinator dropdown — users with the configured role + admins.
+$coordRole = (string) (App::settings()['visitors']['coordinator_role'] ?? 'visitor_coordinator');
+$coords    = [];
+$rs = $db->query("SELECT userID, fullName FROM tblUsers WHERE siteID = " . $siteId . " AND isActive = 1 ORDER BY fullName");
+if ($rs !== false) {
+    while ($r = $rs->fetch_assoc()) {
+        $coords[] = $r;
+    }
+    $rs->free();
+}
+
+$pageTitle   = 'Add visitor';
+$pageSection = 'visitors';
+$breadcrumbs = ['Dashboard' => '/', 'Visitors' => '/visitors', 'Add' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-user-plus me-2"></i>Add visitor</h1>
+
+<div class="card">
+    <div class="card-body">
+        <form method="post" action="/visitors/save">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <div class="row g-2">
+                <div class="col-md-6"><label class="form-label">Full name</label><input type="text" name="fullName" class="form-control" required maxlength="255"></div>
+                <div class="col-md-6"><label class="form-label">Email</label><input type="email" name="email" class="form-control" maxlength="255"></div>
+                <div class="col-md-6"><label class="form-label">Phone</label><input type="tel" name="phone" class="form-control" maxlength="50"></div>
+                <div class="col-md-6">
+                    <label class="form-label">Source</label>
+                    <select name="source" class="form-select">
+                        <option value="in-person">In-person (Sabbath morning, etc.)</option>
+                        <option value="referral">Referral</option>
+                        <option value="website">Website</option>
+                        <option value="other">Other</option>
+                    </select>
+                </div>
+                <div class="col-md-6">
+                    <label class="form-label">Assign to (follow-up coordinator)</label>
+                    <select name="assignedToID" class="form-select">
+                        <option value="">— Unassigned —</option>
+                        <?php foreach ($coords as $c): ?>
+                            <option value="<?php echo (int) $c['userID']; ?>"><?php echo htmlspecialchars((string) $c['fullName'], ENT_QUOTES, 'UTF-8'); ?></option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Notes (markdown supported)</label>
+                    <textarea name="notes" class="form-control" rows="3" placeholder="Anything notable from the encounter…"></textarea>
+                </div>
+            </div>
+            <div class="mt-3">
+                <button type="submit" class="btn btn-primary">Save visitor</button>
+                <a href="/visitors" class="btn btn-outline-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/visitors/profile.php
+++ b/web/public_html/visitors/profile.php
@@ -1,0 +1,179 @@
+<?php
+// Path: public_html/visitors/profile.php
+/**
+ * Visitor Tracking — single visitor profile + contact log + add-contact form.
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Markdown;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$id     = (int) ($_GET['id'] ?? 0);
+
+if ($id <= 0) {
+    header('Location: /visitors');
+    exit();
+}
+
+$v = null;
+$stmt = $db->prepare(
+    'SELECT v.*, u.fullName AS assigneeName FROM tblVisitor v '
+    . 'LEFT JOIN tblUsers u ON u.userID = v.assignedToID '
+    . 'WHERE v.visitorID = ? AND v.siteID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $id, $siteId);
+    $stmt->execute();
+    $v = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+if ($v === null) {
+    http_response_code(404);
+    exit('Visitor not found');
+}
+
+$contacts = [];
+$stmt = $db->prepare(
+    'SELECT c.contactID, c.contactedAt, c.method, c.summary, c.nextContactAt, '
+    . '       u.fullName AS byName '
+    . 'FROM tblVisitorContact c JOIN tblUsers u ON u.userID = c.contactedByID '
+    . 'WHERE c.visitorID = ? ORDER BY c.contactedAt DESC'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $contacts[] = $r;
+    }
+    $stmt->close();
+}
+
+$users = [];
+$rs = $db->query("SELECT userID, fullName FROM tblUsers WHERE siteID = " . $siteId . " AND isActive = 1 ORDER BY fullName");
+if ($rs !== false) {
+    while ($r = $rs->fetch_assoc()) {
+        $users[] = $r;
+    }
+    $rs->free();
+}
+
+$pageTitle   = $v['fullName'];
+$pageSection = 'visitors';
+$breadcrumbs = ['Dashboard' => '/', 'Visitors' => '/visitors', $v['fullName'] => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<h1 class="mb-1"><?php echo htmlspecialchars((string) $v['fullName'], ENT_QUOTES, 'UTF-8'); ?></h1>
+<p class="text-muted">
+    First visited <?php echo htmlspecialchars(date('j M Y', strtotime((string) $v['firstVisitedAt'])), ENT_QUOTES, 'UTF-8'); ?>
+    &middot; source: <?php echo htmlspecialchars((string) $v['source'], ENT_QUOTES, 'UTF-8'); ?>
+</p>
+
+<div class="row g-3 mb-3">
+    <div class="col-md-4">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="h6">Contact details</h2>
+                <p class="small mb-1"><strong>Email:</strong> <?php echo htmlspecialchars((string) ($v['email'] ?? '—'), ENT_QUOTES, 'UTF-8'); ?></p>
+                <p class="small mb-0"><strong>Phone:</strong> <?php echo htmlspecialchars((string) ($v['phone'] ?? '—'), ENT_QUOTES, 'UTF-8'); ?></p>
+            </div>
+        </div>
+    </div>
+    <div class="col-md-8">
+        <div class="card h-100">
+            <div class="card-body">
+                <h2 class="h6">Status &amp; assignment</h2>
+                <form method="post" action="/visitors/save" class="row g-2 align-items-end">
+                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                    <input type="hidden" name="updateStatus" value="1">
+                    <input type="hidden" name="visitorID" value="<?php echo (int) $id; ?>">
+                    <div class="col-md-4">
+                        <label class="form-label small">Status</label>
+                        <select name="status" class="form-select form-select-sm">
+                            <?php foreach (['new','in-touch','converted','lost'] as $s): ?>
+                                <option value="<?php echo $s; ?>" <?php echo $v['status'] === $s ? 'selected' : ''; ?>><?php echo $s; ?></option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-md-6">
+                        <label class="form-label small">Assigned to</label>
+                        <select name="assignedToID" class="form-select form-select-sm">
+                            <option value="0">— Unassigned —</option>
+                            <?php foreach ($users as $u): ?>
+                                <option value="<?php echo (int) $u['userID']; ?>" <?php echo (int) $v['assignedToID'] === (int) $u['userID'] ? 'selected' : ''; ?>>
+                                    <?php echo htmlspecialchars((string) $u['fullName'], ENT_QUOTES, 'UTF-8'); ?>
+                                </option>
+                            <?php endforeach; ?>
+                        </select>
+                    </div>
+                    <div class="col-md-2"><button type="submit" class="btn btn-primary btn-sm w-100">Update</button></div>
+                </form>
+            </div>
+        </div>
+    </div>
+</div>
+
+<div class="card mb-3">
+    <div class="card-body">
+        <h2 class="h6">Record contact</h2>
+        <form method="post" action="/visitors/contact-save" class="row g-2">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <input type="hidden" name="visitorID" value="<?php echo (int) $id; ?>">
+            <div class="col-md-3">
+                <label class="form-label small">Method</label>
+                <select name="method" class="form-select form-select-sm">
+                    <option value="call">Call</option>
+                    <option value="email">Email</option>
+                    <option value="visit">Visit</option>
+                    <option value="text">Text</option>
+                    <option value="other">Other</option>
+                </select>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label small">Next contact (optional)</label>
+                <input type="date" name="nextContactAt" class="form-control form-control-sm">
+            </div>
+            <div class="col-12">
+                <label class="form-label small">Summary</label>
+                <textarea name="summary" class="form-control form-control-sm" rows="3" placeholder="Markdown supported."></textarea>
+            </div>
+            <div class="col-12"><button type="submit" class="btn btn-primary btn-sm">Save contact</button></div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-body">
+        <h2 class="h6">Contact log</h2>
+        <?php if (count($contacts) === 0): ?>
+            <p class="text-muted small mb-0">No contacts recorded yet.</p>
+        <?php else: foreach ($contacts as $c): ?>
+            <div class="border-bottom py-2">
+                <p class="mb-1 small text-muted">
+                    <?php echo htmlspecialchars(date('j M Y, H:i', strtotime((string) $c['contactedAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                    &middot; <strong><?php echo htmlspecialchars((string) $c['byName'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                    &middot; <?php echo htmlspecialchars((string) $c['method'], ENT_QUOTES, 'UTF-8'); ?>
+                    <?php if ($c['nextContactAt'] !== null): ?>
+                        &middot; <span class="badge bg-info text-dark">Next: <?php echo htmlspecialchars(date('j M', strtotime((string) $c['nextContactAt'])), ENT_QUOTES, 'UTF-8'); ?></span>
+                    <?php endif; ?>
+                </p>
+                <div class="portal-markdown"><?php echo Markdown::render((string) ($c['summary'] ?? ''), ['allow_links' => true]); ?></div>
+            </div>
+        <?php endforeach; endif; ?>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/visitors/public-form.php
+++ b/web/public_html/visitors/public-form.php
@@ -1,0 +1,119 @@
+<?php
+// Path: public_html/visitors/public-form.php
+/**
+ * Visitor Tracking — public self-capture form at /visit.
+ *
+ * Renders WITHOUT login when visitors.public_capture_enabled = '1'.
+ * Captcha-gated (reuses existing captcha integration).
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Site;
+
+$siteId = Site::id();
+$enabled = (string) (App::settings()['visitors']['public_capture_enabled'] ?? '0') === '1';
+
+if ($enabled === false) {
+    http_response_code(404);
+    exit('Not found');
+}
+
+$flash = '';
+$flashType = 'info';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    $name  = trim((string) ($_POST['fullName'] ?? ''));
+    $email = trim((string) ($_POST['email'] ?? ''));
+    $phone = trim((string) ($_POST['phone'] ?? ''));
+    $notes = trim((string) ($_POST['notes'] ?? ''));
+
+    // 🛡️ Captcha — uses existing portal captcha if configured.
+    $captchaOk = true;
+    if (class_exists('Portal\\Core\\Captcha') === true
+        && method_exists('Portal\\Core\\Captcha', 'verify') === true
+    ) {
+        $captchaOk = \Portal\Core\Captcha::verify($_POST);
+    }
+
+    if ($name === '' || ($email === '' && $phone === '')) {
+        $flash = 'Please give your name and at least one of email/phone.';
+        $flashType = 'danger';
+    } elseif ($captchaOk === false) {
+        $flash = 'Verification failed — please try again.';
+        $flashType = 'danger';
+    } else {
+        try {
+            $db = App::db();
+            $source = 'public-form';
+            $em = $email !== '' ? $email : null;
+            $ph = $phone !== '' ? $phone : null;
+            $nt = $notes !== '' ? $notes : null;
+            $stmt = $db->prepare(
+                'INSERT INTO tblVisitor (siteID, fullName, email, phone, source, notes) VALUES (?, ?, ?, ?, ?, ?)'
+            );
+            if ($stmt !== false) {
+                $stmt->bind_param('isssss', $siteId, $name, $em, $ph, $source, $nt);
+                $stmt->execute();
+                $stmt->close();
+            }
+            $flash = 'Thanks! Someone will be in touch within the next week.';
+            $flashType = 'success';
+        } catch (\Throwable $e) {
+            $flash = 'Sorry — something went wrong. Please try again later.';
+            $flashType = 'danger';
+        }
+    }
+}
+
+$portalName = htmlspecialchars((string) (App::settings()['site']['name'] ?? 'our portal'), ENT_QUOTES, 'UTF-8');
+?>
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Welcome — <?php echo $portalName; ?></title>
+<style>
+:root{--bg:#f7f8fa;--surface:#fff;--text:#1b2330;--muted:#6b7280;--border:#e5e7eb;--primary:#5e6ad2;}
+@media (prefers-color-scheme: dark){:root{--bg:#0f1115;--surface:#161a22;--text:#e8eaf0;--muted:#9aa3b2;--border:#2c3441;}}
+body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);margin:0;padding:2rem 1rem;}
+.card{max-width:480px;margin:0 auto;background:var(--surface);border:1px solid var(--border);border-radius:.75rem;padding:1.5rem;}
+h1{margin-top:0;}
+label{display:block;font-size:.875rem;margin:.75rem 0 .25rem;}
+input,textarea{width:100%;padding:.5rem;border:1px solid var(--border);border-radius:.375rem;background:var(--surface);color:var(--text);box-sizing:border-box;}
+button{margin-top:1rem;padding:.625rem 1.25rem;background:var(--primary);color:#fff;border:none;border-radius:.375rem;font-weight:500;cursor:pointer;}
+.flash{padding:.5rem;border-radius:.375rem;margin-bottom:1rem;}
+.flash-success{background:#d1fae5;color:#065f46;}
+.flash-danger{background:#fee2e2;color:#991b1b;}
+.flash-info{background:#dbeafe;color:#1e40af;}
+</style>
+</head>
+<body>
+<div class="card">
+    <h1>Welcome to <?php echo $portalName; ?></h1>
+    <p>Glad to have you visit. Share a quick way to reach you and we'll be in touch.</p>
+    <?php if ($flash !== ''): ?>
+        <div class="flash flash-<?php echo htmlspecialchars($flashType, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($flash, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php endif; ?>
+    <?php if ($flashType !== 'success'): ?>
+        <form method="post">
+            <label>Your name</label>
+            <input type="text" name="fullName" required maxlength="255">
+            <label>Email</label>
+            <input type="email" name="email" maxlength="255">
+            <label>Phone</label>
+            <input type="tel" name="phone" maxlength="50">
+            <label>Anything you'd like us to know? (optional)</label>
+            <textarea name="notes" rows="3"></textarea>
+            <button type="submit">Send</button>
+        </form>
+    <?php endif; ?>
+</div>
+</body>
+</html>

--- a/web/public_html/visitors/save.php
+++ b/web/public_html/visitors/save.php
@@ -1,0 +1,76 @@
+<?php
+// Path: public_html/visitors/save.php
+/**
+ * Visitor Tracking — POST handler for new visitor + status updates.
+ *
+ * @package   Portal\Visitors
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/258
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+try {
+    if (isset($_POST['updateStatus']) === true) {
+        // Status / assignee update from the profile page.
+        $id     = (int) ($_POST['visitorID'] ?? 0);
+        $status = (string) ($_POST['status'] ?? 'new');
+        $assignedToID = (int) ($_POST['assignedToID'] ?? 0);
+        if (in_array($status, ['new','in-touch','converted','lost'], true) === false) {
+            $status = 'new';
+        }
+        $assignee = $assignedToID > 0 ? $assignedToID : null;
+        $stmt = $db->prepare('UPDATE tblVisitor SET status = ?, assignedToID = ? WHERE visitorID = ? AND siteID = ?');
+        if ($stmt !== false) {
+            $stmt->bind_param('siii', $status, $assignee, $id, $siteId);
+            $stmt->execute();
+            $stmt->close();
+        }
+        header('Location: /visitors/profile?id=' . $id);
+        exit();
+    }
+
+    // Create new visitor
+    $name   = trim((string) ($_POST['fullName'] ?? ''));
+    $email  = trim((string) ($_POST['email'] ?? '')) ?: null;
+    $phone  = trim((string) ($_POST['phone'] ?? '')) ?: null;
+    $source = (string) ($_POST['source'] ?? 'in-person');
+    $assignedToID = (int) ($_POST['assignedToID'] ?? 0);
+    $notes  = trim((string) ($_POST['notes'] ?? '')) ?: null;
+    if ($name === '') {
+        header('Location: /visitors/new');
+        exit();
+    }
+    if (in_array($source, ['in-person','public-form','referral','website','other'], true) === false) {
+        $source = 'other';
+    }
+    $assignee = $assignedToID > 0 ? $assignedToID : null;
+    $stmt = $db->prepare(
+        'INSERT INTO tblVisitor (siteID, fullName, email, phone, source, assignedToID, notes, createdByID) '
+        . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?)'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('issssisi', $siteId, $name, $email, $phone, $source, $assignee, $notes, $userId);
+        $stmt->execute();
+        $stmt->close();
+    }
+} catch (\Throwable $e) {
+    \Portal\Core\Logger::errorPlatform('Visitors', 'Warning', 'SAVE', $e->getMessage(), '');
+}
+
+header('Location: /visitors');
+exit();


### PR DESCRIPTION
## 2 apps + iCal + 4 admin polish — 7 issues, one cohesive PR

Stacked on the just-merged #280. Validates the App Registry pattern from #279 with two more apps (visitors + directory), wires in the iCal feed every existing calendar/rota app benefits from, and closes the four remaining admin-polish items from the omnibus follow-up queue.

### Closes
- **#258** Visitor Tracking
- **#261** Member Directory
- **#271** iCal feed per calendar
- **#251** Sabbath admin sub-page
- **#254** Mailer plain-text alternative
- **#253** Tour playback JS (completes #237 engine)
- **#252** Settings group sub-pages

### Apps

**#258 Visitor Tracking** — `tblVisitor` + `tblVisitorContact`. Kanban board (New / In-touch / Converted / Lost), assignee + cadence, contact log with auto-bump from 'new' to 'in-touch' on first contact, `/visitors/my-follow-ups` with overdue badge, and a captcha-gated **public** `/visit` form (gated by `visitors.public_capture_enabled`).

**#261 Member Directory** — additive ALTER on `tblUsers` with 7 per-field visibility enums (`private`/`team`/`members`/`public`). Search, profile pages enforce visibility per field, `/directory/my-settings` for the user to opt in field-by-field. Owner + admins always see everything.

### Cross-cutting

**#271 iCal feed** — new `Portal\Core\Ical` (RFC 5545 emitter, ~150 LOC, no vendor). `tblUsers.calendarToken` stores SHA-256 hash; plaintext shown once at generation. `/calendar.ics?token=...` is public-keyed; feeds include `tblEvents` + the user's `tblRotaSlot` duties (try/catch wraps the rota query so absent table is harmless). `/account/calendar-feed` for the user to generate/regenerate/revoke + setup instructions.

### Admin polish

**#251 Sabbath sub-page** — `/admin/settings/sabbath` with friendly inputs (enable switch, method radio, IANA timezone dropdown, lat/lng, offsets, critical-bypass switch) + live "current window" preview via `Sabbath::computeWindow()`.

**#254 Mailer plain-text** — `Mailer::htmlToPlain()` derives a clean plain-text alternative from HTML (converts `<br>`/`</p>`/etc to newlines, preserves `<a href>` as "text (url)", decodes entities, collapses whitespace). `Mailer::send()` now generates `$plainBody` alongside `$htmlBody`; MS Graph derives its own plain-text from HTML so the on-wire multipart/alternative MIME applies once SMTP is wired.

**#253 Tour playback JS** — completes #237. `web/public_html/assets/js/portal-tour.js` (~210 LOC vanilla, Bootstrap-independent). Auto-fetches `/api/tours/active` on authenticated page load; renders a centred modal stepper with title/body/indicator/Skip/Back/Next/Done, per-step `selector` highlight with pulsing ring, mobile swipe + desktop arrow keys + Esc. POSTs `/api/tours/complete` on finish/skip. `header.php` body gains `data-portal-authenticated="0|1"`. `portal.css` gains themed overlay + highlight styles. Per-tour `forRoles` CSV gate honoured.

**#252 Settings group sub-pages** — one definition-driven controller (`admin/settings/group.php`) serving **5 friendly routes**:
| Route | Group |
|---|---|
| `/admin/settings/alerts` | `portal.alerts.*` |
| `/admin/settings/backups` | `portal.backups.*` |
| `/admin/settings/headers` | `portal.headers.*` |
| `/admin/settings/upgrade` | `portal.upgrade.*` |
| `/admin/settings/maintenance` | `portal.maintenance.*` |

Each field has a type (toggle/number/text/textarea/select), label, help text, and the raw key shown as a `<code>` hint. All values still readable/writable via the generic `/admin/settings` editor — these are an ergonomic layer, not a replacement.

### Verification

```
$ python3 tools/audit-checks/check_sql_columns.py
Column-name mismatches: 0

$ python3 tools/audit-checks/check_route_targets.py
Routes inspected (final state): 172+
Missing target files: 0

$ python3 tools/audit-checks/check_no_native_confirm.py
Findings: 0
```

All PHP lint-clean.

### Migrations 078–083

`078_visitors.sql` · `079_directory.sql` · `080_ical_feed.sql` · `081_sabbath_admin.sql` · `082_tour_playback.sql` · `083_settings_subpages.sql` — all idempotent, all in `full_schema.sql`.

### Test plan

- [ ] Enable Visitors + Directory + Reading Plans at `/admin/apps`.
- [ ] **Visitors:** add → assign → contact → status auto-bumps to "in-touch" → "my-follow-ups" shows.
- [ ] **Visitors public form:** set `visitors.public_capture_enabled=1` → `/visit` is reachable without login + captcha-gated.
- [ ] **Directory:** edit my profile → set visibility per field → log in as another user → only fields tagged ≥ `members` show.
- [ ] **iCal:** `/account/calendar-feed` → generate URL → paste into Google Calendar → events sync.
- [ ] **Sabbath:** `/admin/settings/sabbath` → toggle on → preview shows next Fri→Sat window.
- [ ] **Settings groups:** `/admin/settings/alerts` etc. → friendly inputs render → save round-trip works.
- [ ] **Tour:** seed a test row in `tblTours` for a fake user → log in → modal stepper renders → "Skip" persists completion.
- [ ] CI passes.

### Out of scope / deferred per app

Each issue's status comment lists the specific deferrals. Highlights:
- Photo upload (depends on #236 photo approval queue) for directory photos.
- QR code (depends on #275) for `/visit` and `/account/calendar-feed`.
- Convert-to-member triggers invite onboarding (depends on #239).
- SMTP backend for true wire-level multipart/alternative.
- In-portal tour authoring UI (drag-target picker).


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_