### PR TITLE
docs: rename-aftermath sweep — fix stale core/vendor/sql/install path refs (#189, #182, #183, #194)

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -20,7 +20,7 @@ repo root/          <- NOT deployed (docs, CI/CD only)
 web/                <- ALL deployable files (synced to server via SFTP)
   _core/            <- Framework classes (Portal\Core namespace, 26 classes)
   _vendor/simplejwt/<- Vendored RS256 JWT verifier
-  _sql/             <- Numbered SQL migrations (000-052 + full_schema.sql)
+  _sql/             <- Numbered SQL migrations (000-104 + full_schema.sql)
   _lang/            <- I18n translation files (en.php, cy.php, …)
   _install/         <- Standalone 6-step installation wizard (bootstrap-free)
   public_html/      <- Web root: ONE front controller + assets + app controllers.
@@ -70,7 +70,7 @@ Calendar/Events/Preaching Plan is ONE app ("Events") — `/calendar` covers view
 - Detailed inline comments with reference links where applicable
 - File header comments must include: file path, description, package, author, copyright (All Rights Reserved), version
 
-## Key Constants (defined in core/bootstrap.php)
+## Key Constants (defined in _core/bootstrap.php)
 
 - `PORTAL_ROOT` -- web/ on server
 - `PORTAL_CORE` -- web/_core/
@@ -117,4 +117,4 @@ When making changes:
 - macOS case-insensitive: use two-step rename for case changes
 - Never commit: `_auth_keys/`, `_uploads/`, `_backups/`, `_libraries/`, `.env`, `*.key`
 - Deploy workflow syncs `web/` only, excluding server-managed dirs
-- Shared dirs (`core/`, `vendor/`, `sql/`, `_includes/`, `_functions/`, `_libraries/`) mirror with `--delete` — manual server-side edits to these dirs vanish on the next deploy (see DEV_NOTES.md → Troubleshooting)
+- Shared dirs (`_core/`, `_vendor/`, `_sql/`, `_includes/`, `_functions/`, `_libraries/`) mirror with `--delete` — manual server-side edits to these dirs vanish on the next deploy (see DEV_NOTES.md → Troubleshooting)

--- a/DEV_NOTES.md
+++ b/DEV_NOTES.md
@@ -12,9 +12,9 @@ code lives inside `web/`**, which maps directly to the server domain directory:
 
 ```
 Git repo root (NOT deployed)          Server: portal.millrdsdacambridge.uk/
-├── .claude/                           ├── core/
-├── .github/workflows/deploy.yml       ├── vendor/
-├── CHANGELOG.md                       ├── sql/
+├── .claude/                           ├── _core/
+├── .github/workflows/deploy.yml       ├── _vendor/
+├── CHANGELOG.md                       ├── _sql/
 ├── DEV_NOTES.md                       ├── _auth_keys/    (server-managed)
 ├── README.md                          ├── _libraries/    (server-managed)
 └── web/ ─── contents deployed ──────► ├── _uploads/      (server-managed)

--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ Browser -> .htaccess -> index.php -> bootstrap.php -> Router::dispatch()
 ### Upgrading
 
 1. Upload the updated `web/` files to the server (FTP sync)
-2. Navigate to Admin > Upgrade (or `/install/upgrade.php`)
+2. Navigate to Admin > Upgrade (or `/admin/upgrade.php`)
 3. Review and run any pending SQL migrations
 4. Verify the portal is working correctly
 

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -13,7 +13,7 @@
 -- present in web/_sql/ are marked as executed in tblMigrations so the
 -- web-based Migrator won't re-run them.
 --
--- Covers migrations: 000-052 (matches the tblMigrations seed block at the
+-- Covers migrations: 000-104 (matches the tblMigrations seed block at the
 -- end of this file — when you add a new migration, also add its filename
 -- to that block and port its DDL/seeds into the appropriate section here).
 -- =============================================================================


### PR DESCRIPTION
Tiny mechanical sweep cleaning up the rename-aftermath references in four documentation locations. Net change: 8 lines.

## Issues addressed

| # | What was stale | Fix |
|---|---|---|
| #189 | `README.md:128` said `/install/upgrade.php` | → `/admin/upgrade.php` (URL route — public upgrade lives at `/admin/upgrade` per `Maintenance::SKIPLIST`) |
| #182 | `.claude/CLAUDE.md:23` said "000-052 + full_schema.sql" | → "000-104 + full_schema.sql" (current count after wave-4 + wave-5) |
| #182 | `.claude/CLAUDE.md:73` said "core/bootstrap.php" | → "_core/bootstrap.php" |
| #182 | `.claude/CLAUDE.md:120` listed shared dirs as `core/`, `vendor/`, `sql/` | → underscore-prefixed forms |
| #183 | `DEV_NOTES.md:15-17` ASCII tree right column showed `core/`, `vendor/`, `sql/` | → `_core/`, `_vendor/`, `_sql/` (matches the SFTP_BASE_PATH diagram on lines 73-87 of the same doc) |
| #194 | `web/_sql/full_schema.sql:16` claimed "Covers migrations: 000-052" | → "000-104" |

## Closes-by-verification

Issues that turned out to be **already fixed** during the audit:

- **#190** — `// Path: core/...` headers in `web/_core/`. `grep -rn "^// Path: core/" web/_core/` returns **0 matches**. A prior sweep already caught these.
- **#191** — `tblAuditTrail` present in `full_schema.sql` ✓
- **#192** — `tblWorkflows` + 3 siblings present ✓
- **#193** — `tblTasks` present ✓

These four can be closed with no code change.

## Audits

- `check_route_targets.py` → 0 missing
- `check_sql_columns.py` → 0 mismatches

Closes #189, #182, #183, #194, #190, #191, #192, #193.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_