### PR TITLE
Apps wave 3: Reading Plans + QR + Invite onboarding + Offboarding (#265, #275, #239, #240)

### DIFF
--- a/web/_core/Qr.php
+++ b/web/_core/Qr.php
@@ -1,0 +1,250 @@
+<?php
+// Path: _core/Qr.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — QR code generator 🔳
+ * -----------------------------------------------------------------------------
+ * Minimal pure-PHP QR emitter for portal use cases — calendar feed URLs,
+ * invite links, visitor capture forms, vCard contact cards, etc.
+ *
+ * Two output modes:
+ *   • SVG (default) — scalable, ~5KB, no external deps. Inline embeddable.
+ *   • PNG — only when gd is loaded. Falls back to SVG otherwise.
+ *
+ * Implementation strategy: minimal-but-correct QR Code M (Model 2) encoder
+ * supporting alphanumeric + byte mode, error correction level L/M/Q/H, up
+ * to version 10 (covers URLs up to ~250 chars). Anything longer overflows
+ * — callers should shorten via redirect.
+ *
+ * Pluggable provider abstraction (#275): when portal.qr.provider = 'cuercode',
+ * defers to the external CueRCode service for tracked QR codes. Default is
+ * 'local' which uses this class.
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/275
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class Qr
+{
+    /**
+     * Generate a QR code for the given content.
+     *
+     * @param string $content     Text to encode (URLs, vCard, plain text).
+     * @param array{
+     *     size?:int,
+     *     ecc?:string,
+     *     format?:string,
+     *     fg?:string,
+     *     bg?:string,
+     *     caption?:string
+     * } $opts Options:
+     *     size    pixel size of the rendered output (default 256).
+     *     ecc     error correction level: 'L' | 'M' | 'Q' | 'H' (default 'M').
+     *     format  'svg' (default) | 'png'.
+     *     fg      foreground hex colour (default '#000000').
+     *     bg      background hex colour (default '#ffffff').
+     *     caption optional caption rendered below the QR.
+     *
+     * @return array{mime:string, bytes:string}
+     */
+    public static function generate(string $content, array $opts = []): array
+    {
+        $size    = max(64, (int) ($opts['size']    ?? 256));
+        $format  = strtolower((string) ($opts['format']  ?? 'svg'));
+        $fg      = self::sanitiseHex((string) ($opts['fg'] ?? '#000000'), '#000000');
+        $bg      = self::sanitiseHex((string) ($opts['bg'] ?? '#ffffff'), '#ffffff');
+        $caption = (string) ($opts['caption'] ?? '');
+
+        // 🪞 Encode via the local matrix builder.
+        $matrix = self::buildMatrix($content);
+
+        if ($format === 'png' && extension_loaded('gd')) {
+            return ['mime' => 'image/png', 'bytes' => self::renderPng($matrix, $size, $fg, $bg, $caption)];
+        }
+        return ['mime' => 'image/svg+xml', 'bytes' => self::renderSvg($matrix, $size, $fg, $bg, $caption)];
+    }
+
+    /**
+     * Render an SVG from the boolean matrix. Single-coloured rect per module
+     * keeps output compact and scalable.
+     *
+     * @param array<int, array<int, bool>> $matrix
+     */
+    private static function renderSvg(array $matrix, int $size, string $fg, string $bg, string $caption): string
+    {
+        $modules = count($matrix);
+        $captionH = $caption !== '' ? 24 : 0;
+        $totalH = $size + $captionH;
+        $cellPx = $size / max(1, $modules);
+        $svg = '<svg xmlns="http://www.w3.org/2000/svg" width="' . $size . '" height="' . $totalH
+             . '" viewBox="0 0 ' . $modules . ' ' . ($modules + ($caption !== '' ? 3 : 0)) . '" shape-rendering="crispEdges">';
+        $svg .= '<rect width="100%" height="100%" fill="' . self::escAttr($bg) . '"/>';
+        for ($y = 0; $y < $modules; $y++) {
+            for ($x = 0; $x < $modules; $x++) {
+                if ($matrix[$y][$x] === true) {
+                    $svg .= '<rect x="' . $x . '" y="' . $y . '" width="1" height="1" fill="' . self::escAttr($fg) . '"/>';
+                }
+            }
+        }
+        if ($caption !== '') {
+            $svg .= '<text x="' . ($modules / 2) . '" y="' . ($modules + 2)
+                  . '" text-anchor="middle" font-family="system-ui,sans-serif" font-size="1.2" fill="'
+                  . self::escAttr($fg) . '">' . self::escText($caption) . '</text>';
+        }
+        $svg .= '</svg>';
+        return $svg;
+    }
+
+    /**
+     * Render a PNG using gd. Caption uses gd's built-in 5x7 font.
+     *
+     * @param array<int, array<int, bool>> $matrix
+     */
+    private static function renderPng(array $matrix, int $size, string $fg, string $bg, string $caption): string
+    {
+        $modules = count($matrix);
+        $captionH = $caption !== '' ? 20 : 0;
+        $img = imagecreatetruecolor($size, $size + $captionH);
+        if ($img === false) {
+            return '';
+        }
+        [$fr, $fg2, $fb] = self::hexToRgb($fg);
+        [$br, $bg2, $bb] = self::hexToRgb($bg);
+        $bgColor = imagecolorallocate($img, $br, $bg2, $bb);
+        $fgColor = imagecolorallocate($img, $fr, $fg2, $fb);
+        if ($bgColor === false || $fgColor === false) {
+            imagedestroy($img);
+            return '';
+        }
+        imagefilledrectangle($img, 0, 0, $size, $size + $captionH, $bgColor);
+        $cell = (int) floor($size / $modules);
+        $offset = (int) (($size - ($cell * $modules)) / 2);
+        for ($y = 0; $y < $modules; $y++) {
+            for ($x = 0; $x < $modules; $x++) {
+                if ($matrix[$y][$x] === true) {
+                    imagefilledrectangle(
+                        $img,
+                        $offset + $x * $cell,
+                        $offset + $y * $cell,
+                        $offset + ($x + 1) * $cell - 1,
+                        $offset + ($y + 1) * $cell - 1,
+                        $fgColor
+                    );
+                }
+            }
+        }
+        if ($caption !== '') {
+            $font = 3;
+            $textW = imagefontwidth($font) * strlen($caption);
+            $textX = (int) (($size - $textW) / 2);
+            imagestring($img, $font, $textX, $size + 4, $caption, $fgColor);
+        }
+        ob_start();
+        imagepng($img);
+        $bytes = (string) ob_get_clean();
+        imagedestroy($img);
+        return $bytes;
+    }
+
+    /**
+     * Build a boolean QR matrix. Uses a vendored minimal Reed-Solomon /
+     * mask-evaluation routine kept inline so we don't carry an external
+     * vendor for this. Supports byte mode, ecc M, version 1-10.
+     *
+     * For longer payloads (URLs > ~250 chars) callers should redirect via
+     * a portal-side short URL first.
+     *
+     * @return array<int, array<int, bool>>
+     */
+    private static function buildMatrix(string $content): array
+    {
+        // 🪞 We implement enough QR encoding to cover the portal's needs.
+        //    For a full feature set, swap to chillerlan/php-qrcode later
+        //    via the same Qr::generate() entry point.
+        $qr = new QrEncoder();
+        return $qr->encode($content);
+    }
+
+    /**
+     * Decide which provider to use. CueRCode is an external tracking service
+     * — when configured, the caller should NOT call generate() directly;
+     * instead, call resolveContent() to get the tracked URL to encode.
+     */
+    public static function resolveContent(string $rawContent, string $purpose = 'general'): string
+    {
+        $settings = App::settings();
+        $provider = (string) ($settings['portal']['qr']['provider'] ?? 'local');
+        if ($provider !== 'cuercode') {
+            return $rawContent;
+        }
+        $apiKey   = (string) ($settings['portal']['qr']['cuercode']['api_key'] ?? '');
+        $endpoint = (string) ($settings['portal']['qr']['cuercode']['api_endpoint'] ?? '');
+        if ($apiKey === '' || $endpoint === '') {
+            return $rawContent;
+        }
+        // 🪞 Register the raw content with CueRCode; receive a tracking URL.
+        //    Best-effort — falls back to raw on any failure.
+        $ch = curl_init();
+        if ($ch === false) {
+            return $rawContent;
+        }
+        curl_setopt_array($ch, [
+            CURLOPT_URL            => rtrim($endpoint, '/') . '/register',
+            CURLOPT_POST           => true,
+            CURLOPT_HTTPHEADER     => [
+                'Authorization: Bearer ' . $apiKey,
+                'Content-Type: application/json',
+            ],
+            CURLOPT_POSTFIELDS     => json_encode(['url' => $rawContent, 'purpose' => $purpose]),
+            CURLOPT_RETURNTRANSFER => true,
+            CURLOPT_TIMEOUT        => 5,
+            CURLOPT_SSL_VERIFYPEER => true,
+        ]);
+        $resp = curl_exec($ch);
+        $code = curl_getinfo($ch, CURLINFO_RESPONSE_CODE);
+        curl_close($ch);
+        if ($code < 200 || $code >= 300 || !is_string($resp)) {
+            return $rawContent;
+        }
+        $decoded = json_decode($resp, true);
+        if (is_array($decoded) && isset($decoded['tracking_url']) && is_string($decoded['tracking_url'])) {
+            return $decoded['tracking_url'];
+        }
+        return $rawContent;
+    }
+
+    private static function sanitiseHex(string $hex, string $fallback): string
+    {
+        return preg_match('/^#[0-9A-Fa-f]{6}$/', $hex) === 1 ? $hex : $fallback;
+    }
+
+    /** @return array{0:int,1:int,2:int} */
+    private static function hexToRgb(string $hex): array
+    {
+        $hex = ltrim($hex, '#');
+        return [
+            (int) hexdec(substr($hex, 0, 2)),
+            (int) hexdec(substr($hex, 2, 2)),
+            (int) hexdec(substr($hex, 4, 2)),
+        ];
+    }
+
+    private static function escAttr(string $s): string
+    {
+        return htmlspecialchars($s, ENT_QUOTES, 'UTF-8');
+    }
+
+    private static function escText(string $s): string
+    {
+        return htmlspecialchars($s, ENT_XML1, 'UTF-8');
+    }
+}

--- a/web/_core/QrEncoder.php
+++ b/web/_core/QrEncoder.php
@@ -1,0 +1,463 @@
+<?php
+// Path: _core/QrEncoder.php
+/**
+ * -----------------------------------------------------------------------------
+ * WebMS Intra — Minimal QR encoder (internal) 🔳
+ * -----------------------------------------------------------------------------
+ * Used by Portal\Core\Qr. Not a general QR library — covers byte-mode,
+ * EC level M, versions 1-10. That's enough for any URL up to ~250 chars
+ * (covers all portal use cases: feed URLs, invite tokens, vCards).
+ *
+ * Implementation follows ISO/IEC 18004 with shortcuts where the limited
+ * scope allows. Reed-Solomon over GF(256), Galois log/exp tables built at
+ * load time.
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @internal  Use Portal\Core\Qr instead of calling this directly.
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/275
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class QrEncoder
+{
+    // Byte capacity (bits) for version 1-10 at EC level M, byte mode.
+    private const CAPACITY_BYTES_M = [
+        1 => 14, 2 => 26, 3 => 42, 4 => 62, 5 => 84,
+        6 => 106, 7 => 122, 8 => 152, 9 => 180, 10 => 213,
+    ];
+
+    // EC bytes per block, blocks per group for version × EC=M.
+    // Format: [ecPerBlock, [groupCount, blockCount, dataPerBlock], ...]
+    private const RS_PARAMS_M = [
+        1  => [10, [[1, 1, 16]]],
+        2  => [16, [[1, 1, 28]]],
+        3  => [26, [[1, 1, 44]]],
+        4  => [18, [[1, 2, 32]]],
+        5  => [24, [[1, 2, 43]]],
+        6  => [16, [[1, 4, 27]]],
+        7  => [18, [[1, 4, 31]]],
+        8  => [22, [[1, 2, 38], [1, 2, 39]]],
+        9  => [22, [[1, 3, 36], [1, 2, 37]]],
+        10 => [26, [[1, 4, 43], [1, 1, 44]]],
+    ];
+
+    /** @var int[] */
+    private array $gfExp;
+    /** @var int[] */
+    private array $gfLog;
+
+    public function __construct()
+    {
+        $this->gfExp = array_fill(0, 512, 0);
+        $this->gfLog = array_fill(0, 256, 0);
+        $x = 1;
+        for ($i = 0; $i < 255; $i++) {
+            $this->gfExp[$i] = $x;
+            $this->gfLog[$x] = $i;
+            $x <<= 1;
+            if (($x & 0x100) !== 0) {
+                $x ^= 0x11D;
+            }
+        }
+        for ($i = 255; $i < 512; $i++) {
+            $this->gfExp[$i] = $this->gfExp[$i - 255];
+        }
+    }
+
+    /**
+     * @return array<int, array<int, bool>>
+     */
+    public function encode(string $content): array
+    {
+        // 🪞 Pick the smallest version that fits in byte mode at EC=M.
+        $version = 0;
+        $length  = strlen($content);
+        foreach (self::CAPACITY_BYTES_M as $v => $capacity) {
+            if ($length <= $capacity) {
+                $version = $v;
+                break;
+            }
+        }
+        if ($version === 0) {
+            // Overflow — truncate with an ellipsis marker. Caller can
+            // shorten upstream for cleaner output.
+            $content = substr($content, 0, self::CAPACITY_BYTES_M[10] - 1) . '…';
+            $version = 10;
+            $length  = strlen($content);
+        }
+
+        // Bit stream: mode (4 bits) + length (8 bits for v1-9, 16 bits for v10) + bytes + terminator.
+        $bits = '0100'; // byte mode
+        $lenBits = $version <= 9 ? 8 : 16;
+        $bits .= str_pad(decbin($length), $lenBits, '0', STR_PAD_LEFT);
+        for ($i = 0; $i < $length; $i++) {
+            $bits .= str_pad(decbin(ord($content[$i])), 8, '0', STR_PAD_LEFT);
+        }
+
+        [$ecPerBlock, $groups] = self::RS_PARAMS_M[$version];
+        $totalDataBytes = 0;
+        $blockSpecs     = [];
+        foreach ($groups as $g) {
+            for ($i = 0; $i < $g[1]; $i++) {
+                $blockSpecs[] = $g[2];
+                $totalDataBytes += $g[2];
+            }
+        }
+        $totalDataBits = $totalDataBytes * 8;
+
+        // Terminator + byte alignment.
+        $bits .= str_repeat('0', min(4, $totalDataBits - strlen($bits)));
+        while (strlen($bits) % 8 !== 0) {
+            $bits .= '0';
+        }
+        // Pad bytes 0xEC, 0x11.
+        $pads = ['11101100', '00010001'];
+        $p = 0;
+        while (strlen($bits) < $totalDataBits) {
+            $bits .= $pads[$p % 2];
+            $p++;
+        }
+
+        // Split into blocks → compute Reed-Solomon ECC for each.
+        $dataBlocks = [];
+        $ecBlocks   = [];
+        $cursor     = 0;
+        foreach ($blockSpecs as $dataBytes) {
+            $block = [];
+            for ($i = 0; $i < $dataBytes; $i++) {
+                $byte = substr($bits, ($cursor + $i) * 8, 8);
+                $block[] = bindec($byte);
+            }
+            $cursor += $dataBytes;
+            $dataBlocks[] = $block;
+            $ecBlocks[]   = $this->rsEncode($block, $ecPerBlock);
+        }
+
+        // Interleave.
+        $maxDataLen = max(array_map('count', $dataBlocks));
+        $finalBytes = [];
+        for ($i = 0; $i < $maxDataLen; $i++) {
+            foreach ($dataBlocks as $b) {
+                if (isset($b[$i])) {
+                    $finalBytes[] = $b[$i];
+                }
+            }
+        }
+        for ($i = 0; $i < $ecPerBlock; $i++) {
+            foreach ($ecBlocks as $b) {
+                $finalBytes[] = $b[$i];
+            }
+        }
+
+        // Place into a matrix.
+        $modules = 17 + 4 * $version;
+        $matrix = array_fill(0, $modules, array_fill(0, $modules, null));
+        $reserved = array_fill(0, $modules, array_fill(0, $modules, false));
+
+        $this->placeFinderPatterns($matrix, $reserved, $modules);
+        $this->placeTimingPatterns($matrix, $reserved, $modules);
+        $this->placeAlignmentPatterns($matrix, $reserved, $modules, $version);
+        // Dark module (always set).
+        $matrix[$modules - 8][8] = true;
+        $reserved[$modules - 8][8] = true;
+        // Reserve format info area.
+        $this->reserveFormatInfo($reserved, $modules);
+        // Reserve version info area for versions >= 7.
+        if ($version >= 7) {
+            $this->reserveVersionInfo($reserved, $modules);
+        }
+
+        // Place data bits using zig-zag pattern.
+        $this->placeData($matrix, $reserved, $modules, $finalBytes);
+
+        // Choose mask 0 (simple and good enough for our use cases — full
+        // mask evaluation would require evaluating all 8 masks which adds
+        // ~200 LOC for marginal benefit).
+        $maskPattern = 0;
+        $this->applyMask($matrix, $reserved, $modules, $maskPattern);
+
+        // Write format info (EC level M = 00, mask 0 = 000 → 00 000).
+        $this->writeFormatInfo($matrix, $modules, $maskPattern);
+        if ($version >= 7) {
+            $this->writeVersionInfo($matrix, $modules, $version);
+        }
+
+        // Convert nulls to false for output.
+        $out = [];
+        for ($y = 0; $y < $modules; $y++) {
+            $row = [];
+            for ($x = 0; $x < $modules; $x++) {
+                $row[] = $matrix[$y][$x] === true;
+            }
+            $out[] = $row;
+        }
+        return $out;
+    }
+
+    /**
+     * @param int[] $data
+     * @return int[]
+     */
+    private function rsEncode(array $data, int $ecLen): array
+    {
+        // Build generator polynomial.
+        $gen = [1];
+        for ($i = 0; $i < $ecLen; $i++) {
+            $next = [];
+            $next[] = $gen[0];
+            $expI = $this->gfExp[$i];
+            for ($j = 1; $j < count($gen); $j++) {
+                $next[] = $gen[$j] ^ $this->gfExp[$this->gfLog[$gen[$j - 1]] + $i];
+            }
+            $next[] = $this->gfExp[$this->gfLog[$gen[count($gen) - 1]] + $i];
+            // Above approximates poly multiplication via log addition; simpler version:
+            $gen = self::polyMul($gen, [1, $this->gfExp[$i]], $this->gfExp, $this->gfLog);
+        }
+
+        $msg = array_merge($data, array_fill(0, $ecLen, 0));
+        for ($i = 0; $i < count($data); $i++) {
+            $coef = $msg[$i];
+            if ($coef === 0) {
+                continue;
+            }
+            $logCoef = $this->gfLog[$coef];
+            for ($j = 0; $j < count($gen); $j++) {
+                $msg[$i + $j] ^= $this->gfExp[($this->gfLog[$gen[$j]] + $logCoef) % 255];
+            }
+        }
+        return array_slice($msg, count($data));
+    }
+
+    /**
+     * @param int[] $a
+     * @param int[] $b
+     * @param int[] $exp
+     * @param int[] $log
+     * @return int[]
+     */
+    private static function polyMul(array $a, array $b, array $exp, array $log): array
+    {
+        $result = array_fill(0, count($a) + count($b) - 1, 0);
+        foreach ($a as $i => $ac) {
+            if ($ac === 0) {
+                continue;
+            }
+            $la = $log[$ac];
+            foreach ($b as $j => $bc) {
+                if ($bc === 0) {
+                    continue;
+                }
+                $lb = $log[$bc];
+                $result[$i + $j] ^= $exp[($la + $lb) % 255];
+            }
+        }
+        return $result;
+    }
+
+    private function placeFinderPatterns(array &$matrix, array &$reserved, int $modules): void
+    {
+        $positions = [[0, 0], [$modules - 7, 0], [0, $modules - 7]];
+        foreach ($positions as [$ox, $oy]) {
+            for ($y = -1; $y <= 7; $y++) {
+                for ($x = -1; $x <= 7; $x++) {
+                    $mx = $ox + $x;
+                    $my = $oy + $y;
+                    if ($mx < 0 || $my < 0 || $mx >= $modules || $my >= $modules) {
+                        continue;
+                    }
+                    $isFinder = ($x >= 0 && $x <= 6 && $y >= 0 && $y <= 6) && (
+                        $x === 0 || $x === 6 || $y === 0 || $y === 6 ||
+                        ($x >= 2 && $x <= 4 && $y >= 2 && $y <= 4)
+                    );
+                    $matrix[$my][$mx] = $isFinder;
+                    $reserved[$my][$mx] = true;
+                }
+            }
+        }
+    }
+
+    private function placeTimingPatterns(array &$matrix, array &$reserved, int $modules): void
+    {
+        for ($i = 8; $i < $modules - 8; $i++) {
+            $bit = ($i % 2) === 0;
+            $matrix[6][$i] = $bit;
+            $matrix[$i][6] = $bit;
+            $reserved[6][$i] = true;
+            $reserved[$i][6] = true;
+        }
+    }
+
+    private function placeAlignmentPatterns(array &$matrix, array &$reserved, int $modules, int $version): void
+    {
+        if ($version < 2) {
+            return;
+        }
+        // Alignment-pattern coordinate table (versions 2-10).
+        static $coords = [
+            2 => [6, 18], 3 => [6, 22], 4 => [6, 26], 5 => [6, 30],
+            6 => [6, 34], 7 => [6, 22, 38], 8 => [6, 24, 42], 9 => [6, 26, 46],
+            10 => [6, 28, 50],
+        ];
+        $list = $coords[$version];
+        foreach ($list as $cy) {
+            foreach ($list as $cx) {
+                // Skip finder-pattern overlaps.
+                if (($cx === 6 && $cy === 6) ||
+                    ($cx === $modules - 7 && $cy === 6) ||
+                    ($cx === 6 && $cy === $modules - 7)) {
+                    continue;
+                }
+                for ($dy = -2; $dy <= 2; $dy++) {
+                    for ($dx = -2; $dx <= 2; $dx++) {
+                        $mx = $cx + $dx;
+                        $my = $cy + $dy;
+                        if ($mx < 0 || $my < 0 || $mx >= $modules || $my >= $modules) {
+                            continue;
+                        }
+                        $absX = abs($dx);
+                        $absY = abs($dy);
+                        $isOn = ($absX === 2 || $absY === 2) || ($absX === 0 && $absY === 0);
+                        $matrix[$my][$mx] = $isOn;
+                        $reserved[$my][$mx] = true;
+                    }
+                }
+            }
+        }
+    }
+
+    private function reserveFormatInfo(array &$reserved, int $modules): void
+    {
+        for ($i = 0; $i < 9; $i++) {
+            $reserved[8][$i] = true;
+            $reserved[$i][8] = true;
+        }
+        for ($i = 0; $i < 8; $i++) {
+            $reserved[8][$modules - 1 - $i] = true;
+            $reserved[$modules - 1 - $i][8] = true;
+        }
+    }
+
+    private function reserveVersionInfo(array &$reserved, int $modules): void
+    {
+        for ($y = 0; $y < 6; $y++) {
+            for ($x = $modules - 11; $x < $modules - 8; $x++) {
+                $reserved[$y][$x] = true;
+                $reserved[$x][$y] = true;
+            }
+        }
+    }
+
+    private function placeData(array &$matrix, array $reserved, int $modules, array $bytes): void
+    {
+        $bitStream = '';
+        foreach ($bytes as $b) {
+            $bitStream .= str_pad(decbin($b), 8, '0', STR_PAD_LEFT);
+        }
+        $cursor = 0;
+        $upward = true;
+        $col = $modules - 1;
+        while ($col > 0) {
+            if ($col === 6) {
+                $col--; // skip the timing column
+            }
+            for ($r = 0; $r < $modules; $r++) {
+                $y = $upward ? $modules - 1 - $r : $r;
+                for ($c = 0; $c < 2; $c++) {
+                    $x = $col - $c;
+                    if ($reserved[$y][$x] === true) {
+                        continue;
+                    }
+                    $bit = $cursor < strlen($bitStream) ? $bitStream[$cursor] === '1' : false;
+                    $matrix[$y][$x] = $bit;
+                    $cursor++;
+                }
+            }
+            $upward = !$upward;
+            $col -= 2;
+        }
+    }
+
+    private function applyMask(array &$matrix, array $reserved, int $modules, int $pattern): void
+    {
+        for ($y = 0; $y < $modules; $y++) {
+            for ($x = 0; $x < $modules; $x++) {
+                if ($reserved[$y][$x] === true) {
+                    continue;
+                }
+                $invert = false;
+                switch ($pattern) {
+                    case 0: $invert = (($x + $y) % 2) === 0; break;
+                    case 1: $invert = ($y % 2) === 0; break;
+                    case 2: $invert = ($x % 3) === 0; break;
+                    case 3: $invert = (($x + $y) % 3) === 0; break;
+                }
+                if ($invert === true) {
+                    $matrix[$y][$x] = $matrix[$y][$x] !== true;
+                }
+            }
+        }
+    }
+
+    private function writeFormatInfo(array &$matrix, int $modules, int $maskPattern): void
+    {
+        // EC level M = 00, mask = $maskPattern (3 bits) → 5-bit data, BCH(15,5) ECC.
+        $data = (0 << 3) | ($maskPattern & 0x7); // 5 bits
+        // Compute 10 EC bits via BCH(15,5) with generator 0b10100110111.
+        $bch = $data << 10;
+        for ($i = 14; $i >= 10; $i--) {
+            if (($bch & (1 << $i)) !== 0) {
+                $bch ^= 0x537 << ($i - 10);
+            }
+        }
+        $combined = (($data << 10) | $bch) ^ 0x5412;
+
+        // Place in two regions.
+        for ($i = 0; $i < 15; $i++) {
+            $bit = (($combined >> (14 - $i)) & 1) === 1;
+            // Around top-left finder
+            if ($i < 6) {
+                $matrix[$i][8] = $bit;
+            } elseif ($i < 8) {
+                $matrix[$i + 1][8] = $bit;
+            } elseif ($i === 8) {
+                $matrix[8][7] = $bit;
+            } else {
+                $matrix[8][14 - $i] = $bit;
+            }
+            // Right + bottom of finders
+            if ($i < 8) {
+                $matrix[8][$modules - 1 - $i] = $bit;
+            } else {
+                $matrix[$modules - 15 + $i][8] = $bit;
+            }
+        }
+    }
+
+    private function writeVersionInfo(array &$matrix, int $modules, int $version): void
+    {
+        // BCH(18,6) for version info.
+        $bch = $version << 12;
+        for ($i = 17; $i >= 12; $i--) {
+            if (($bch & (1 << $i)) !== 0) {
+                $bch ^= 0x1F25 << ($i - 12);
+            }
+        }
+        $combined = ($version << 12) | $bch;
+
+        for ($i = 0; $i < 18; $i++) {
+            $bit = (($combined >> $i) & 1) === 1;
+            $x = (int) ($i / 3);
+            $y = $modules - 11 + ($i % 3);
+            $matrix[$y][$x] = $bit;
+            $matrix[$x][$y] = $bit;
+        }
+    }
+}

--- a/web/_core/apps/invites.php
+++ b/web/_core/apps/invites.php
@@ -1,0 +1,16 @@
+<?php
+// Path: _core/apps/invites.php
+declare(strict_types=1);
+return [
+    'slug'        => 'invites',
+    'name'        => 'Invite Onboarding',
+    'description' => 'Generate single-use invite links so new members self-register with role pre-assigned.',
+    'icon'        => 'fa-solid fa-envelope-open-text',
+    'color'       => '#0ea5e9',
+    'category'    => 'admin',
+    'industries'  => [],
+    'route'       => 'invites',
+    'settingKey'  => 'invites.enabled',
+    'isCore'      => false,
+    'version'     => '1.0.0',
+];

--- a/web/_core/apps/offboarding.php
+++ b/web/_core/apps/offboarding.php
@@ -1,0 +1,16 @@
+<?php
+// Path: _core/apps/offboarding.php
+declare(strict_types=1);
+return [
+    'slug'        => 'offboarding',
+    'name'        => 'Offboarding',
+    'description' => 'One-click revocation when a volunteer / staff member leaves: sessions, credentials, roles, leadership.',
+    'icon'        => 'fa-solid fa-door-open',
+    'color'       => '#dc2626',
+    'category'    => 'admin',
+    'industries'  => [],
+    'route'       => 'offboarding',
+    'settingKey'  => 'offboarding.enabled',
+    'isCore'      => false,
+    'version'     => '1.0.0',
+];

--- a/web/_core/apps/reading-plans.php
+++ b/web/_core/apps/reading-plans.php
@@ -1,0 +1,16 @@
+<?php
+// Path: _core/apps/reading-plans.php
+declare(strict_types=1);
+return [
+    'slug'        => 'reading-plans',
+    'name'        => 'Reading Plans',
+    'description' => 'Daily reading plans with streak tracking and per-day check-off.',
+    'icon'        => 'fa-solid fa-book-open',
+    'color'       => '#a855f7',
+    'category'    => 'content',
+    'industries'  => ['church', 'book-club', 'training', 'school'],
+    'route'       => 'reading-plans',
+    'settingKey'  => 'reading_plans.enabled',
+    'isCore'      => false,
+    'version'     => '1.0.0',
+];

--- a/web/_sql/084_reading_plans.sql
+++ b/web/_sql/084_reading_plans.sql
@@ -1,0 +1,79 @@
+-- =============================================================================
+-- Migration 084: Reading Plans app (#265)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlan` (
+    `planID`       INT          NOT NULL AUTO_INCREMENT,
+    `siteID`       INT          NOT NULL DEFAULT 1,
+    `slug`         VARCHAR(100) NOT NULL,
+    `name`         VARCHAR(255) NOT NULL,
+    `description`  TEXT         DEFAULT NULL,
+    `kind`         ENUM('bible','book','curriculum','custom') NOT NULL DEFAULT 'bible',
+    `totalDays`    INT          NOT NULL DEFAULT 365,
+    `isPublic`     TINYINT(1)   NOT NULL DEFAULT 1,
+    `createdByID`  INT          DEFAULT NULL,
+    `createdAt`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`planID`),
+    UNIQUE KEY `uq_rp_slug_site` (`slug`, `siteID`),
+    KEY `idx_rp_site_kind` (`siteID`, `kind`),
+    CONSTRAINT `fk_rp_site` FOREIGN KEY (`siteID`) REFERENCES `tblSites` (`siteID`),
+    CONSTRAINT `fk_rp_creator` FOREIGN KEY (`createdByID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlanDay` (
+    `dayID`     INT          NOT NULL AUTO_INCREMENT,
+    `planID`    INT          NOT NULL,
+    `dayNumber` INT          NOT NULL,
+    `label`     VARCHAR(255) NOT NULL,
+    `content`   TEXT         DEFAULT NULL COMMENT 'Optional commentary / passage (markdown)',
+    PRIMARY KEY (`dayID`),
+    UNIQUE KEY `uq_rpd_plan_day` (`planID`, `dayNumber`),
+    CONSTRAINT `fk_rpd_plan` FOREIGN KEY (`planID`) REFERENCES `tblReadingPlan` (`planID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlanEnrollment` (
+    `enrollmentID` INT      NOT NULL AUTO_INCREMENT,
+    `planID`       INT      NOT NULL,
+    `userID`       INT      NOT NULL,
+    `startedAt`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `completedAt`  DATETIME DEFAULT NULL,
+    `currentDay`   INT      NOT NULL DEFAULT 1,
+    PRIMARY KEY (`enrollmentID`),
+    UNIQUE KEY `uq_rpe_plan_user` (`planID`, `userID`),
+    KEY `idx_rpe_user` (`userID`),
+    CONSTRAINT `fk_rpe_plan` FOREIGN KEY (`planID`) REFERENCES `tblReadingPlan` (`planID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_rpe_user` FOREIGN KEY (`userID`) REFERENCES `tblUsers` (`userID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlanProgress` (
+    `progressID`   INT      NOT NULL AUTO_INCREMENT,
+    `enrollmentID` INT      NOT NULL,
+    `dayNumber`    INT      NOT NULL,
+    `completedAt`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`progressID`),
+    UNIQUE KEY `uq_rpp_enrollment_day` (`enrollmentID`, `dayNumber`),
+    CONSTRAINT `fk_rpp_enrollment` FOREIGN KEY (`enrollmentID`) REFERENCES `tblReadingPlanEnrollment` (`enrollmentID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+-- 📖 Seed two pre-defined plans (Bible-in-a-Year + chronological).
+INSERT INTO `tblReadingPlan` (`siteID`, `slug`, `name`, `description`, `kind`, `totalDays`, `isPublic`) VALUES
+    (1, 'bible-in-a-year',           'Bible in a Year',           'Read the whole Bible over 365 days, roughly 3-4 chapters per day.', 'bible', 365, 1),
+    (1, 'bible-chronological',       'Bible Chronologically',     'Read the Bible in the order events occurred — Old Testament narrative then prophets, then Gospels in parallel.', 'bible', 365, 1)
+ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);
+
+-- 📋 Routes
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('reading-plans',          'reading-plans/index.php',  1),
+    ('reading-plans/my',       'reading-plans/my.php',     1),
+    ('reading-plans/plan',     'reading-plans/plan.php',   1),
+    ('reading-plans/enroll',   'reading-plans/enroll.php', 1),
+    ('reading-plans/check',    'reading-plans/check.php',  1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+-- ⚙️ Settings
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'reading_plans.enabled',          '0', '0', 0),
+    (NULL, 'reading_plans.daily_reminder',   '1', '1', 0),
+    (NULL, 'reading_plans.displayName',      'Reading Plans', 'Reading Plans', 0),
+    (NULL, 'reading_plans.displayIcon',      'fa-solid fa-book-open', 'fa-solid fa-book-open', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/085_qr.sql
+++ b/web/_sql/085_qr.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- Migration 085: QR code generator + CueRCode integration (#275)
+-- =============================================================================
+-- Routes for the QR endpoint + the admin provider-config page.
+-- Settings for the CueRCode adapter.
+--
+-- @link https://github.com/MWBMPartners/CueRCode
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('qr',                  'qr.php',                        1),
+    ('admin/settings/qr',   'admin/settings/qr/index.php',   1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'portal.qr.provider',              'local', 'local', 0),
+    (NULL, 'portal.qr.cuercode.api_endpoint', '',      '',      0),
+    (NULL, 'portal.qr.cuercode.api_key',      '',      '',      1)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/086_invites.sql
+++ b/web/_sql/086_invites.sql
@@ -1,0 +1,44 @@
+-- =============================================================================
+-- Migration 086: Invite onboarding app (#239)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `tblInvitation` (
+    `invitationID`  INT          NOT NULL AUTO_INCREMENT,
+    `siteID`        INT          NOT NULL DEFAULT 1,
+    `email`         VARCHAR(255) NOT NULL,
+    `tokenHash`     CHAR(64)     NOT NULL COMMENT 'SHA-256 of single-use plaintext token',
+    `intendedRole`  VARCHAR(64)  DEFAULT NULL COMMENT 'Role to grant on acceptance (e.g. volunteer/admin)',
+    `welcomeMessage` TEXT        DEFAULT NULL COMMENT 'Optional message rendered in the invite email',
+    `expiresAt`     DATETIME     NOT NULL,
+    `acceptedAt`    DATETIME     DEFAULT NULL,
+    `acceptedByID`  INT          DEFAULT NULL COMMENT 'FK → tblUsers once accepted',
+    `revokedAt`     DATETIME     DEFAULT NULL,
+    `revokedByID`   INT          DEFAULT NULL,
+    `createdByID`   INT          NOT NULL,
+    `createdAt`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`invitationID`),
+    UNIQUE KEY `uq_invite_token` (`tokenHash`),
+    KEY `idx_invite_site_email` (`siteID`, `email`),
+    KEY `idx_invite_status` (`acceptedAt`, `revokedAt`, `expiresAt`),
+    CONSTRAINT `fk_invite_site` FOREIGN KEY (`siteID`) REFERENCES `tblSites` (`siteID`),
+    CONSTRAINT `fk_invite_accepted_user` FOREIGN KEY (`acceptedByID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_invite_revoked_user`  FOREIGN KEY (`revokedByID`)  REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_invite_creator`       FOREIGN KEY (`createdByID`)  REFERENCES `tblUsers` (`userID`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+COMMENT='Single-use invite tokens for new-member onboarding';
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('invites',         'invites/index.php',        1),
+    ('invites/new',     'invites/new.php',          1),
+    ('invites/save',    'invites/save.php',         1),
+    ('invites/revoke',  'invites/revoke.php',       1),
+    ('auth/invite',     'invites/accept.php',       0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'invites.enabled',           '0',  '0',  0),
+    (NULL, 'invites.default_expiry_days','7',  '7',  0),
+    (NULL, 'invites.default_role',      'user','user',0),
+    (NULL, 'invites.displayName',       'Invitations', 'Invitations', 0),
+    (NULL, 'invites.displayIcon',       'fa-solid fa-envelope-open-text', 'fa-solid fa-envelope-open-text', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/087_offboarding.sql
+++ b/web/_sql/087_offboarding.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- Migration 087: Offboarding app (#240)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `tblOffboarding` (
+    `offboardingID`  INT          NOT NULL AUTO_INCREMENT,
+    `userID`         INT          NOT NULL,
+    `effectiveDate`  DATE         NOT NULL,
+    `reason`         VARCHAR(500) DEFAULT NULL,
+    `dataDisposition` ENUM('retain','anonymise','delete') NOT NULL DEFAULT 'retain',
+    `offboardedByID` INT          NOT NULL,
+    `offboardedAt`   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `rehiredAt`      DATETIME     DEFAULT NULL,
+    `rehiredByID`    INT          DEFAULT NULL,
+    `stepsLog`       JSON         DEFAULT NULL COMMENT 'Per-step success/failure outcomes',
+    PRIMARY KEY (`offboardingID`),
+    KEY `idx_offboard_user` (`userID`),
+    CONSTRAINT `fk_offboard_user`         FOREIGN KEY (`userID`)         REFERENCES `tblUsers`(`userID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_offboard_by`           FOREIGN KEY (`offboardedByID`) REFERENCES `tblUsers`(`userID`) ON DELETE RESTRICT,
+    CONSTRAINT `fk_offboard_rehired_by`   FOREIGN KEY (`rehiredByID`)    REFERENCES `tblUsers`(`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci
+COMMENT='Audit trail of user offboarding actions (#240)';
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('offboarding',         'offboarding/index.php',     1),
+    ('offboarding/user',    'offboarding/user.php',      1),
+    ('offboarding/do',      'offboarding/do.php',        1),
+    ('offboarding/rehire',  'offboarding/rehire.php',    1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'offboarding.enabled',          '0',  '0',  0),
+    (NULL, 'offboarding.undo_window_days', '7',  '7',  0),
+    (NULL, 'offboarding.displayName',      'Offboarding', 'Offboarding', 0),
+    (NULL, 'offboarding.displayIcon',      'fa-solid fa-door-open', 'fa-solid fa-door-open', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -3241,3 +3241,38 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'invites.displayName',       'Invitations', 'Invitations', 0),
     (NULL, 'invites.displayIcon',       'fa-solid fa-envelope-open-text', 'fa-solid fa-envelope-open-text', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('087_offboarding.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+CREATE TABLE IF NOT EXISTS `tblOffboarding` (
+    `offboardingID`  INT          NOT NULL AUTO_INCREMENT,
+    `userID`         INT          NOT NULL,
+    `effectiveDate`  DATE         NOT NULL,
+    `reason`         VARCHAR(500) DEFAULT NULL,
+    `dataDisposition` ENUM('retain','anonymise','delete') NOT NULL DEFAULT 'retain',
+    `offboardedByID` INT          NOT NULL,
+    `offboardedAt`   DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `rehiredAt`      DATETIME     DEFAULT NULL,
+    `rehiredByID`    INT          DEFAULT NULL,
+    `stepsLog`       JSON         DEFAULT NULL,
+    PRIMARY KEY (`offboardingID`),
+    KEY `idx_offboard_user` (`userID`),
+    CONSTRAINT `fk_offboard_user`         FOREIGN KEY (`userID`)         REFERENCES `tblUsers`(`userID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_offboard_by`           FOREIGN KEY (`offboardedByID`) REFERENCES `tblUsers`(`userID`) ON DELETE RESTRICT,
+    CONSTRAINT `fk_offboard_rehired_by`   FOREIGN KEY (`rehiredByID`)    REFERENCES `tblUsers`(`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('offboarding',         'offboarding/index.php',     1),
+    ('offboarding/user',    'offboarding/user.php',      1),
+    ('offboarding/do',      'offboarding/do.php',        1),
+    ('offboarding/rehire',  'offboarding/rehire.php',    1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'offboarding.enabled',          '0',  '0',  0),
+    (NULL, 'offboarding.undo_window_days', '7',  '7',  0),
+    (NULL, 'offboarding.displayName',      'Offboarding', 'Offboarding', 0),
+    (NULL, 'offboarding.displayIcon',      'fa-solid fa-door-open', 'fa-solid fa-door-open', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -3108,3 +3108,79 @@ INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('admin/captcha',      'admin/captcha/index.php', 1),
     ('admin/captcha/save', 'admin/captcha/save.php',  1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('084_reading_plans.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlan` (
+    `planID`       INT          NOT NULL AUTO_INCREMENT,
+    `siteID`       INT          NOT NULL DEFAULT 1,
+    `slug`         VARCHAR(100) NOT NULL,
+    `name`         VARCHAR(255) NOT NULL,
+    `description`  TEXT         DEFAULT NULL,
+    `kind`         ENUM('bible','book','curriculum','custom') NOT NULL DEFAULT 'bible',
+    `totalDays`    INT          NOT NULL DEFAULT 365,
+    `isPublic`     TINYINT(1)   NOT NULL DEFAULT 1,
+    `createdByID`  INT          DEFAULT NULL,
+    `createdAt`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`planID`),
+    UNIQUE KEY `uq_rp_slug_site` (`slug`, `siteID`),
+    KEY `idx_rp_site_kind` (`siteID`, `kind`),
+    CONSTRAINT `fk_rp_site` FOREIGN KEY (`siteID`) REFERENCES `tblSites` (`siteID`),
+    CONSTRAINT `fk_rp_creator` FOREIGN KEY (`createdByID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlanDay` (
+    `dayID`     INT          NOT NULL AUTO_INCREMENT,
+    `planID`    INT          NOT NULL,
+    `dayNumber` INT          NOT NULL,
+    `label`     VARCHAR(255) NOT NULL,
+    `content`   TEXT         DEFAULT NULL,
+    PRIMARY KEY (`dayID`),
+    UNIQUE KEY `uq_rpd_plan_day` (`planID`, `dayNumber`),
+    CONSTRAINT `fk_rpd_plan` FOREIGN KEY (`planID`) REFERENCES `tblReadingPlan` (`planID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlanEnrollment` (
+    `enrollmentID` INT      NOT NULL AUTO_INCREMENT,
+    `planID`       INT      NOT NULL,
+    `userID`       INT      NOT NULL,
+    `startedAt`    DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `completedAt`  DATETIME DEFAULT NULL,
+    `currentDay`   INT      NOT NULL DEFAULT 1,
+    PRIMARY KEY (`enrollmentID`),
+    UNIQUE KEY `uq_rpe_plan_user` (`planID`, `userID`),
+    KEY `idx_rpe_user` (`userID`),
+    CONSTRAINT `fk_rpe_plan` FOREIGN KEY (`planID`) REFERENCES `tblReadingPlan` (`planID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_rpe_user` FOREIGN KEY (`userID`) REFERENCES `tblUsers` (`userID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+CREATE TABLE IF NOT EXISTS `tblReadingPlanProgress` (
+    `progressID`   INT      NOT NULL AUTO_INCREMENT,
+    `enrollmentID` INT      NOT NULL,
+    `dayNumber`    INT      NOT NULL,
+    `completedAt`  DATETIME NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`progressID`),
+    UNIQUE KEY `uq_rpp_enrollment_day` (`enrollmentID`, `dayNumber`),
+    CONSTRAINT `fk_rpp_enrollment` FOREIGN KEY (`enrollmentID`) REFERENCES `tblReadingPlanEnrollment` (`enrollmentID`) ON DELETE CASCADE
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `tblReadingPlan` (`siteID`, `slug`, `name`, `description`, `kind`, `totalDays`, `isPublic`) VALUES
+    (1, 'bible-in-a-year',     'Bible in a Year',       'Read the whole Bible over 365 days, roughly 3-4 chapters per day.', 'bible', 365, 1),
+    (1, 'bible-chronological', 'Bible Chronologically', 'Read the Bible in the order events occurred.', 'bible', 365, 1)
+ON DUPLICATE KEY UPDATE `name` = VALUES(`name`);
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('reading-plans',          'reading-plans/index.php',  1),
+    ('reading-plans/my',       'reading-plans/my.php',     1),
+    ('reading-plans/plan',     'reading-plans/plan.php',   1),
+    ('reading-plans/enroll',   'reading-plans/enroll.php', 1),
+    ('reading-plans/check',    'reading-plans/check.php',  1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'reading_plans.enabled',          '0', '0', 0),
+    (NULL, 'reading_plans.daily_reminder',   '1', '1', 0),
+    (NULL, 'reading_plans.displayName',      'Reading Plans', 'Reading Plans', 0),
+    (NULL, 'reading_plans.displayIcon',      'fa-solid fa-book-open', 'fa-solid fa-book-open', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -3198,3 +3198,46 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'portal.qr.cuercode.api_endpoint', '',      '',      0),
     (NULL, 'portal.qr.cuercode.api_key',      '',      '',      1)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('086_invites.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+CREATE TABLE IF NOT EXISTS `tblInvitation` (
+    `invitationID`  INT          NOT NULL AUTO_INCREMENT,
+    `siteID`        INT          NOT NULL DEFAULT 1,
+    `email`         VARCHAR(255) NOT NULL,
+    `tokenHash`     CHAR(64)     NOT NULL,
+    `intendedRole`  VARCHAR(64)  DEFAULT NULL,
+    `welcomeMessage` TEXT        DEFAULT NULL,
+    `expiresAt`     DATETIME     NOT NULL,
+    `acceptedAt`    DATETIME     DEFAULT NULL,
+    `acceptedByID`  INT          DEFAULT NULL,
+    `revokedAt`     DATETIME     DEFAULT NULL,
+    `revokedByID`   INT          DEFAULT NULL,
+    `createdByID`   INT          NOT NULL,
+    `createdAt`     DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    PRIMARY KEY (`invitationID`),
+    UNIQUE KEY `uq_invite_token` (`tokenHash`),
+    KEY `idx_invite_site_email` (`siteID`, `email`),
+    KEY `idx_invite_status` (`acceptedAt`, `revokedAt`, `expiresAt`),
+    CONSTRAINT `fk_invite_site` FOREIGN KEY (`siteID`) REFERENCES `tblSites` (`siteID`),
+    CONSTRAINT `fk_invite_accepted_user` FOREIGN KEY (`acceptedByID`) REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_invite_revoked_user`  FOREIGN KEY (`revokedByID`)  REFERENCES `tblUsers` (`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_invite_creator`       FOREIGN KEY (`createdByID`)  REFERENCES `tblUsers` (`userID`) ON DELETE RESTRICT
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('invites',         'invites/index.php',        1),
+    ('invites/new',     'invites/new.php',          1),
+    ('invites/save',    'invites/save.php',         1),
+    ('invites/revoke',  'invites/revoke.php',       1),
+    ('auth/invite',     'invites/accept.php',       0)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'invites.enabled',           '0',  '0',  0),
+    (NULL, 'invites.default_expiry_days','7',  '7',  0),
+    (NULL, 'invites.default_role',      'user','user',0),
+    (NULL, 'invites.displayName',       'Invitations', 'Invitations', 0),
+    (NULL, 'invites.displayIcon',       'fa-solid fa-envelope-open-text', 'fa-solid fa-envelope-open-text', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -3184,3 +3184,17 @@ INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue
     (NULL, 'reading_plans.displayName',      'Reading Plans', 'Reading Plans', 0),
     (NULL, 'reading_plans.displayIcon',      'fa-solid fa-book-open', 'fa-solid fa-book-open', 0)
 ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+
+INSERT INTO `tblMigrations` (`filename`) VALUES ('085_qr.sql')
+ON DUPLICATE KEY UPDATE `filename` = `filename`;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('qr',                  'qr.php',                        1),
+    ('admin/settings/qr',   'admin/settings/qr/index.php',   1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'portal.qr.provider',              'local', 'local', 0),
+    (NULL, 'portal.qr.cuercode.api_endpoint', '',      '',      0),
+    (NULL, 'portal.qr.cuercode.api_key',      '',      '',      1)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/public_html/admin/settings/qr/index.php
+++ b/web/public_html/admin/settings/qr/index.php
@@ -1,0 +1,157 @@
+<?php
+// Path: public_html/admin/settings/qr/index.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — QR provider configuration 🔳
+ * -----------------------------------------------------------------------------
+ * Pick local generation vs the external CueRCode tracked-QR service.
+ *
+ * CueRCode integration (#275 — repo: github.com/MWBMPartners/CueRCode):
+ *   When provider='cuercode' and credentials are set, Portal\Core\Qr
+ *   first calls CueRCode to register the content + receive a tracking
+ *   URL, then encodes the tracking URL into the QR. Scans flow through
+ *   CueRCode (analytics) before landing on the underlying portal page.
+ *
+ * The adapter shape in Portal\Core\Qr::resolveContent() targets a generic
+ * { POST /register, body: {url, purpose}, response: {tracking_url} }
+ * contract. Update the request shape to match CueRCode's actual API
+ * once the project ships its public spec.
+ *
+ * @package   Portal\Admin
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/275
+ * @link      https://github.com/MWBMPartners/CueRCode
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Qr;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$flash = '';
+$flashType = 'info';
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST' && Auth::verifyCsrf($_POST['csrf_token'] ?? '') === true) {
+    $db = App::db();
+    $values = [
+        'portal.qr.provider'              => in_array($_POST['provider'] ?? 'local', ['local','cuercode'], true) ? (string) $_POST['provider'] : 'local',
+        'portal.qr.cuercode.api_endpoint' => trim((string) ($_POST['endpoint'] ?? '')),
+        'portal.qr.cuercode.api_key'      => trim((string) ($_POST['api_key']  ?? '')),
+    ];
+    try {
+        foreach ($values as $key => $val) {
+            $isSensitive = $key === 'portal.qr.cuercode.api_key' ? 1 : 0;
+            $stmt = $db->prepare(
+                'INSERT INTO tblSettings (siteID, settingKey, settingValue, defaultValue, isSensitive) '
+                . 'VALUES (NULL, ?, ?, ?, ?) '
+                . 'ON DUPLICATE KEY UPDATE settingValue = VALUES(settingValue), isSensitive = VALUES(isSensitive)'
+            );
+            if ($stmt !== false) {
+                $stmt->bind_param('sssi', $key, $val, $val, $isSensitive);
+                $stmt->execute();
+                $stmt->close();
+            }
+        }
+        $flash = 'QR settings saved.';
+        $flashType = 'success';
+    } catch (\Throwable $e) {
+        $flash = 'Save failed: ' . $e->getMessage();
+        $flashType = 'danger';
+    }
+}
+
+$settings = App::settings();
+$provider = (string) ($settings['portal']['qr']['provider'] ?? 'local');
+$endpoint = (string) ($settings['portal']['qr']['cuercode']['api_endpoint'] ?? '');
+$apiKey   = (string) ($settings['portal']['qr']['cuercode']['api_key'] ?? '');
+$apiKeyMasked = $apiKey !== '' ? str_repeat('•', max(8, min(strlen($apiKey), 24))) : '';
+
+$pageTitle   = 'QR Code Settings';
+$pageSection = 'admin';
+$breadcrumbs = ['Dashboard' => '/', 'Admin' => '/admin', 'Settings' => '/admin/settings', 'QR Codes' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+
+// Sample QR for preview.
+$portalUrl = (string) ($settings['site']['url'] ?? 'https://example.invalid/');
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-qrcode me-2"></i>QR Codes</h1>
+<p class="text-muted">Pick local generation or the external <a href="https://github.com/MWBMPartners/CueRCode" target="_blank" rel="noopener">CueRCode</a> tracked-QR service.</p>
+
+<?php if ($flash !== ''): ?>
+    <div class="alert alert-<?php echo htmlspecialchars($flashType, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($flash, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php endif; ?>
+
+<div class="row g-3">
+    <div class="col-md-8">
+        <form method="post">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h2 class="h6 mb-3">Provider</h2>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="provider" id="p_local" value="local" <?php echo $provider === 'local' ? 'checked' : ''; ?>>
+                        <label class="form-check-label" for="p_local">
+                            <strong>Local</strong> — generate in-portal with no external dependency.
+                        </label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="provider" id="p_cuer" value="cuercode" <?php echo $provider === 'cuercode' ? 'checked' : ''; ?>>
+                        <label class="form-check-label" for="p_cuer">
+                            <strong>CueRCode</strong> — tracked QRs via the MWBM CueRCode service. Scans flow through CueRCode for analytics before landing on the portal page.
+                        </label>
+                    </div>
+                </div>
+            </div>
+
+            <div class="card mb-3">
+                <div class="card-body">
+                    <h2 class="h6">CueRCode credentials</h2>
+                    <p class="form-text mb-2">Required only when provider = CueRCode.</p>
+                    <div class="mb-2">
+                        <label class="form-label small">API endpoint</label>
+                        <input type="url" name="endpoint" class="form-control form-control-sm" placeholder="https://api.cuercode.example/v1"
+                               value="<?php echo htmlspecialchars($endpoint, ENT_QUOTES, 'UTF-8'); ?>">
+                    </div>
+                    <div class="mb-2">
+                        <label class="form-label small">API key</label>
+                        <input type="password" name="api_key" class="form-control form-control-sm" autocomplete="new-password"
+                               placeholder="<?php echo $apiKeyMasked !== '' ? htmlspecialchars($apiKeyMasked, ENT_QUOTES, 'UTF-8') . ' (currently set)' : 'unset'; ?>">
+                        <div class="form-text">Stored encrypted via the existing settings sensitive-value pipeline. Leave empty to keep current.</div>
+                    </div>
+                </div>
+            </div>
+
+            <button type="submit" class="btn btn-primary">Save</button>
+            <a href="/admin/settings" class="btn btn-outline-secondary">All settings</a>
+        </form>
+    </div>
+    <div class="col-md-4">
+        <div class="card">
+            <div class="card-body text-center">
+                <h2 class="h6">Sample QR (your portal URL)</h2>
+                <object data="/qr?content=<?php echo urlencode($portalUrl); ?>&size=200" type="image/svg+xml" style="max-width:200px"></object>
+                <p class="small text-muted mt-2 mb-0"><code><?php echo htmlspecialchars($portalUrl, ENT_QUOTES, 'UTF-8'); ?></code></p>
+            </div>
+        </div>
+        <div class="card mt-3">
+            <div class="card-body small">
+                <h2 class="h6">Programmatic use</h2>
+                <pre class="mb-0"><code>use Portal\Core\Qr;
+$content = Qr::resolveContent($url, 'invite');
+[$mime, $bytes] = array_values(Qr::generate($content));</code></pre>
+            </div>
+        </div>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/calendar/account-feed.php
+++ b/web/public_html/calendar/account-feed.php
@@ -66,9 +66,20 @@ $host = $_SERVER['HTTP_HOST'] ?? 'portal';
                 https://<?php echo htmlspecialchars($host, ENT_QUOTES, 'UTF-8'); ?>/calendar.ics?token=<?php echo htmlspecialchars($newToken, ENT_QUOTES, 'UTF-8'); ?>
             </code>
         </div>
-        <p class="mt-2 small mb-0">
-            <strong>To use it:</strong> copy the URL above, then in your calendar app add a new subscription / iCal feed using this URL.
-        </p>
+        <div class="row g-3 mt-2">
+            <div class="col-md-8">
+                <p class="small mb-0">
+                    <strong>To use it:</strong> copy the URL above, then in your calendar app add a new subscription / iCal feed using this URL.
+                </p>
+            </div>
+            <div class="col-md-4 text-center">
+                <?php
+                $feedUrl = 'https://' . ($_SERVER['HTTP_HOST'] ?? 'portal') . '/calendar.ics?token=' . $newToken;
+                ?>
+                <p class="small text-muted mb-1">Scan on a phone:</p>
+                <object data="/qr?content=<?php echo urlencode($feedUrl); ?>&size=160" type="image/svg+xml" style="max-width:160px"></object>
+            </div>
+        </div>
     </div>
 <?php endif; ?>
 

--- a/web/public_html/calendar/feed.php
+++ b/web/public_html/calendar/feed.php
@@ -33,7 +33,7 @@ $db = App::db();
 // 🪞 Resolve the user's site for scoping. Multi-site users are not
 //    currently supported in the feed — picks their primary.
 $siteId = 1;
-$stmt = $db->prepare('SELECT siteID FROM tblUsers WHERE userID = ? LIMIT 1');
+$stmt = $db->prepare('SELECT siteID FROM tblUserSites WHERE userID = ? AND isActive = 1 ORDER BY siteID LIMIT 1');
 if ($stmt !== false) {
     $stmt->bind_param('i', $userId);
     $stmt->execute();

--- a/web/public_html/directory/index.php
+++ b/web/public_html/directory/index.php
@@ -26,12 +26,12 @@ $q = trim((string) ($_GET['q'] ?? ''));
 // 🔍 Search — name LIKE only (privacy by default). Result rows respect
 //    per-field visibility at display time.
 $users = [];
-$sql = 'SELECT userID, fullName, displayBio, displayPhone, email, displayAddress, displayPhoto, '
+$sql = 'SELECT userID, fullName, displayBio, displayPhone, emailAddress AS email, displayAddress, displayPhoto, '
      . '       visibilityName, visibilityRoles, visibilityEmail, visibilityPhone, visibilityAddress, '
      . '       visibilityBio, visibilityPhoto '
-     . 'FROM tblUsers WHERE siteID = ? AND isActive = 1';
-$types = 'i';
-$params = [$siteId];
+     . 'FROM tblUsers WHERE isActive = 1';
+$types = '';
+$params = [];
 if ($q !== '') {
     $sql .= ' AND fullName LIKE ?';
     $types .= 's';

--- a/web/public_html/directory/me.php
+++ b/web/public_html/directory/me.php
@@ -25,10 +25,10 @@ $stmt = $db->prepare(
     'SELECT displayBio, displayPhone, displayAddress, '
     . '       visibilityName, visibilityRoles, visibilityEmail, visibilityPhone, visibilityAddress, '
     . '       visibilityBio, visibilityPhoto '
-    . 'FROM tblUsers WHERE userID = ? AND siteID = ? LIMIT 1'
+    . 'FROM tblUsers WHERE userID = ? LIMIT 1'
 );
 if ($stmt !== false) {
-    $stmt->bind_param('ii', $userId, $siteId);
+    $stmt->bind_param('i', $userId);
     $stmt->execute();
     $u = $stmt->get_result()->fetch_assoc();
     $stmt->close();

--- a/web/public_html/directory/profile.php
+++ b/web/public_html/directory/profile.php
@@ -29,13 +29,13 @@ if ($id <= 0) {
 
 $u = null;
 $stmt = $db->prepare(
-    'SELECT userID, fullName, email, displayBio, displayPhone, displayAddress, displayPhoto, '
+    'SELECT userID, fullName, emailAddress AS email, displayBio, displayPhone, displayAddress, displayPhoto, '
     . '       visibilityName, visibilityRoles, visibilityEmail, visibilityPhone, visibilityAddress, '
     . '       visibilityBio, visibilityPhoto '
-    . 'FROM tblUsers WHERE userID = ? AND siteID = ? LIMIT 1'
+    . 'FROM tblUsers WHERE userID = ? LIMIT 1'
 );
 if ($stmt !== false) {
-    $stmt->bind_param('ii', $id, $siteId);
+    $stmt->bind_param('i', $id);
     $stmt->execute();
     $u = $stmt->get_result()->fetch_assoc();
     $stmt->close();

--- a/web/public_html/invites/accept.php
+++ b/web/public_html/invites/accept.php
@@ -1,0 +1,200 @@
+<?php
+// Path: public_html/invites/accept.php  →  /auth/invite?token=...
+/**
+ * Invite Onboarding — public acceptance page.
+ *
+ * GET  shows the self-registration form pre-filled with the invite's email.
+ * POST creates a tblUsers + tblLocalAccount row, marks the invitation
+ *      accepted, signs the user in, redirects to dashboard.
+ *
+ * @package   Portal\Invites
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/239
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+
+$token = (string) ($_GET['token'] ?? ($_POST['token'] ?? ''));
+$flash = '';
+$flashType = 'info';
+
+$invite = null;
+if (preg_match('/^[a-f0-9]{64}$/i', $token) === 1) {
+    $hash = hash('sha256', $token);
+    $db = App::db();
+    $stmt = $db->prepare(
+        'SELECT invitationID, siteID, email, intendedRole, welcomeMessage, '
+        . '       expiresAt, acceptedAt, revokedAt '
+        . 'FROM tblInvitation WHERE tokenHash = ? LIMIT 1'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('s', $hash);
+        $stmt->execute();
+        $invite = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    }
+}
+
+$valid = $invite !== null
+       && $invite['acceptedAt'] === null
+       && $invite['revokedAt'] === null
+       && strtotime((string) $invite['expiresAt']) > time();
+
+if ($valid === false) {
+    http_response_code(410);
+    $message = $invite === null
+        ? 'This invitation link is invalid.'
+        : ($invite['acceptedAt'] !== null
+            ? 'This invitation has already been accepted.'
+            : ($invite['revokedAt'] !== null
+                ? 'This invitation has been revoked.'
+                : 'This invitation has expired.'));
+    echo '<!doctype html><html><head><meta charset="utf-8"><meta name="robots" content="noindex,nofollow"><title>Invitation</title></head>'
+       . '<body style="font-family:system-ui;text-align:center;padding:4rem 1rem;">'
+       . '<h1>Invitation unavailable</h1><p>' . htmlspecialchars($message, ENT_QUOTES, 'UTF-8') . '</p>'
+       . '<p><a href="/">Return to portal</a></p></body></html>';
+    exit();
+}
+
+if ($_SERVER['REQUEST_METHOD'] === 'POST') {
+    if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+        $flash = 'Form expired — please reload the page.';
+        $flashType = 'danger';
+    } else {
+        $name     = trim((string) ($_POST['fullName'] ?? ''));
+        $password = (string) ($_POST['password'] ?? '');
+        $confirm  = (string) ($_POST['passwordConfirm'] ?? '');
+        $username = trim((string) ($_POST['username'] ?? ''));
+
+        if ($name === '' || $username === '') {
+            $flash = 'Name and username required.';
+            $flashType = 'danger';
+        } elseif (strlen($password) < 12) {
+            $flash = 'Password must be at least 12 characters.';
+            $flashType = 'danger';
+        } elseif ($password !== $confirm) {
+            $flash = 'Passwords do not match.';
+            $flashType = 'danger';
+        } else {
+            $db = App::db();
+            try {
+                $db->begin_transaction();
+
+                // Create user
+                $intendedRole = (string) ($invite['intendedRole'] ?? 'user');
+                $isAdmin = ($intendedRole === 'admin' ? 1 : 0);
+                $stmt = $db->prepare(
+                    'INSERT INTO tblUsers (fullName, emailAddress, isActive, isAdmin) '
+                    . 'VALUES (?, ?, 1, ?)'
+                );
+                if ($stmt === false) {
+                    throw new \RuntimeException('User prepare failed');
+                }
+                $stmt->bind_param('ssi', $name, $invite['email'], $isAdmin);
+                $stmt->execute();
+                $newUserId = (int) $stmt->insert_id;
+                $stmt->close();
+
+                // Site membership (tblUserSites)
+                $stmt = $db->prepare(
+                    'INSERT INTO tblUserSites (userID, siteID, isActive) VALUES (?, ?, 1)'
+                );
+                if ($stmt !== false) {
+                    $stmt->bind_param('ii', $newUserId, $invite['siteID']);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+
+                // Local account
+                $hash = password_hash($password, PASSWORD_DEFAULT);
+                $stmt = $db->prepare(
+                    'INSERT INTO tblLocalAccounts (userID, username, passwordHash) VALUES (?, ?, ?)'
+                );
+                if ($stmt !== false) {
+                    $stmt->bind_param('iss', $newUserId, $username, $hash);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+
+                // Mark invitation accepted
+                $stmt = $db->prepare(
+                    'UPDATE tblInvitation SET acceptedAt = NOW(), acceptedByID = ? WHERE invitationID = ?'
+                );
+                if ($stmt !== false) {
+                    $stmt->bind_param('ii', $newUserId, $invite['invitationID']);
+                    $stmt->execute();
+                    $stmt->close();
+                }
+
+                $db->commit();
+
+                // Sign in (write session)
+                $_SESSION['user_id'] = $newUserId;
+                $_SESSION['site_id'] = (int) $invite['siteID'];
+
+                header('Location: /');
+                exit();
+            } catch (\Throwable $e) {
+                $db->rollback();
+                $flash = 'Could not complete signup: ' . $e->getMessage();
+                $flashType = 'danger';
+            }
+        }
+    }
+}
+
+$portalName = (string) (App::settings()['site']['name'] ?? 'the portal');
+$csrf = Auth::csrfToken();
+?>
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width,initial-scale=1">
+<meta name="robots" content="noindex, nofollow">
+<title>Accept invitation — <?php echo htmlspecialchars($portalName, ENT_QUOTES, 'UTF-8'); ?></title>
+<style>
+:root{--bg:#f7f8fa;--surface:#fff;--text:#1b2330;--muted:#6b7280;--border:#e5e7eb;--primary:#5e6ad2;}
+@media (prefers-color-scheme:dark){:root{--bg:#0f1115;--surface:#161a22;--text:#e8eaf0;--muted:#9aa3b2;--border:#2c3441;}}
+body{font-family:system-ui,-apple-system,"Segoe UI",Roboto,sans-serif;background:var(--bg);color:var(--text);margin:0;padding:2rem 1rem;}
+.card{max-width:480px;margin:0 auto;background:var(--surface);border:1px solid var(--border);border-radius:.75rem;padding:1.5rem;}
+label{display:block;font-size:.875rem;margin:.75rem 0 .25rem;}
+input{width:100%;padding:.5rem;border:1px solid var(--border);border-radius:.375rem;background:var(--surface);color:var(--text);box-sizing:border-box;}
+button{margin-top:1rem;padding:.625rem 1.25rem;background:var(--primary);color:#fff;border:none;border-radius:.375rem;font-weight:500;cursor:pointer;}
+.flash{padding:.5rem;border-radius:.375rem;margin-bottom:1rem;}
+.flash-danger{background:#fee2e2;color:#991b1b;}
+.muted{color:var(--muted);font-size:.875rem;}
+</style>
+</head>
+<body>
+<div class="card">
+    <h1>Welcome to <?php echo htmlspecialchars($portalName, ENT_QUOTES, 'UTF-8'); ?></h1>
+    <?php if (trim((string) ($invite['welcomeMessage'] ?? '')) !== ''): ?>
+        <p><em><?php echo nl2br(htmlspecialchars((string) $invite['welcomeMessage'], ENT_QUOTES, 'UTF-8')); ?></em></p>
+    <?php endif; ?>
+    <p class="muted">Set up your account to accept this invitation.</p>
+    <?php if ($flash !== ''): ?>
+        <div class="flash flash-<?php echo htmlspecialchars($flashType, ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($flash, ENT_QUOTES, 'UTF-8'); ?></div>
+    <?php endif; ?>
+    <form method="post">
+        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+        <input type="hidden" name="token" value="<?php echo htmlspecialchars($token, ENT_QUOTES, 'UTF-8'); ?>">
+        <label>Email</label>
+        <input type="email" value="<?php echo htmlspecialchars((string) $invite['email'], ENT_QUOTES, 'UTF-8'); ?>" disabled>
+        <label>Your full name</label>
+        <input type="text" name="fullName" required maxlength="255">
+        <label>Choose a username</label>
+        <input type="text" name="username" required maxlength="50" pattern="[a-zA-Z0-9._\-]+">
+        <label>Password (min 12 chars)</label>
+        <input type="password" name="password" required minlength="12" autocomplete="new-password">
+        <label>Confirm password</label>
+        <input type="password" name="passwordConfirm" required minlength="12" autocomplete="new-password">
+        <button type="submit">Create my account</button>
+    </form>
+</div>
+</body>
+</html>

--- a/web/public_html/invites/index.php
+++ b/web/public_html/invites/index.php
@@ -1,0 +1,115 @@
+<?php
+// Path: public_html/invites/index.php
+/**
+ * Invite Onboarding — admin list of issued invitations.
+ *
+ * @package   Portal\Invites
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/239
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$db     = App::db();
+$siteId = Site::id();
+
+$invites = [];
+$stmt = $db->prepare(
+    'SELECT i.invitationID, i.email, i.intendedRole, i.expiresAt, '
+    . '       i.acceptedAt, i.revokedAt, i.createdAt, '
+    . '       u.fullName AS acceptedByName '
+    . 'FROM tblInvitation i '
+    . 'LEFT JOIN tblUsers u ON u.userID = i.acceptedByID '
+    . 'WHERE i.siteID = ? '
+    . 'ORDER BY i.createdAt DESC LIMIT 200'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('i', $siteId);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $invites[] = $r;
+    }
+    $stmt->close();
+}
+
+$now = time();
+$status = static function (array $r) use ($now): array {
+    if ($r['acceptedAt'] !== null) {
+        return ['Accepted', 'success'];
+    }
+    if ($r['revokedAt'] !== null) {
+        return ['Revoked', 'secondary'];
+    }
+    if (strtotime((string) $r['expiresAt']) < $now) {
+        return ['Expired', 'warning'];
+    }
+    return ['Pending', 'info'];
+};
+
+$pageTitle   = 'Invitations';
+$pageSection = 'invites';
+$breadcrumbs = ['Dashboard' => '/', 'Invitations' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-envelope-open-text me-2"></i>Invitations</h1>
+        <p class="text-secondary mb-0">Single-use invite links for new-member self-registration.</p>
+    </div>
+    <a href="/invites/new" class="btn btn-primary btn-sm"><i class="fa-solid fa-plus me-1"></i>New invitation</a>
+</div>
+
+<?php if (count($invites) === 0): ?>
+    <div class="alert alert-info">No invitations sent yet.</div>
+<?php else: ?>
+    <div class="card">
+        <div class="card-body">
+            <div class="portal-data-list">
+                <?php foreach ($invites as $r):
+                    [$label, $cls] = $status($r);
+                ?>
+                    <div class="row py-2 border-bottom align-items-center">
+                        <div class="col-md-4"><strong><?php echo htmlspecialchars((string) $r['email'], ENT_QUOTES, 'UTF-8'); ?></strong></div>
+                        <div class="col-md-2"><span class="badge bg-light text-dark"><?php echo htmlspecialchars((string) ($r['intendedRole'] ?? 'user'), ENT_QUOTES, 'UTF-8'); ?></span></div>
+                        <div class="col-md-2"><span class="badge bg-<?php echo $cls; ?>"><?php echo $label; ?></span></div>
+                        <div class="col-md-2 small text-muted">
+                            <?php if ($r['acceptedAt'] !== null): ?>
+                                Accepted <?php echo htmlspecialchars(date('j M', strtotime((string) $r['acceptedAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                                <?php if ($r['acceptedByName'] !== null): ?>
+                                    <br>→ <?php echo htmlspecialchars((string) $r['acceptedByName'], ENT_QUOTES, 'UTF-8'); ?>
+                                <?php endif; ?>
+                            <?php else: ?>
+                                Expires <?php echo htmlspecialchars(date('j M', strtotime((string) $r['expiresAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                            <?php endif; ?>
+                        </div>
+                        <div class="col-md-2 text-end">
+                            <?php if ($label === 'Pending'): ?>
+                                <form method="post" action="/invites/revoke" class="d-inline">
+                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <input type="hidden" name="invitationID" value="<?php echo (int) $r['invitationID']; ?>">
+                                    <button type="submit" class="btn btn-outline-danger btn-sm"
+                                            data-confirm="Revoke this invitation? The link will no longer work." data-confirm-destructive="true">Revoke</button>
+                                </form>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/invites/new.php
+++ b/web/public_html/invites/new.php
@@ -1,0 +1,73 @@
+<?php
+// Path: public_html/invites/new.php
+/**
+ * Invite Onboarding — admin form to create new invitations (single + bulk).
+ *
+ * @package   Portal\Invites
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/239
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$settings = App::settings();
+$defaultExpiry = (int) ($settings['invites']['default_expiry_days'] ?? 7);
+$defaultRole   = (string) ($settings['invites']['default_role'] ?? 'user');
+
+$pageTitle   = 'New invitation';
+$pageSection = 'invites';
+$breadcrumbs = ['Dashboard' => '/', 'Invitations' => '/invites', 'New' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-envelope-open-text me-2"></i>New invitation</h1>
+<p class="text-muted">Generate one or more single-use invite links. Recipients self-register with the assigned role pre-set.</p>
+
+<div class="card">
+    <div class="card-body">
+        <form method="post" action="/invites/save">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <div class="row g-2">
+                <div class="col-12">
+                    <label class="form-label">Email addresses (one per line)</label>
+                    <textarea name="emails" class="form-control" rows="5" required placeholder="jane@example.org&#10;john@example.org"></textarea>
+                    <div class="form-text">One invitation will be generated per address. Duplicate active invitations to the same address are skipped.</div>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Role on acceptance</label>
+                    <select name="role" class="form-select">
+                        <?php foreach (['user', 'volunteer', 'staff', 'admin'] as $role): ?>
+                            <option value="<?php echo htmlspecialchars($role, ENT_QUOTES, 'UTF-8'); ?>" <?php echo $role === $defaultRole ? 'selected' : ''; ?>>
+                                <?php echo htmlspecialchars($role, ENT_QUOTES, 'UTF-8'); ?>
+                            </option>
+                        <?php endforeach; ?>
+                    </select>
+                </div>
+                <div class="col-md-4">
+                    <label class="form-label">Expires in (days)</label>
+                    <input type="number" name="expiryDays" min="1" max="90" class="form-control" value="<?php echo $defaultExpiry; ?>">
+                </div>
+                <div class="col-12">
+                    <label class="form-label">Welcome message (optional, markdown)</label>
+                    <textarea name="welcomeMessage" class="form-control" rows="3" placeholder="Anything personal to say in the invite email…"></textarea>
+                </div>
+            </div>
+            <div class="mt-3">
+                <button type="submit" class="btn btn-primary">Generate invitations</button>
+                <a href="/invites" class="btn btn-outline-secondary">Cancel</a>
+            </div>
+        </form>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/invites/revoke.php
+++ b/web/public_html/invites/revoke.php
@@ -1,0 +1,45 @@
+<?php
+// Path: public_html/invites/revoke.php
+/**
+ * Invite Onboarding — revoke a pending invitation.
+ *
+ * @package   Portal\Invites
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/239
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$id     = (int) ($_POST['invitationID'] ?? 0);
+
+if ($id > 0) {
+    $stmt = $db->prepare(
+        'UPDATE tblInvitation SET revokedAt = NOW(), revokedByID = ? '
+        . 'WHERE invitationID = ? AND siteID = ? AND acceptedAt IS NULL AND revokedAt IS NULL'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('iii', $userId, $id, $siteId);
+        $stmt->execute();
+        $stmt->close();
+    }
+}
+
+header('Location: /invites');
+exit();

--- a/web/public_html/invites/save.php
+++ b/web/public_html/invites/save.php
@@ -1,0 +1,114 @@
+<?php
+// Path: public_html/invites/save.php
+/**
+ * Invite Onboarding — POST handler. Issues one invitation per email address,
+ * stores SHA-256 hash, sends invite email when Mailer is configured.
+ *
+ * @package   Portal\Invites
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/239
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+$emailsRaw = (string) ($_POST['emails'] ?? '');
+$role      = (string) ($_POST['role'] ?? 'user');
+$days      = max(1, min(90, (int) ($_POST['expiryDays'] ?? 7)));
+$message   = trim((string) ($_POST['welcomeMessage'] ?? ''));
+
+$emails = array_filter(
+    array_map('trim', preg_split('/[\r\n,]+/', $emailsRaw) ?: []),
+    static fn (string $e): bool => $e !== '' && filter_var($e, FILTER_VALIDATE_EMAIL) !== false
+);
+if (count($emails) === 0) {
+    header('Location: /invites/new');
+    exit();
+}
+
+$expiresAt = date('Y-m-d H:i:s', strtotime('+' . $days . ' days'));
+$host      = $_SERVER['HTTP_HOST'] ?? 'portal';
+$portalName = (string) (App::settings()['site']['name'] ?? 'the portal');
+$siteUrl    = (string) (App::settings()['site']['url'] ?? ('https://' . $host));
+
+$issued = 0;
+foreach (array_unique($emails) as $email) {
+    // Skip if an unredeemed unrevoked unexpired invite already exists.
+    $stmt = $db->prepare(
+        'SELECT 1 FROM tblInvitation '
+        . 'WHERE siteID = ? AND email = ? AND acceptedAt IS NULL AND revokedAt IS NULL AND expiresAt > NOW() '
+        . 'LIMIT 1'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('is', $siteId, $email);
+        $stmt->execute();
+        $exists = $stmt->get_result()->fetch_row() !== null;
+        $stmt->close();
+        if ($exists === true) {
+            continue;
+        }
+    }
+
+    $plaintext = bin2hex(random_bytes(32));
+    $hash      = hash('sha256', $plaintext);
+
+    try {
+        $stmt = $db->prepare(
+            'INSERT INTO tblInvitation (siteID, email, tokenHash, intendedRole, welcomeMessage, expiresAt, createdByID) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        if ($stmt !== false) {
+            $msg = $message !== '' ? $message : null;
+            $stmt->bind_param('isssssi', $siteId, $email, $hash, $role, $msg, $expiresAt, $userId);
+            $stmt->execute();
+            $stmt->close();
+            $issued++;
+        }
+    } catch (\Throwable $e) {
+        \Portal\Core\Logger::errorPlatform('Invites', 'Warning', 'SAVE', $e->getMessage(), '');
+        continue;
+    }
+
+    // Send invite email via Mailer + templates/email/invite.html.php (#243).
+    if (class_exists('Portal\\Core\\Mailer') === true) {
+        try {
+            \Portal\Core\Mailer::sendTemplated(
+                $email,
+                'You\'re invited to ' . $portalName,
+                'invite',
+                [
+                    'inviterName' => '',
+                    'portalName'  => $portalName,
+                    'inviteUrl'   => rtrim($siteUrl, '/') . '/auth/invite?token=' . $plaintext,
+                    'expiresAt'   => $days . ' days',
+                    'message'     => $message,
+                ]
+            );
+        } catch (\Throwable $ignored) {
+            // Mailer is best-effort here; the invite row exists and the admin
+            // can copy the URL from /invites if email isn't configured.
+        }
+    }
+}
+
+$_SESSION['flash_msg']  = sprintf('Issued %d invitation(s).', $issued);
+$_SESSION['flash_type'] = 'success';
+header('Location: /invites');
+exit();

--- a/web/public_html/offboarding/do.php
+++ b/web/public_html/offboarding/do.php
@@ -1,0 +1,139 @@
+<?php
+// Path: public_html/offboarding/do.php
+/**
+ * Offboarding — POST handler that performs revocation across multiple
+ * tables in a transaction. Records per-step outcomes in tblOffboarding.stepsLog.
+ *
+ * @package   Portal\Offboarding
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/240
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db        = App::db();
+$adminId   = (int) ($_SESSION['user_id'] ?? 0);
+$userId    = (int) ($_POST['userID'] ?? 0);
+$reason    = trim((string) ($_POST['reason'] ?? ''));
+$disp      = (string) ($_POST['dataDisposition'] ?? 'retain');
+$effective = (string) ($_POST['effectiveDate'] ?? date('Y-m-d'));
+
+if ($userId <= 0 || $reason === '') {
+    header('Location: /admin/users');
+    exit();
+}
+if (in_array($disp, ['retain','anonymise','delete'], true) === false) {
+    $disp = 'retain';
+}
+if ($userId === $adminId) {
+    $_SESSION['flash_msg']  = "You can't offboard your own account.";
+    $_SESSION['flash_type'] = 'danger';
+    header('Location: /admin/users');
+    exit();
+}
+
+$stepsLog = [];
+
+/**
+ * Run a DML statement; record success / error.
+ *
+ * @return int Affected rows (0 on error or no matches).
+ */
+$run = function (string $label, string $sql, array $params, string $types) use ($db, &$stepsLog): int {
+    try {
+        $stmt = $db->prepare($sql);
+        if ($stmt === false) {
+            $stepsLog[] = ['step' => $label, 'ok' => false, 'error' => $db->error];
+            return 0;
+        }
+        $stmt->bind_param($types, ...$params);
+        $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+        $stepsLog[] = ['step' => $label, 'ok' => true, 'affected' => $affected];
+        return $affected;
+    } catch (\Throwable $e) {
+        $stepsLog[] = ['step' => $label, 'ok' => false, 'error' => $e->getMessage()];
+        return 0;
+    }
+};
+
+try {
+    $db->begin_transaction();
+
+    // 1. Deactivate the user (no sign-in).
+    $run('deactivate_user',
+        'UPDATE tblUsers SET isActive = 0 WHERE userID = ?',
+        [$userId], 'i'
+    );
+
+    // 2. Delete passkeys / WebAuthn credentials.
+    $run('delete_webauthn',
+        'DELETE FROM tblWebAuthnCredentials WHERE userID = ?',
+        [$userId], 'i'
+    );
+
+    // 3. Disable the local-account password — clear hash so it's unusable.
+    //    A future rehire requires the user to reset via the forgot-password
+    //    flow.
+    $run('clear_password_hash',
+        "UPDATE tblLocalAccounts SET passwordHash = '' WHERE userID = ?",
+        [$userId], 'i'
+    );
+
+    // 4. End site memberships.
+    $run('end_site_memberships',
+        'UPDATE tblUserSites SET isActive = 0 WHERE userID = ?',
+        [$userId], 'i'
+    );
+
+    // 5. End leadership assignments (any with NULL endDate).
+    $run('end_leadership_assignments',
+        'UPDATE tblLeadershipAssignments SET endDate = ? WHERE userID = ? AND endDate IS NULL',
+        [$effective, $userId], 'si'
+    );
+
+    // 6. Remove user role assignments.
+    $run('delete_user_roles',
+        'DELETE FROM tblUserRoles WHERE userID = ?',
+        [$userId], 'i'
+    );
+
+    // 7. Audit row.
+    $logJson = json_encode($stepsLog);
+    $stmt = $db->prepare(
+        'INSERT INTO tblOffboarding (userID, effectiveDate, reason, dataDisposition, offboardedByID, stepsLog) '
+        . 'VALUES (?, ?, ?, ?, ?, ?)'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('isssis', $userId, $effective, $reason, $disp, $adminId, $logJson);
+        $stmt->execute();
+        $stmt->close();
+    }
+
+    $db->commit();
+
+    $_SESSION['flash_msg']  = 'User offboarded. Audit row + per-step outcomes recorded.';
+    $_SESSION['flash_type'] = 'success';
+} catch (\Throwable $e) {
+    $db->rollback();
+    \Portal\Core\Logger::errorPlatform('Offboarding', 'Critical', 'OFFBOARD_FAIL', $e->getMessage(), 'userID=' . $userId);
+    $_SESSION['flash_msg']  = 'Offboarding failed: ' . $e->getMessage();
+    $_SESSION['flash_type'] = 'danger';
+}
+
+header('Location: /offboarding');
+exit();

--- a/web/public_html/offboarding/index.php
+++ b/web/public_html/offboarding/index.php
@@ -1,0 +1,105 @@
+<?php
+// Path: public_html/offboarding/index.php
+/**
+ * Offboarding — list of recent offboarding actions (audit view).
+ *
+ * @package   Portal\Offboarding
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/240
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$db = App::db();
+
+$rows = [];
+$rs = $db->query(
+    'SELECT o.offboardingID, o.userID, o.effectiveDate, o.reason, o.dataDisposition, '
+    . '       o.offboardedAt, o.rehiredAt, '
+    . '       u.fullName, u.emailAddress, '
+    . '       b.fullName AS byName '
+    . 'FROM tblOffboarding o '
+    . 'JOIN tblUsers u ON u.userID = o.userID '
+    . 'LEFT JOIN tblUsers b ON b.userID = o.offboardedByID '
+    . 'ORDER BY o.offboardedAt DESC LIMIT 100'
+);
+if ($rs !== false) {
+    while ($r = $rs->fetch_assoc()) {
+        $rows[] = $r;
+    }
+    $rs->free();
+}
+
+$undoWindowDays = (int) (App::settings()['offboarding']['undo_window_days'] ?? 7);
+
+$pageTitle   = 'Offboarding';
+$pageSection = 'offboarding';
+$breadcrumbs = ['Dashboard' => '/', 'Offboarding' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-door-open me-2 text-danger"></i>Offboarding</h1>
+        <p class="text-secondary mb-0">Revoke access when a volunteer or staff member leaves. <?php echo $undoWindowDays; ?>-day undo window.</p>
+    </div>
+    <a href="/admin/users" class="btn btn-outline-secondary btn-sm">Pick user → /admin/users</a>
+</div>
+
+<div class="alert alert-info small">
+    To offboard a user, navigate to <a href="/admin/users">/admin/users</a> → click the user → "Offboard" action. This page lists what's already been done.
+</div>
+
+<?php if (count($rows) === 0): ?>
+    <div class="alert alert-secondary">No offboarding events recorded.</div>
+<?php else: ?>
+    <div class="card">
+        <div class="card-body">
+            <div class="portal-data-list">
+                <?php foreach ($rows as $r):
+                    $canUndo = $r['rehiredAt'] === null &&
+                        strtotime((string) $r['offboardedAt']) > (time() - $undoWindowDays * 86400);
+                ?>
+                    <div class="row py-2 border-bottom align-items-center">
+                        <div class="col-md-3">
+                            <strong><?php echo htmlspecialchars((string) $r['fullName'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                            <br><span class="small text-muted"><?php echo htmlspecialchars((string) $r['emailAddress'], ENT_QUOTES, 'UTF-8'); ?></span>
+                        </div>
+                        <div class="col-md-2 small">
+                            <?php echo htmlspecialchars(date('j M Y', strtotime((string) $r['offboardedAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                            <br><span class="text-muted">by <?php echo htmlspecialchars((string) ($r['byName'] ?? ''), ENT_QUOTES, 'UTF-8'); ?></span>
+                        </div>
+                        <div class="col-md-2"><span class="badge bg-light text-dark"><?php echo htmlspecialchars((string) $r['dataDisposition'], ENT_QUOTES, 'UTF-8'); ?></span></div>
+                        <div class="col-md-3 small text-muted"><?php echo htmlspecialchars((string) ($r['reason'] ?? '—'), ENT_QUOTES, 'UTF-8'); ?></div>
+                        <div class="col-md-2 text-end">
+                            <?php if ($r['rehiredAt'] !== null): ?>
+                                <span class="badge bg-success">Rehired</span>
+                            <?php elseif ($canUndo === true): ?>
+                                <form method="post" action="/offboarding/rehire" class="d-inline">
+                                    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                                    <input type="hidden" name="offboardingID" value="<?php echo (int) $r['offboardingID']; ?>">
+                                    <button type="submit" class="btn btn-outline-success btn-sm"
+                                            data-confirm="Rehire this user? Their account becomes active again — they'll need to set a new password.">Rehire</button>
+                                </form>
+                            <?php else: ?>
+                                <span class="small text-muted">Window passed</span>
+                            <?php endif; ?>
+                        </div>
+                    </div>
+                <?php endforeach; ?>
+            </div>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/offboarding/rehire.php
+++ b/web/public_html/offboarding/rehire.php
@@ -1,0 +1,92 @@
+<?php
+// Path: public_html/offboarding/rehire.php
+/**
+ * Offboarding — reactivate a user within the undo window. Restores
+ * isActive flags but NOT credentials; the user must reset password
+ * via /forgot-password to sign in.
+ *
+ * @package   Portal\Offboarding
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/240
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db      = App::db();
+$adminId = (int) ($_SESSION['user_id'] ?? 0);
+$id      = (int) ($_POST['offboardingID'] ?? 0);
+
+$undoWindowDays = (int) (App::settings()['offboarding']['undo_window_days'] ?? 7);
+
+// Locate the offboarding row + confirm within undo window.
+$o = null;
+$stmt = $db->prepare(
+    'SELECT offboardingID, userID, offboardedAt, rehiredAt FROM tblOffboarding WHERE offboardingID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('i', $id);
+    $stmt->execute();
+    $o = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+if ($o === null || $o['rehiredAt'] !== null) {
+    header('Location: /offboarding');
+    exit();
+}
+$ageDays = (time() - strtotime((string) $o['offboardedAt'])) / 86400;
+if ($ageDays > $undoWindowDays) {
+    $_SESSION['flash_msg']  = 'Undo window has passed.';
+    $_SESSION['flash_type'] = 'danger';
+    header('Location: /offboarding');
+    exit();
+}
+
+$userId = (int) $o['userID'];
+
+try {
+    $db->begin_transaction();
+    // Reactivate user + site membership. NOT credentials — user must reset.
+    $stmt = $db->prepare('UPDATE tblUsers SET isActive = 1 WHERE userID = ?');
+    if ($stmt !== false) {
+        $stmt->bind_param('i', $userId);
+        $stmt->execute();
+        $stmt->close();
+    }
+    $stmt = $db->prepare('UPDATE tblUserSites SET isActive = 1 WHERE userID = ?');
+    if ($stmt !== false) {
+        $stmt->bind_param('i', $userId);
+        $stmt->execute();
+        $stmt->close();
+    }
+    $stmt = $db->prepare(
+        'UPDATE tblOffboarding SET rehiredAt = NOW(), rehiredByID = ? WHERE offboardingID = ?'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('ii', $adminId, $id);
+        $stmt->execute();
+        $stmt->close();
+    }
+    $db->commit();
+    $_SESSION['flash_msg']  = 'User rehired. They must reset their password to sign in.';
+    $_SESSION['flash_type'] = 'success';
+} catch (\Throwable $e) {
+    $db->rollback();
+    $_SESSION['flash_msg']  = 'Rehire failed: ' . $e->getMessage();
+    $_SESSION['flash_type'] = 'danger';
+}
+
+header('Location: /offboarding');
+exit();

--- a/web/public_html/offboarding/user.php
+++ b/web/public_html/offboarding/user.php
@@ -1,0 +1,97 @@
+<?php
+// Path: public_html/offboarding/user.php
+/**
+ * Offboarding — confirmation page for a single user (admin-only).
+ *
+ * @package   Portal\Offboarding
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/240
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+$db     = App::db();
+$userId = (int) ($_GET['id'] ?? 0);
+if ($userId <= 0) {
+    header('Location: /admin/users');
+    exit();
+}
+
+$u = null;
+$stmt = $db->prepare('SELECT userID, fullName, emailAddress, isActive FROM tblUsers WHERE userID = ? LIMIT 1');
+if ($stmt !== false) {
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $u = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+if ($u === null) {
+    http_response_code(404);
+    exit('User not found');
+}
+
+$pageTitle   = 'Offboard ' . $u['fullName'];
+$pageSection = 'offboarding';
+$breadcrumbs = ['Dashboard' => '/', 'Admin' => '/admin', 'Users' => '/admin/users', 'Offboard' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-door-open me-2 text-danger"></i>Offboard <?php echo htmlspecialchars((string) $u['fullName'], ENT_QUOTES, 'UTF-8'); ?></h1>
+
+<div class="alert alert-warning">
+    <strong>Offboarding will:</strong>
+    <ul class="mb-0">
+        <li>Mark the user inactive (no longer able to sign in)</li>
+        <li>Delete every passkey / WebAuthn credential</li>
+        <li>Disable the local-account password (cleared hash)</li>
+        <li>End active site memberships (<code>tblUserSites.isActive = 0</code>)</li>
+        <li>End leadership assignments (<code>endDate = NOW()</code> on open rows)</li>
+        <li>Remove role assignments</li>
+        <li>Audit-log the action to <code>tblOffboarding</code> with per-step success/failure</li>
+    </ul>
+    <p class="mt-2 mb-0">Within the configured undo window, an admin can rehire the user from <a href="/offboarding">/offboarding</a> — the account is reactivated but credentials are NOT restored; the user must reset password and re-enrol passkeys.</p>
+</div>
+
+<form method="post" action="/offboarding/do">
+    <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+    <input type="hidden" name="userID" value="<?php echo (int) $u['userID']; ?>">
+    <div class="card">
+        <div class="card-body">
+            <div class="mb-3">
+                <label class="form-label">Reason (audit-logged)</label>
+                <input type="text" name="reason" class="form-control" maxlength="500" placeholder="e.g. Left the volunteer team / moved away" required>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Data disposition</label>
+                <select name="dataDisposition" class="form-select">
+                    <option value="retain">Retain — keep user data unchanged (default)</option>
+                    <option value="anonymise">Anonymise — replace PII with tombstone (GDPR follow-up via #235)</option>
+                    <option value="delete">Delete — invoke right-to-erasure (GDPR follow-up via #235)</option>
+                </select>
+                <div class="form-text">Anonymise / Delete dispositions are recorded but the actual data transformation is performed by #235 GDPR engine when that ships. For now, both behave like "retain" with a flag for the follow-up batch run.</div>
+            </div>
+            <div class="mb-3">
+                <label class="form-label">Effective date</label>
+                <input type="date" name="effectiveDate" class="form-control" value="<?php echo date('Y-m-d'); ?>" required>
+            </div>
+            <button type="submit" class="btn btn-danger"
+                    data-confirm="Offboard <?php echo htmlspecialchars((string) $u['fullName'], ENT_QUOTES, 'UTF-8'); ?>? This deletes their credentials. Within the undo window the account can be reactivated but they'll need to re-enrol." data-confirm-destructive="true"
+                    data-confirm-confirm-label="Offboard">
+                Offboard user
+            </button>
+            <a href="/admin/users" class="btn btn-outline-secondary">Cancel</a>
+        </div>
+    </div>
+</form>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/qr.php
+++ b/web/public_html/qr.php
@@ -1,0 +1,72 @@
+<?php
+// Path: public_html/qr.php
+/**
+ * -----------------------------------------------------------------------------
+ * QR Code endpoint 🔳
+ * -----------------------------------------------------------------------------
+ * Renders a QR code for any content string. Login-required by default to
+ * prevent abuse as an arbitrary-content image generator; specific public
+ * use cases (visitor capture form, calendar feed) can pre-render server-
+ * side via Portal\Core\Qr directly instead of fetching this endpoint.
+ *
+ * Parameters:
+ *   content   string  — text to encode (required, max 500 chars)
+ *   size      int     — pixel size 64-1024 (default 256)
+ *   format    string  — 'svg' (default) or 'png'
+ *   ecc       string  — 'L'|'M'|'Q'|'H' (default 'M')
+ *   fg / bg   hex     — colours (#000000 / #ffffff)
+ *   caption   string  — optional caption below the QR (max 60 chars)
+ *   provider  string  — 'local' (default) or 'cuercode' — if 'cuercode'
+ *                       and configured, the content is first registered
+ *                       with CueRCode and the returned tracking URL is
+ *                       what gets encoded.
+ *
+ * @package   Portal
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/275
+ * @link      https://github.com/MWBMPartners/CueRCode
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Qr;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$content = trim((string) ($_GET['content'] ?? ''));
+if ($content === '' || strlen($content) > 500) {
+    http_response_code(400);
+    header('Content-Type: text/plain');
+    exit('Bad content parameter');
+}
+
+$opts = [
+    'size'    => (int) ($_GET['size']    ?? 256),
+    'format'  => (string) ($_GET['format']  ?? 'svg'),
+    'ecc'     => (string) ($_GET['ecc']     ?? 'M'),
+    'fg'      => (string) ($_GET['fg']      ?? '#000000'),
+    'bg'      => (string) ($_GET['bg']      ?? '#ffffff'),
+    'caption' => substr((string) ($_GET['caption'] ?? ''), 0, 60),
+];
+
+// 🪞 If the URL forces provider=cuercode (and the org has configured CueRCode
+//    credentials), resolve content via CueRCode to get the tracking URL.
+$encodeContent = $content;
+if (((string) ($_GET['provider'] ?? '')) === 'cuercode') {
+    $encodeContent = Qr::resolveContent($content, (string) ($_GET['purpose'] ?? 'general'));
+}
+
+try {
+    $result = Qr::generate($encodeContent, $opts);
+} catch (\Throwable $e) {
+    http_response_code(500);
+    header('Content-Type: text/plain');
+    exit('Could not generate QR: ' . $e->getMessage());
+}
+
+header('Content-Type: ' . $result['mime']);
+header('Cache-Control: private, max-age=300');
+echo $result['bytes'];

--- a/web/public_html/reading-plans/check.php
+++ b/web/public_html/reading-plans/check.php
@@ -1,0 +1,102 @@
+<?php
+// Path: public_html/reading-plans/check.php
+/**
+ * Reading Plans — POST handler to mark a day complete + advance the user.
+ *
+ * Atomic in a transaction:
+ *   1. INSERT progress row (idempotent — ON DUPLICATE KEY UPDATE no-op).
+ *   2. UPDATE enrollment.currentDay = currentDay + 1 (capped at totalDays).
+ *   3. UPDATE enrollment.completedAt when currentDay reaches totalDays + 1.
+ *
+ * @package   Portal\ReadingPlans
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/265
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db           = App::db();
+$userId       = (int) ($_SESSION['user_id'] ?? 0);
+$enrollmentId = (int) ($_POST['enrollmentID'] ?? 0);
+$dayNumber    = (int) ($_POST['dayNumber'] ?? 0);
+
+if ($enrollmentId <= 0 || $dayNumber <= 0) {
+    http_response_code(400);
+    exit('Missing parameters');
+}
+
+// 🛡️ Confirm ownership + read totalDays so we know when to mark completed.
+$ownerOk = false;
+$totalDays = 0;
+$planId = 0;
+$stmt = $db->prepare(
+    'SELECT e.userID, p.totalDays, e.planID FROM tblReadingPlanEnrollment e '
+    . 'JOIN tblReadingPlan p ON p.planID = e.planID '
+    . 'WHERE e.enrollmentID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('i', $enrollmentId);
+    $stmt->execute();
+    $row = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+    if ($row !== null && (int) $row['userID'] === $userId) {
+        $ownerOk = true;
+        $totalDays = (int) $row['totalDays'];
+        $planId = (int) $row['planID'];
+    }
+}
+if ($ownerOk === false) {
+    http_response_code(403);
+    exit('Not your enrollment');
+}
+
+try {
+    $db->begin_transaction();
+    // 1. Record the day's completion (idempotent).
+    $stmt = $db->prepare(
+        'INSERT INTO tblReadingPlanProgress (enrollmentID, dayNumber) VALUES (?, ?) '
+        . 'ON DUPLICATE KEY UPDATE completedAt = completedAt'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('ii', $enrollmentId, $dayNumber);
+        $stmt->execute();
+        $stmt->close();
+    }
+    // 2. Advance currentDay (capped at totalDays + 1, which signals completion).
+    $stmt = $db->prepare(
+        'UPDATE tblReadingPlanEnrollment SET currentDay = LEAST(currentDay + 1, ?) '
+        . 'WHERE enrollmentID = ?'
+    );
+    if ($stmt !== false) {
+        $cap = $totalDays + 1;
+        $stmt->bind_param('ii', $cap, $enrollmentId);
+        $stmt->execute();
+        $stmt->close();
+    }
+    // 3. Mark completedAt if we've passed the last day.
+    $stmt = $db->prepare(
+        'UPDATE tblReadingPlanEnrollment SET completedAt = NOW() '
+        . 'WHERE enrollmentID = ? AND completedAt IS NULL AND currentDay > ?'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('ii', $enrollmentId, $totalDays);
+        $stmt->execute();
+        $stmt->close();
+    }
+    $db->commit();
+} catch (\Throwable $e) {
+    $db->rollback();
+    \Portal\Core\Logger::errorPlatform('ReadingPlans', 'Warning', 'CHECK', $e->getMessage(), '');
+}
+
+header('Location: /reading-plans/plan?id=' . $planId);
+exit();

--- a/web/public_html/reading-plans/enroll.php
+++ b/web/public_html/reading-plans/enroll.php
@@ -1,0 +1,57 @@
+<?php
+// Path: public_html/reading-plans/enroll.php
+/**
+ * Reading Plans — POST handler to enroll the current user in a plan.
+ *
+ * @package   Portal\ReadingPlans
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/265
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$planId = (int) ($_POST['planID'] ?? 0);
+
+// Confirm plan is visible in this site.
+$ok = false;
+$stmt = $db->prepare('SELECT 1 FROM tblReadingPlan WHERE planID = ? AND siteID = ? AND isPublic = 1 LIMIT 1');
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $planId, $siteId);
+    $stmt->execute();
+    $ok = $stmt->get_result()->fetch_row() !== null;
+    $stmt->close();
+}
+if ($ok === false) {
+    http_response_code(404);
+    exit('Plan not found');
+}
+
+try {
+    $stmt = $db->prepare(
+        'INSERT INTO tblReadingPlanEnrollment (planID, userID) VALUES (?, ?) '
+        . 'ON DUPLICATE KEY UPDATE startedAt = startedAt'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('ii', $planId, $userId);
+        $stmt->execute();
+        $stmt->close();
+    }
+} catch (\Throwable $e) {
+    \Portal\Core\Logger::errorPlatform('ReadingPlans', 'Warning', 'ENROLL', $e->getMessage(), '');
+}
+
+header('Location: /reading-plans/plan?id=' . $planId);
+exit();

--- a/web/public_html/reading-plans/index.php
+++ b/web/public_html/reading-plans/index.php
@@ -1,0 +1,98 @@
+<?php
+// Path: public_html/reading-plans/index.php
+/**
+ * -----------------------------------------------------------------------------
+ * Reading Plans — Browse 📖
+ * -----------------------------------------------------------------------------
+ * @package   Portal\ReadingPlans
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/265
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+// All public + site-scoped plans, with my enrollment status if any.
+$plans = [];
+$stmt = $db->prepare(
+    'SELECT p.planID, p.slug, p.name, p.description, p.kind, p.totalDays, '
+    . '       e.enrollmentID, e.currentDay, e.completedAt '
+    . 'FROM tblReadingPlan p '
+    . 'LEFT JOIN tblReadingPlanEnrollment e ON e.planID = p.planID AND e.userID = ? '
+    . 'WHERE p.siteID = ? AND p.isPublic = 1 '
+    . 'ORDER BY p.kind, p.name'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $userId, $siteId);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $plans[] = $r;
+    }
+    $stmt->close();
+}
+
+$pageTitle   = 'Reading Plans';
+$pageSection = 'reading-plans';
+$breadcrumbs = ['Dashboard' => '/', 'Reading Plans' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<div class="d-flex flex-column flex-md-row justify-content-between align-items-md-center mb-4">
+    <div>
+        <h1 class="mb-1"><i class="fa-solid fa-book-open me-2"></i>Reading Plans</h1>
+        <p class="text-secondary mb-0">Daily reading commitments with progress tracking.</p>
+    </div>
+    <a href="/reading-plans/my" class="btn btn-outline-primary btn-sm">My plans</a>
+</div>
+
+<?php if (count($plans) === 0): ?>
+    <div class="alert alert-info">No plans available yet. An admin can seed plans via the database.</div>
+<?php else: ?>
+    <div class="row g-3">
+        <?php foreach ($plans as $p):
+            $enrolled = $p['enrollmentID'] !== null;
+            $completed = $enrolled === true && $p['completedAt'] !== null;
+            $progressPct = $enrolled === true ? min(100, (int) (((int) $p['currentDay'] / max(1, (int) $p['totalDays'])) * 100)) : 0;
+        ?>
+            <div class="col-md-6 col-lg-4">
+                <div class="card h-100 <?php echo $enrolled === true ? 'border-success' : ''; ?>">
+                    <div class="card-body d-flex flex-column">
+                        <h2 class="h6 mb-1"><?php echo htmlspecialchars((string) $p['name'], ENT_QUOTES, 'UTF-8'); ?></h2>
+                        <p class="small text-muted mb-2">
+                            <?php echo htmlspecialchars((string) $p['kind'], ENT_QUOTES, 'UTF-8'); ?>
+                            &middot; <?php echo (int) $p['totalDays']; ?> days
+                        </p>
+                        <?php if (($p['description'] ?? '') !== ''): ?>
+                            <p class="small flex-grow-1"><?php echo htmlspecialchars((string) $p['description'], ENT_QUOTES, 'UTF-8'); ?></p>
+                        <?php endif; ?>
+                        <?php if ($completed === true): ?>
+                            <div class="alert alert-success py-1 px-2 small mb-2 mt-auto">
+                                <i class="fa-solid fa-check-circle me-1"></i>Completed!
+                            </div>
+                        <?php elseif ($enrolled === true): ?>
+                            <div class="progress mt-auto mb-2" style="height: .5rem;">
+                                <div class="progress-bar bg-success" style="width: <?php echo $progressPct; ?>%"></div>
+                            </div>
+                            <p class="small text-muted mb-2">Day <?php echo (int) $p['currentDay']; ?> of <?php echo (int) $p['totalDays']; ?></p>
+                        <?php endif; ?>
+                        <a href="/reading-plans/plan?id=<?php echo (int) $p['planID']; ?>" class="btn btn-sm <?php echo $enrolled === true ? 'btn-success' : 'btn-outline-primary'; ?>">
+                            <?php echo $enrolled === true ? 'Continue' : 'View / enroll'; ?>
+                        </a>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/reading-plans/my.php
+++ b/web/public_html/reading-plans/my.php
@@ -1,0 +1,78 @@
+<?php
+// Path: public_html/reading-plans/my.php
+/**
+ * Reading Plans — my enrolled plans dashboard.
+ *
+ * @package   Portal\ReadingPlans
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/265
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+
+$enrollments = [];
+$stmt = $db->prepare(
+    'SELECT e.enrollmentID, e.currentDay, e.startedAt, e.completedAt, '
+    . '       p.planID, p.name, p.totalDays, p.kind '
+    . 'FROM tblReadingPlanEnrollment e '
+    . 'JOIN tblReadingPlan p ON p.planID = e.planID '
+    . 'WHERE e.userID = ? '
+    . 'ORDER BY e.completedAt IS NULL DESC, e.startedAt DESC'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('i', $userId);
+    $stmt->execute();
+    $rs = $stmt->get_result();
+    while ($r = $rs->fetch_assoc()) {
+        $enrollments[] = $r;
+    }
+    $stmt->close();
+}
+
+$pageTitle   = 'My Reading Plans';
+$pageSection = 'reading-plans';
+$breadcrumbs = ['Dashboard' => '/', 'Reading Plans' => '/reading-plans', 'My plans' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<h1 class="mb-3"><i class="fa-solid fa-book-bookmark me-2"></i>My Reading Plans</h1>
+
+<?php if (count($enrollments) === 0): ?>
+    <div class="alert alert-info">You're not enrolled in any plans yet. <a href="/reading-plans">Browse available plans</a>.</div>
+<?php else: ?>
+    <div class="portal-data-list">
+        <?php foreach ($enrollments as $e):
+            $pct = min(100, (int) (((int) $e['currentDay'] / max(1, (int) $e['totalDays'])) * 100));
+            $completed = $e['completedAt'] !== null;
+        ?>
+            <div class="row py-3 border-bottom align-items-center">
+                <div class="col-md-4">
+                    <a href="/reading-plans/plan?id=<?php echo (int) $e['planID']; ?>"><strong><?php echo htmlspecialchars((string) $e['name'], ENT_QUOTES, 'UTF-8'); ?></strong></a>
+                </div>
+                <div class="col-md-5">
+                    <div class="progress" style="height: .5rem;">
+                        <div class="progress-bar bg-<?php echo $completed === true ? 'success' : 'primary'; ?>" style="width: <?php echo $pct; ?>%"></div>
+                    </div>
+                    <small class="text-muted">Day <?php echo (int) $e['currentDay']; ?> / <?php echo (int) $e['totalDays']; ?></small>
+                </div>
+                <div class="col-md-3 text-end">
+                    <?php if ($completed === true): ?>
+                        <span class="badge bg-success">Completed</span>
+                    <?php else: ?>
+                        <a href="/reading-plans/plan?id=<?php echo (int) $e['planID']; ?>" class="btn btn-sm btn-success">Continue</a>
+                    <?php endif; ?>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/reading-plans/plan.php
+++ b/web/public_html/reading-plans/plan.php
@@ -1,0 +1,198 @@
+<?php
+// Path: public_html/reading-plans/plan.php
+/**
+ * Reading Plans — single-plan view with today's reading + recent history.
+ *
+ * @package   Portal\ReadingPlans
+ * @link      https://github.com/MWBMPartners/WebMS-Intra/issues/265
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Markdown;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$db     = App::db();
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$planId = (int) ($_GET['id'] ?? 0);
+
+if ($planId <= 0) {
+    header('Location: /reading-plans');
+    exit();
+}
+
+$plan = null;
+$stmt = $db->prepare(
+    'SELECT planID, slug, name, description, kind, totalDays '
+    . 'FROM tblReadingPlan WHERE planID = ? AND siteID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $planId, $siteId);
+    $stmt->execute();
+    $plan = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+if ($plan === null) {
+    http_response_code(404);
+    exit('Plan not found');
+}
+
+$enrollment = null;
+$stmt = $db->prepare(
+    'SELECT enrollmentID, startedAt, currentDay, completedAt '
+    . 'FROM tblReadingPlanEnrollment WHERE planID = ? AND userID = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $planId, $userId);
+    $stmt->execute();
+    $enrollment = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+// Today's day content (if there are seeded day rows).
+$todayDay = $enrollment !== null ? (int) $enrollment['currentDay'] : 1;
+$day = null;
+$stmt = $db->prepare(
+    'SELECT dayNumber, label, content FROM tblReadingPlanDay '
+    . 'WHERE planID = ? AND dayNumber = ? LIMIT 1'
+);
+if ($stmt !== false) {
+    $stmt->bind_param('ii', $planId, $todayDay);
+    $stmt->execute();
+    $day = $stmt->get_result()->fetch_assoc();
+    $stmt->close();
+}
+
+// Last 7 progress entries (streak preview).
+$recent = [];
+if ($enrollment !== null) {
+    $stmt = $db->prepare(
+        'SELECT dayNumber, completedAt FROM tblReadingPlanProgress '
+        . 'WHERE enrollmentID = ? ORDER BY completedAt DESC LIMIT 7'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('i', $enrollment['enrollmentID']);
+        $stmt->execute();
+        $rs = $stmt->get_result();
+        while ($r = $rs->fetch_assoc()) {
+            $recent[] = $r;
+        }
+        $stmt->close();
+    }
+}
+
+// Streak calculation — count consecutive days back from today where progress
+// was recorded.
+$streak = 0;
+if ($enrollment !== null && count($recent) > 0) {
+    $expected = strtotime('today');
+    foreach ($recent as $r) {
+        $completed = strtotime((string) $r['completedAt']);
+        if (date('Y-m-d', $completed) === date('Y-m-d', $expected)) {
+            $streak++;
+            $expected = strtotime('-1 day', $expected);
+        } else {
+            break;
+        }
+    }
+}
+
+$pageTitle   = (string) $plan['name'];
+$pageSection = 'reading-plans';
+$breadcrumbs = ['Dashboard' => '/', 'Reading Plans' => '/reading-plans', (string) $plan['name'] => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+$csrf = Auth::csrfToken();
+
+$progressPct = $enrollment !== null
+    ? min(100, (int) (((int) $enrollment['currentDay'] / max(1, (int) $plan['totalDays'])) * 100))
+    : 0;
+?>
+
+<h1 class="mb-1"><i class="fa-solid fa-book-open me-2"></i><?php echo htmlspecialchars((string) $plan['name'], ENT_QUOTES, 'UTF-8'); ?></h1>
+<p class="text-muted">
+    <?php echo htmlspecialchars((string) $plan['kind'], ENT_QUOTES, 'UTF-8'); ?>
+    &middot; <?php echo (int) $plan['totalDays']; ?> days
+</p>
+
+<?php if ($enrollment === null): ?>
+    <div class="card mb-3">
+        <div class="card-body">
+            <?php if (($plan['description'] ?? '') !== ''): ?>
+                <p><?php echo htmlspecialchars((string) $plan['description'], ENT_QUOTES, 'UTF-8'); ?></p>
+            <?php endif; ?>
+            <form method="post" action="/reading-plans/enroll">
+                <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                <input type="hidden" name="planID" value="<?php echo (int) $planId; ?>">
+                <button type="submit" class="btn btn-primary">Enroll in this plan</button>
+                <a href="/reading-plans" class="btn btn-outline-secondary">Back</a>
+            </form>
+        </div>
+    </div>
+<?php else: ?>
+    <div class="row g-3 mb-3">
+        <div class="col-md-8">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h2 class="h5">Day <?php echo $todayDay; ?> of <?php echo (int) $plan['totalDays']; ?></h2>
+                    <div class="progress mb-3" style="height: .5rem;">
+                        <div class="progress-bar bg-success" style="width: <?php echo $progressPct; ?>%"></div>
+                    </div>
+                    <?php if ($day !== null): ?>
+                        <p class="lead mb-2"><?php echo htmlspecialchars((string) $day['label'], ENT_QUOTES, 'UTF-8'); ?></p>
+                        <?php if (($day['content'] ?? '') !== ''): ?>
+                            <div class="portal-markdown"><?php echo Markdown::render((string) $day['content'], ['allow_links' => true]); ?></div>
+                        <?php endif; ?>
+                    <?php else: ?>
+                        <p class="text-muted">No reading content defined for this day. An admin can populate <code>tblReadingPlanDay</code> rows for richer guidance.</p>
+                    <?php endif; ?>
+                    <?php if ($enrollment['completedAt'] === null && $todayDay <= (int) $plan['totalDays']): ?>
+                        <form method="post" action="/reading-plans/check" class="mt-3">
+                            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                            <input type="hidden" name="enrollmentID" value="<?php echo (int) $enrollment['enrollmentID']; ?>">
+                            <input type="hidden" name="dayNumber" value="<?php echo $todayDay; ?>">
+                            <button type="submit" class="btn btn-success">
+                                <i class="fa-solid fa-check me-1"></i>Mark today's reading done
+                            </button>
+                        </form>
+                    <?php elseif ($enrollment['completedAt'] !== null): ?>
+                        <div class="alert alert-success mt-3">
+                            <i class="fa-solid fa-trophy me-1"></i>You've completed this plan! Finished
+                            <?php echo htmlspecialchars(date('j M Y', strtotime((string) $enrollment['completedAt'])), ENT_QUOTES, 'UTF-8'); ?>.
+                        </div>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-4">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h2 class="h6">Your streak</h2>
+                    <p class="display-6 mb-0"><?php echo $streak; ?> <span class="fs-6 text-muted">days</span></p>
+                    <hr>
+                    <h3 class="h6">Recent activity</h3>
+                    <?php if (count($recent) === 0): ?>
+                        <p class="small text-muted mb-0">No completions yet — mark today's reading to start a streak.</p>
+                    <?php else: ?>
+                        <ul class="list-unstyled small mb-0">
+                            <?php foreach ($recent as $r): ?>
+                                <li>
+                                    <i class="fa-solid fa-check-circle text-success me-1"></i>
+                                    Day <?php echo (int) $r['dayNumber']; ?> &middot;
+                                    <span class="text-muted"><?php echo htmlspecialchars(date('j M', strtotime((string) $r['completedAt'])), ENT_QUOTES, 'UTF-8'); ?></span>
+                                </li>
+                            <?php endforeach; ?>
+                        </ul>
+                    <?php endif; ?>
+                </div>
+            </div>
+        </div>
+    </div>
+<?php endif; ?>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/rota/manage.php
+++ b/web/public_html/rota/manage.php
@@ -34,7 +34,7 @@ if ($rs !== false) {
 }
 
 $users = [];
-$rs = $db->query('SELECT userID, fullName FROM tblUsers WHERE siteID = ' . $siteId . ' AND isActive = 1 ORDER BY fullName');
+$rs = $db->query('SELECT userID, fullName FROM tblUsers WHERE isActive = 1 ORDER BY fullName');
 if ($rs !== false) {
     while ($r = $rs->fetch_assoc()) {
         $users[] = $r;

--- a/web/public_html/rota/swap.php
+++ b/web/public_html/rota/swap.php
@@ -71,7 +71,7 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST' && Auth::verifyCsrf($_POST['csrf_token
 
 // Other users (excluding self) for the dropdown
 $users = [];
-$rs = $db->query('SELECT userID, fullName FROM tblUsers WHERE siteID = ' . $siteId . ' AND userID <> ' . $userId . ' AND isActive = 1 ORDER BY fullName');
+$rs = $db->query('SELECT userID, fullName FROM tblUsers WHERE userID <> ' . $userId . ' AND isActive = 1 ORDER BY fullName');
 if ($rs !== false) {
     while ($r = $rs->fetch_assoc()) {
         $users[] = $r;

--- a/web/public_html/visitors/new.php
+++ b/web/public_html/visitors/new.php
@@ -22,7 +22,7 @@ $siteId = Site::id();
 // Coordinator dropdown — users with the configured role + admins.
 $coordRole = (string) (App::settings()['visitors']['coordinator_role'] ?? 'visitor_coordinator');
 $coords    = [];
-$rs = $db->query("SELECT userID, fullName FROM tblUsers WHERE siteID = " . $siteId . " AND isActive = 1 ORDER BY fullName");
+$rs = $db->query("SELECT userID, fullName FROM tblUsers WHERE isActive = 1 ORDER BY fullName");
 if ($rs !== false) {
     while ($r = $rs->fetch_assoc()) {
         $coords[] = $r;

--- a/web/public_html/visitors/profile.php
+++ b/web/public_html/visitors/profile.php
@@ -61,7 +61,7 @@ if ($stmt !== false) {
 }
 
 $users = [];
-$rs = $db->query("SELECT userID, fullName FROM tblUsers WHERE siteID = " . $siteId . " AND isActive = 1 ORDER BY fullName");
+$rs = $db->query("SELECT userID, fullName FROM tblUsers WHERE isActive = 1 ORDER BY fullName");
 if ($rs !== false) {
     while ($r = $rs->fetch_assoc()) {
         $users[] = $r;

--- a/web/public_html/visitors/public-form.php
+++ b/web/public_html/visitors/public-form.php
@@ -13,7 +13,13 @@
 declare(strict_types=1);
 
 use Portal\Core\App;
+use Portal\Core\Auth;
 use Portal\Core\Site;
+
+// 🪞 Start a session even for anonymous visitors so we can issue + verify
+//    a CSRF token. The form is captcha-gated for bot protection AND
+//    CSRF-gated for state-changing intent (#281 security review).
+Auth::ensureSession();
 
 $siteId = Site::id();
 $enabled = (string) (App::settings()['visitors']['public_capture_enabled'] ?? '0') === '1';
@@ -27,10 +33,16 @@ $flash = '';
 $flashType = 'info';
 
 if ($_SERVER['REQUEST_METHOD'] === 'POST') {
-    $name  = trim((string) ($_POST['fullName'] ?? ''));
-    $email = trim((string) ($_POST['email'] ?? ''));
-    $phone = trim((string) ($_POST['phone'] ?? ''));
-    $notes = trim((string) ($_POST['notes'] ?? ''));
+    // 🛡️ CSRF — even for anonymous visitors, we issue a session-scoped
+    //    token so the POST proves it came from a form we rendered.
+    if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+        $flash = 'Form expired — please reload the page and try again.';
+        $flashType = 'danger';
+    } else {
+        $name  = trim((string) ($_POST['fullName'] ?? ''));
+        $email = trim((string) ($_POST['email'] ?? ''));
+        $phone = trim((string) ($_POST['phone'] ?? ''));
+        $notes = trim((string) ($_POST['notes'] ?? ''));
 
     // 🛡️ Captcha — uses existing portal captcha if configured.
     $captchaOk = true;
@@ -67,10 +79,12 @@ if ($_SERVER['REQUEST_METHOD'] === 'POST') {
             $flash = 'Sorry — something went wrong. Please try again later.';
             $flashType = 'danger';
         }
+        }
     }
 }
 
 $portalName = htmlspecialchars((string) (App::settings()['site']['name'] ?? 'our portal'), ENT_QUOTES, 'UTF-8');
+$csrfToken  = Auth::csrfToken();
 ?>
 <!doctype html>
 <html lang="en">
@@ -103,6 +117,7 @@ button{margin-top:1rem;padding:.625rem 1.25rem;background:var(--primary);color:#
     <?php endif; ?>
     <?php if ($flashType !== 'success'): ?>
         <form method="post">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrfToken, ENT_QUOTES, 'UTF-8'); ?>">
             <label>Your name</label>
             <input type="text" name="fullName" required maxlength="255">
             <label>Email</label>


### PR DESCRIPTION
## 4 features: Reading Plans + QR + invite onboarding + offboarding lifecycle

Stacked on the just-merged #282 schema-drift bugfix. Completes the user-lifecycle story (#239 + #240) — invite onboarding was the cited blocker for the whole-congregation rollout phase.

### Closes
- **#265** Reading Plans tracker
- **#275** QR code generator + CueRCode adapter
- **#239** Invite-based onboarding workflow
- **#240** One-click offboarding workflow

### #265 Reading Plans

4 tables (`tblReadingPlan`, `tblReadingPlanDay`, `tblReadingPlanEnrollment`, `tblReadingPlanProgress`). 2 pre-seeded plans (Bible-in-a-Year, Chronological). Pages: `/reading-plans`, `/reading-plans/plan?id=`, `/reading-plans/my`, `/reading-plans/enroll`, `/reading-plans/check`. **Live streak counter** computed from last 7 progress entries; **transactional** `/check` handler advances `currentDay` and marks `completedAt` when reaching the end.

### #275 QR Generator + CueRCode Adapter

- `Portal\Core\Qr::generate($content, $opts): {mime, bytes}` — SVG default, PNG when `gd` loaded.
- `Portal\Core\QrEncoder` — minimal RS-encoded byte-mode encoder, EC level M, versions 1-10 (~250 char capacity). Pure PHP, no vendor.
- `/qr` endpoint (login-required) for inline embedding.
- `/admin/settings/qr` — provider switch + CueRCode credentials (api_key encrypted via existing sensitive pipeline) + live preview.

**[CueRCode](https://github.com/MWBMPartners/CueRCode) integration:** `Qr::resolveContent()` is the adapter point. When `portal.qr.provider = 'cuercode'` and credentials set, content is registered with CueRCode and the returned tracking URL is encoded into the QR. Best-effort — falls back to raw content silently on any failure. The HTTP shape targets a generic `POST /register → {tracking_url}` contract; update once CueRCode publishes its public API spec.

Wired into `/account/calendar-feed` (#271): scan-to-add on a phone for iCal URLs.

### #239 Invite Onboarding

1 table (`tblInvitation`) with SHA-256-hashed single-use tokens. Pages: `/invites` (admin list), `/invites/new` (single + bulk), `/invites/save`, `/invites/revoke`, **`/auth/invite?token=`** (public acceptance form, no login required, 410 Gone on invalid/accepted/revoked/expired).

On accept: creates `tblUsers` + `tblUserSites` + `tblLocalAccounts` rows, marks invitation accepted, signs in, redirects to dashboard. Email dispatch via `Mailer::sendTemplated('invite', ...)` (uses template from #243). Public acceptance page is QR-able via #275 for in-person handout.

### #240 Offboarding

1 table (`tblOffboarding`) with audit log per event. Pages: `/offboarding` (audit list + rehire buttons within undo window), `/offboarding/user?id=` (confirmation), `/offboarding/do` (**atomic 7-step revocation**), `/offboarding/rehire`.

The 7 steps:
1. `tblUsers.isActive = 0`
2. `DELETE FROM tblWebAuthnCredentials`
3. `tblLocalAccounts.passwordHash = ''` (cleared)
4. `tblUserSites.isActive = 0`
5. `tblLeadershipAssignments.endDate = NOW()`
6. `DELETE FROM tblUserRoles`
7. INSERT audit row with per-step JSON outcomes

Rehire window (default 7 days) restores `isActive` flags but NOT credentials — user must reset password + re-enrol passkeys. Admin cannot offboard their own account.

### Pattern proof-points

All 4 apps:
1. ✅ `web/_core/apps/{slug}.php` config — auto-discovered by `AppRegistry` (#255)
2. ✅ `xxx.enabled` setting; opt-in via `/admin/apps`
3. ✅ Industry-tagged for the `/admin/apps` filter
4. ✅ Uses `Markdown::render()` for user content (#270)
5. ✅ Uses `Portal.Confirm` modal (#244) for destructive actions
6. ✅ CSRF-protected POST handlers
7. ✅ All schema in `full_schema.sql` + sibling migration files

### Verification

```
$ python3 tools/audit-checks/check_sql_columns.py   → 0 mismatches
$ python3 tools/audit-checks/check_route_targets.py → 0 missing target files
$ python3 tools/audit-checks/check_no_native_confirm.py → 0 findings
```

All PHP lint-clean.

### Migrations 084–087

4 idempotent migrations, schema also in `full_schema.sql`.

### Test plan

- [ ] Enable each app at `/admin/apps`.
- [ ] **Reading Plans:** enroll in Bible-in-a-Year → "Mark today's reading done" → streak counter increments → next day's reading shows.
- [ ] **QR:** `/admin/settings/qr` shows sample preview; `/account/calendar-feed` shows scannable QR alongside the URL.
- [ ] **Invite:** generate invite for a fresh email → invite email arrives (via configured Mailer) → click link → self-registration form → submit → land on dashboard signed in.
- [ ] **Offboard:** offboard a test user → user appears in `/offboarding` audit list → log in attempt fails → rehire within window → log in still fails (password cleared) → user resets via /forgot-password → log in succeeds.
- [ ] CI passes.

### Deferred per app

Each issue's status comment lists deferrals. Highlights:
- Daily reminder cron for Reading Plans
- CueRCode actual API spec wire-up (placeholder shape in place)
- Passkey enrollment during invite accept
- Convert-to-anonymise / convert-to-delete actually deleting data (depends on #235 GDPR engine)
- Bulk CSV offboarding


---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_