### PR TITLE
feat(ops): external error monitor (Sentry / GlitchTip) (#143)

### DIFF
--- a/web/_core/ErrorMonitor.php
+++ b/web/_core/ErrorMonitor.php
@@ -1,0 +1,245 @@
+<?php
+// Path: _core/ErrorMonitor.php
+/**
+ * -----------------------------------------------------------------------------
+ * External error monitor adapter 📡
+ * -----------------------------------------------------------------------------
+ * Sentry- and GlitchTip-compatible error reporting. Forwards Logger-captured
+ * errors to an external service so they're recorded even when the portal's
+ * own DB is unreachable (the case `tblErrors` cannot cover).
+ *
+ * The Sentry store endpoint format also matches GlitchTip — both accept
+ * the same JSON envelope and `X-Sentry-Auth` header — so configuring the
+ * `monitoring.sentryDsn` setting with a GlitchTip DSN works without code
+ * changes.
+ *
+ * Settings:
+ *   monitoring.enabled       — '1' / '0'  (master switch; default off)
+ *   monitoring.sentryDsn     — full DSN string (sensitive, encrypted)
+ *   monitoring.environment   — defaults to PORTAL_ENV
+ *   monitoring.sampleRate    — float 0.0–1.0; events are dropped via
+ *                              random sampling when < 1.0 (default 1.0)
+ *
+ * When `monitoring.enabled` is '0' or `monitoring.sentryDsn` is empty,
+ * every method is a silent no-op. This is the common case — most
+ * installs won't configure external monitoring.
+ *
+ * @package   Portal\Core
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/143
+ * @link      https://develop.sentry.dev/sdk/data-model/envelopes/
+ * @link      https://glitchtip.com/documentation
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class ErrorMonitor
+{
+    /**
+     * Forward an error event to the configured monitor.
+     *
+     * Called from Logger::errorPlatform() after the DB insert; wrapped
+     * in try/catch by the caller so transport failures never break
+     * the logging path.
+     */
+    public static function capture(
+        string $platform,
+        string $severity,
+        string $code,
+        string $title,
+        string $detail = '',
+        ?int $userId = null
+    ): void {
+        $settings = App::settings()['monitoring'] ?? [];
+        if ((string) ($settings['enabled'] ?? '0') !== '1') {
+            return;
+        }
+        $dsn = (string) ($settings['sentryDsn'] ?? '');
+        if ($dsn === '') {
+            return;
+        }
+
+        // Sample-rate gate. Random.org-grade randomness isn't required —
+        // we just want to drop some fraction of high-volume events.
+        $sample = (float) ($settings['sampleRate'] ?? 1.0);
+        if ($sample < 1.0) {
+            $roll = (mt_rand() / mt_getrandmax());
+            if ($roll > $sample) {
+                return;
+            }
+        }
+
+        $parsed = self::parseDsn($dsn);
+        if ($parsed === null) {
+            return;
+        }
+        $environment = (string) ($settings['environment'] ?? App::env());
+        $payload = self::buildPayload($platform, $severity, $code, $title, $detail, $userId, $environment);
+
+        self::send($parsed, $payload);
+    }
+
+    /**
+     * Public hook for sending an arbitrary message event (admin "test
+     * monitor" button in /admin/integrations/monitoring uses this).
+     */
+    public static function sendTestEvent(string $message = 'Portal monitor smoke test'): bool
+    {
+        $settings = App::settings()['monitoring'] ?? [];
+        $dsn = (string) ($settings['sentryDsn'] ?? '');
+        if ($dsn === '') {
+            return false;
+        }
+        $parsed = self::parseDsn($dsn);
+        if ($parsed === null) {
+            return false;
+        }
+        $environment = (string) ($settings['environment'] ?? App::env());
+        $payload = self::buildPayload('Portal', 'Info', 'TEST', $message, 'Manually triggered from /admin/integrations/monitoring.', null, $environment);
+        return self::send($parsed, $payload);
+    }
+
+    // -------------------------------------------------------------------------
+    // Internals
+    // -------------------------------------------------------------------------
+
+    /**
+     * Parse a Sentry/GlitchTip DSN into its constituent parts.
+     *
+     * Format:
+     *   https://PUBLIC_KEY@HOST/PROJECT_ID
+     *   https://PUBLIC_KEY:SECRET@HOST/PROJECT_ID   (legacy; secret ignored)
+     */
+    private static function parseDsn(string $dsn): ?array
+    {
+        $u = parse_url($dsn);
+        if (is_array($u) === false) {
+            return null;
+        }
+        $scheme = (string) ($u['scheme'] ?? '');
+        $host   = (string) ($u['host']   ?? '');
+        $user   = (string) ($u['user']   ?? '');
+        $path   = (string) ($u['path']   ?? '');
+        if ($scheme === '' || $host === '' || $user === '' || $path === '') {
+            return null;
+        }
+        $projectId = trim($path, '/');
+        if ($projectId === '' || preg_match('/^[0-9]+$/', $projectId) !== 1) {
+            return null;
+        }
+        $portPart = isset($u['port']) === true ? ':' . (int) $u['port'] : '';
+        $storeUrl = $scheme . '://' . $host . $portPart . '/api/' . $projectId . '/store/';
+        return [
+            'public'   => $user,
+            'storeUrl' => $storeUrl,
+            'project'  => $projectId,
+        ];
+    }
+
+    /**
+     * Build the Sentry "store" envelope (single event JSON).
+     *
+     * @link https://develop.sentry.dev/sdk/data-model/event-payloads/
+     */
+    private static function buildPayload(string $platform, string $severity, string $code, string $title, string $detail, ?int $userId, string $environment): array
+    {
+        $level = self::severityToLevel($severity);
+        $payload = [
+            'event_id'    => str_replace('-', '', self::uuid4()),
+            'timestamp'   => gmdate('Y-m-d\TH:i:s\Z'),
+            'platform'    => 'php',
+            'level'       => $level,
+            'environment' => $environment,
+            'logger'      => $platform,
+            'release'     => App::version(),
+            'message'     => [
+                'formatted' => trim($title . ($detail !== '' ? ' — ' . $detail : '')),
+            ],
+            'tags' => [
+                'severity' => $severity,
+                'code'     => $code,
+                'platform' => $platform,
+            ],
+            'request' => [
+                'url'         => self::currentUrl(),
+                'method'      => $_SERVER['REQUEST_METHOD']   ?? 'GET',
+                'headers'     => [
+                    'User-Agent' => $_SERVER['HTTP_USER_AGENT'] ?? '',
+                ],
+            ],
+            'server_name' => $_SERVER['SERVER_NAME'] ?? gethostname() ?: 'portal',
+        ];
+        if ($userId !== null) {
+            $payload['user'] = ['id' => (string) $userId];
+        }
+        return $payload;
+    }
+
+    /**
+     * POST the event to the resolved store URL with the X-Sentry-Auth
+     * header. cURL with a short timeout — best-effort dispatch; we never
+     * want monitor failures to slow down the user's response.
+     */
+    private static function send(array $parsed, array $payload): bool
+    {
+        $body = json_encode($payload);
+        if ($body === false) {
+            return false;
+        }
+        $ch = curl_init($parsed['storeUrl']);
+        curl_setopt($ch, CURLOPT_RETURNTRANSFER, true);
+        curl_setopt($ch, CURLOPT_POST, true);
+        curl_setopt($ch, CURLOPT_POSTFIELDS, $body);
+        curl_setopt($ch, CURLOPT_HTTPHEADER, [
+            'Content-Type: application/json',
+            'X-Sentry-Auth: Sentry sentry_version=7, sentry_client=webms-intra/' . App::version() . ', sentry_key=' . $parsed['public'],
+        ]);
+        // Tight timeouts — under no circumstances should monitoring slow
+        // down user-facing response time. If the monitor is unreachable
+        // we accept the dropped event silently.
+        curl_setopt($ch, CURLOPT_CONNECTTIMEOUT, 2);
+        curl_setopt($ch, CURLOPT_TIMEOUT, 5);
+        curl_exec($ch);
+        $code = (int) curl_getinfo($ch, CURLINFO_HTTP_CODE);
+        curl_close($ch);
+        return $code >= 200 && $code < 300;
+    }
+
+    /**
+     * Map Logger's severity strings to Sentry's `level` enum.
+     */
+    private static function severityToLevel(string $severity): string
+    {
+        $s = strtolower($severity);
+        return match (true) {
+            str_contains($s, 'critical') => 'fatal',
+            str_contains($s, 'fatal')    => 'fatal',
+            str_contains($s, 'error')    => 'error',
+            str_contains($s, 'warn')     => 'warning',
+            str_contains($s, 'info')     => 'info',
+            default                      => 'error',
+        };
+    }
+
+    /**
+     * RFC-4122 UUID v4 (random). Sentry requires `event_id` as a 32-char
+     * lowercase hex without hyphens; we strip after generation.
+     */
+    private static function uuid4(): string
+    {
+        $b = random_bytes(16);
+        $b[6] = chr(ord($b[6]) & 0x0f | 0x40);
+        $b[8] = chr(ord($b[8]) & 0x3f | 0x80);
+        return vsprintf('%s%s-%s-%s-%s-%s%s%s', str_split(bin2hex($b), 4));
+    }
+
+    private static function currentUrl(): string
+    {
+        $scheme = (($_SERVER['HTTPS'] ?? '') !== '' && (string) ($_SERVER['HTTPS'] ?? '') !== 'off') ? 'https' : 'http';
+        $host   = (string) ($_SERVER['HTTP_HOST'] ?? 'unknown');
+        $uri    = (string) ($_SERVER['REQUEST_URI'] ?? '/');
+        return $scheme . '://' . $host . $uri;
+    }
+}

--- a/web/_core/Logger.php
+++ b/web/_core/Logger.php
@@ -240,6 +240,17 @@ class Logger
         } catch (\Throwable $ignored) {
             error_log('Alert dispatch failed: ' . $ignored->getMessage());
         }
+
+        // 📡 External error monitor (#143). When monitoring.enabled = '1' AND
+        //    monitoring.sentryDsn is set, forward the event to Sentry /
+        //    GlitchTip. Both accept the same store-API envelope. Silent
+        //    no-op when not configured. Wrapped in try/catch so any
+        //    transport / config failure can never break the logging path.
+        try {
+            ErrorMonitor::capture($platform, $severity, $code, $title, $detail, $userId);
+        } catch (\Throwable $ignored) {
+            error_log('Error monitor capture failed: ' . $ignored->getMessage());
+        }
     }
 
     private static function maybeDispatchAlert(

--- a/web/_sql/105_error_monitoring.sql
+++ b/web/_sql/105_error_monitoring.sql
@@ -1,0 +1,16 @@
+-- =============================================================================
+-- Migration 105: External error monitoring (#143)
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/integrations/monitoring',      'admin/integrations/monitoring/index.php', 1),
+    ('admin/integrations/monitoring/save', 'admin/integrations/monitoring/save.php',  1),
+    ('admin/integrations/monitoring/test', 'admin/integrations/monitoring/test.php',  1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'monitoring.enabled',     '0', '0', 0),
+    (NULL, 'monitoring.sentryDsn',   '',  '',  1),
+    (NULL, 'monitoring.environment', '',  '',  0),
+    (NULL, 'monitoring.sampleRate',  '1.0', '1.0', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -4331,3 +4331,20 @@ ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('help/disaster-recovery', 'help/disaster-recovery.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+-- =============================================================================
+-- External error monitoring (migration 105, #143)
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/integrations/monitoring',      'admin/integrations/monitoring/index.php', 1),
+    ('admin/integrations/monitoring/save', 'admin/integrations/monitoring/save.php',  1),
+    ('admin/integrations/monitoring/test', 'admin/integrations/monitoring/test.php',  1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    (NULL, 'monitoring.enabled',     '0', '0', 0),
+    (NULL, 'monitoring.sentryDsn',   '',  '',  1),
+    (NULL, 'monitoring.environment', '',  '',  0),
+    (NULL, 'monitoring.sampleRate',  '1.0', '1.0', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/public_html/admin/integrations/monitoring/index.php
+++ b/web/public_html/admin/integrations/monitoring/index.php
@@ -1,0 +1,115 @@
+<?php
+// Path: public_html/admin/integrations/monitoring/index.php
+/**
+ * Admin — External error monitoring (Sentry / GlitchTip) config + test.
+ *
+ * @package   Portal\Admin
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/143
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\ErrorMonitor;
+use Portal\Core\Router;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    Router::renderError(403);
+    return;
+}
+
+$settings = App::settings()['monitoring'] ?? [];
+$enabled  = (string) ($settings['enabled'] ?? '0') === '1';
+$hasDsn   = ((string) ($settings['sentryDsn'] ?? '')) !== '';
+$env      = (string) ($settings['environment'] ?? App::env());
+$sample   = (string) ($settings['sampleRate'] ?? '1.0');
+
+$flashMsg  = $_SESSION['flash_msg']  ?? '';
+$flashType = $_SESSION['flash_type'] ?? '';
+unset($_SESSION['flash_msg'], $_SESSION['flash_type']);
+$csrf = Auth::csrfToken();
+
+$pageTitle   = 'Error monitoring';
+$pageSection = 'admin';
+$breadcrumbs = ['Dashboard' => '/', 'Admin' => '/admin', 'Integrations' => '/admin/integrations', 'Error monitoring' => ''];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+
+<?php if ($flashMsg !== ''): ?>
+    <div class="alert alert-<?php echo htmlspecialchars($flashType !== '' ? $flashType : 'info', ENT_QUOTES, 'UTF-8'); ?>"><?php echo htmlspecialchars($flashMsg, ENT_QUOTES, 'UTF-8'); ?></div>
+<?php endif; ?>
+
+<h1 class="mb-3"><i class="fa-solid fa-satellite-dish me-2"></i>Error monitoring</h1>
+<p class="text-secondary">
+    Forward every <code>Logger::errorPlatform()</code> event to an external
+    service (Sentry / GlitchTip) so errors are captured even when the portal's
+    own database is unreachable. Silent no-op when DSN is empty.
+</p>
+
+<div class="card mb-3">
+    <div class="card-header"><strong>Configuration</strong></div>
+    <div class="card-body">
+        <form method="post" action="/admin/integrations/monitoring/save" class="row g-3">
+            <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+            <div class="col-md-9">
+                <label class="form-label">Sentry / GlitchTip DSN <?php echo $hasDsn === true ? '<span class="badge bg-success">set</span>' : ''; ?></label>
+                <input type="password" class="form-control" name="dsn" placeholder="<?php echo $hasDsn === true ? 'Leave blank to keep current' : 'https://PUBLIC_KEY@oXXXXXX.ingest.sentry.io/PROJECT_ID'; ?>" autocomplete="off">
+                <small class="text-muted">GlitchTip DSNs use the same format and same store API.</small>
+            </div>
+            <div class="col-md-3 d-flex align-items-end">
+                <div class="form-check">
+                    <input type="checkbox" class="form-check-input" id="enabled" name="enabled" value="1" <?php echo $enabled === true ? 'checked' : ''; ?>>
+                    <label class="form-check-label" for="enabled">Enable</label>
+                </div>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Environment tag</label>
+                <input type="text" class="form-control" name="environment" value="<?php echo htmlspecialchars($env, ENT_QUOTES, 'UTF-8'); ?>" placeholder="<?php echo htmlspecialchars(App::env(), ENT_QUOTES, 'UTF-8'); ?>">
+                <small class="text-muted">Defaults to PORTAL_ENV (<code><?php echo htmlspecialchars(App::env(), ENT_QUOTES, 'UTF-8'); ?></code>).</small>
+            </div>
+            <div class="col-md-4">
+                <label class="form-label">Sample rate (0.0 – 1.0)</label>
+                <input type="text" class="form-control" name="sampleRate" value="<?php echo htmlspecialchars($sample, ENT_QUOTES, 'UTF-8'); ?>">
+                <small class="text-muted">1.0 = every event; 0.1 = 10% sampling.</small>
+            </div>
+            <div class="col-12">
+                <button class="btn btn-primary" type="submit">Save</button>
+                <?php if ($hasDsn === true): ?>
+                    <form method="post" action="/admin/integrations/monitoring/test" class="d-inline ms-2">
+                        <input type="hidden" name="csrf_token" value="<?php echo htmlspecialchars($csrf, ENT_QUOTES, 'UTF-8'); ?>">
+                        <button class="btn btn-outline-warning" type="submit">
+                            <i class="fa-solid fa-paper-plane me-1"></i>Send test event
+                        </button>
+                    </form>
+                <?php endif; ?>
+            </div>
+        </form>
+    </div>
+</div>
+
+<div class="card">
+    <div class="card-header"><strong>How it works</strong></div>
+    <div class="card-body small">
+        <p>
+            Every call to <code>Portal\Core\Logger::errorPlatform()</code> writes a row to
+            <code>tblErrors</code> first, then (best-effort) fires the event to the
+            configured monitor's <code>store</code> endpoint. The store call uses
+            cURL with a 5-second timeout and a 2-second connect timeout — under no
+            circumstances should monitoring slow down user-facing response time.
+        </p>
+        <p>
+            The same configuration works for <strong>Sentry</strong>, <strong>GlitchTip</strong>,
+            and any other service that accepts Sentry's <code>store</code> envelope shape.
+        </p>
+        <p class="mb-0">
+            Threat model: the DSN itself doesn't grant write access to anything
+            other than the configured project's event ingestion endpoint, so it's
+            stored encrypted at rest via the existing libsodium pipeline.
+        </p>
+    </div>
+</div>
+
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/public_html/admin/integrations/monitoring/save.php
+++ b/web/public_html/admin/integrations/monitoring/save.php
@@ -1,0 +1,81 @@
+<?php
+// Path: public_html/admin/integrations/monitoring/save.php
+/**
+ * Admin — Error-monitoring settings save handler.
+ *
+ * @package   Portal\Admin
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/143
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Router;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    Router::renderError(403);
+    return;
+}
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$db = App::db();
+$upsert = static function (mysqli $db, string $key, string $value, bool $isSensitive): void {
+    if ($isSensitive === true && $value !== '' && function_exists('encrypt_setting') === true) {
+        $value = encrypt_setting($value);
+    }
+    $sens = $isSensitive === true ? 1 : 0;
+    $stmt = $db->prepare('SELECT settingID FROM tblSettings WHERE settingKey = ? AND siteID IS NULL LIMIT 1');
+    if ($stmt === false) {
+        return;
+    }
+    $stmt->bind_param('s', $key);
+    $stmt->execute();
+    $stmt->bind_result($id);
+    $exists = $stmt->fetch() === true;
+    $stmt->close();
+    if ($exists === true) {
+        $u = $db->prepare('UPDATE tblSettings SET settingValue = ?, isSensitive = ?, updatedAt = NOW() WHERE settingID = ?');
+        if ($u !== false) {
+            $u->bind_param('sii', $value, $sens, $id);
+            $u->execute();
+            $u->close();
+        }
+    } else {
+        $u = $db->prepare('INSERT INTO tblSettings (settingKey, settingValue, isSensitive, siteID, updatedAt) VALUES (?, ?, ?, NULL, NOW())');
+        if ($u !== false) {
+            $u->bind_param('ssi', $key, $value, $sens);
+            $u->execute();
+            $u->close();
+        }
+    }
+};
+
+$enabled = isset($_POST['enabled']) === true ? '1' : '0';
+$env     = trim((string) ($_POST['environment'] ?? ''));
+$rateRaw = (float) ($_POST['sampleRate'] ?? 1.0);
+if ($rateRaw < 0.0) {
+    $rateRaw = 0.0;
+} elseif ($rateRaw > 1.0) {
+    $rateRaw = 1.0;
+}
+$sampleRate = sprintf('%.3f', $rateRaw);
+
+$upsert($db, 'monitoring.enabled',     $enabled, false);
+$upsert($db, 'monitoring.environment', $env,     false);
+$upsert($db, 'monitoring.sampleRate',  $sampleRate, false);
+
+$dsn = trim((string) ($_POST['dsn'] ?? ''));
+if ($dsn !== '') {
+    $upsert($db, 'monitoring.sentryDsn', $dsn, true);
+}
+
+$_SESSION['flash_msg']  = 'Error-monitoring settings saved.';
+$_SESSION['flash_type'] = 'success';
+header('Location: /admin/integrations/monitoring');
+exit();

--- a/web/public_html/admin/integrations/monitoring/test.php
+++ b/web/public_html/admin/integrations/monitoring/test.php
@@ -1,0 +1,42 @@
+<?php
+// Path: public_html/admin/integrations/monitoring/test.php
+/**
+ * Admin — Send a smoke-test event to the configured monitor.
+ *
+ * @package   Portal\Admin
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/143
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\ErrorMonitor;
+use Portal\Core\Logger;
+use Portal\Core\Router;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) {
+    Router::renderError(403);
+    return;
+}
+if ($_SERVER['REQUEST_METHOD'] !== 'POST' || Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) {
+    http_response_code(400);
+    exit('Bad request');
+}
+
+$adminId = (int) ($_SESSION['user_id'] ?? 0);
+$ok = ErrorMonitor::sendTestEvent('Portal admin smoke test — ' . date('c'));
+
+Logger::activity('ErrorMonitorTest', $ok === true ? 'Test event accepted' : 'Test event failed', $adminId);
+
+if ($ok === true) {
+    $_SESSION['flash_msg']  = 'Test event accepted by the monitor — check the project dashboard for it.';
+    $_SESSION['flash_type'] = 'success';
+} else {
+    $_SESSION['flash_msg']  = 'Test event was NOT accepted — verify DSN and that the host is reachable.';
+    $_SESSION['flash_type'] = 'danger';
+}
+header('Location: /admin/integrations/monitoring');
+exit();


### PR DESCRIPTION
## External error monitor — Sentry / GlitchTip

`tblErrors` covers in-portal logging, but **if the portal's own DB is unreachable those rows never get written**. An external monitor catches the cases we can't see from inside.

## `Portal\Core\ErrorMonitor`

- **`capture(platform, severity, code, title, detail, userID?)`** — forwards each `Logger::errorPlatform()` event to the configured monitor's `store` endpoint. Silent no-op when `monitoring.enabled = '0'` or `monitoring.sentryDsn` is empty.
- **`sendTestEvent(message?)`** — admin smoke-test path.

## DSN parsing

`https://PUBLIC_KEY@HOST/PROJECT_ID` resolves to a store URL of `https://HOST/api/PROJECT_ID/store/`. **The same envelope works for Sentry and GlitchTip** — both accept the `X-Sentry-Auth` header with `sentry_version=7, sentry_client=…, sentry_key=…`. No code path needs to know which service is in use.

## Payload

Sentry "event" schema:
- `event_id` (32-char hex, no hyphens — UUID v4 stripped)
- `timestamp`, `platform: php`, `level` (Logger severity → fatal/error/warning/info)
- `environment`, `logger`, `release` (portal version)
- `message.formatted` (title + detail)
- `tags`: `severity`, `code`, `platform`
- `request`: url, method, User-Agent
- `server_name`
- `user.id` when userID supplied

## Performance posture

- **2 s connect-timeout + 5 s total-timeout** on the cURL call.
- Under no circumstances should monitoring slow down the user response.
- Failures swallowed silently — caller (`Logger::errorPlatform`) wraps the call in `try/catch` so the logging path is never broken even if the monitor is unreachable or misconfigured.
- Sample-rate gate (`monitoring.sampleRate`, 0.0-1.0) drops events **before** any network call.

## Schema (migration 105)

| Setting | Default | Sensitive | Purpose |
|---|---|---|---|
| `monitoring.enabled` | `'0'` | no | Master switch |
| `monitoring.sentryDsn` | `''` | **yes** | DSN encrypted at rest via libsodium |
| `monitoring.environment` | `''` | no | Tag — defaults to `PORTAL_ENV` |
| `monitoring.sampleRate` | `'1.0'` | no | Float 0.0–1.0 |

## Admin UI

`/admin/integrations/monitoring`:
- DSN input (password type — blank preserves current), enable toggle, environment override, sample-rate input.
- **"Send test event"** button (visible once DSN is set) — calls `ErrorMonitor::sendTestEvent()` and reports success/failure from the HTTP status code.
- Explanatory copy on the threat model and timeouts.

## Why nothing else changed

The integration point is one line in `Logger::errorPlatform()`. Existing call sites are unchanged. Adding a new platform later means appending to the `severityToLevel` switch — no plumbing surgery required.

## Audits

```
check_route_targets.py     → 304 routes, 0 missing
check_sql_columns.py       → 109 tables, 0 mismatches
check_no_native_confirm.py → 0 findings
php -l ✅ on all 5 changed files
```

Closes #143.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_