### PR TITLE
feat(api): write-side CRUD for Announcements, Tasks, Prayer Requests, Leadership (#157)

### DIFF
--- a/web/_apps/announcements/api/create.php
+++ b/web/_apps/announcements/api/create.php
@@ -1,0 +1,112 @@
+<?php
+// Path: _apps/announcements/api/create.php
+/**
+ * Announcements API — Create
+ *
+ *   POST /api/announcements/create
+ *   Content-Type: application/json
+ *   {
+ *     "title":        "Sabbath service cancelled this week",  (required)
+ *     "body":         "Boiler failure — see updates …",        (required)
+ *     "priority":     "important",                              (optional: normal|important|urgent)
+ *     "isPinned":     true,                                     (optional)
+ *     "publishAt":    "2026-06-07T08:00:00",                   (optional ISO 8601; NULL = immediate)
+ *     "expiresAt":    "2026-06-14T00:00:00",                   (optional; NULL = no expiry)
+ *     "isPublished":  true                                       (optional, default true)
+ *   }
+ *
+ * @package   Portal\API\Announcements
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+ApiResponse::requireAdmin();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$title = trim((string) ($body['title'] ?? ''));
+$text  = trim((string) ($body['body']  ?? ''));
+if ($title === '' || $text === '') {
+    ApiResponse::error('title and body are required', 400);
+}
+$priority = (string) ($body['priority'] ?? 'normal');
+if (in_array($priority, ['normal', 'important', 'urgent'], true) === false) {
+    $priority = 'normal';
+}
+$isPinned    = isset($body['isPinned'])    === true && (bool) $body['isPinned']    === true ? 1 : 0;
+$isPublished = isset($body['isPublished']) === false || (bool) $body['isPublished'] === true ? 1 : 0;
+
+$publishAt = null;
+if (isset($body['publishAt']) === true && trim((string) $body['publishAt']) !== '') {
+    $ts = strtotime((string) $body['publishAt']);
+    if ($ts === false) {
+        ApiResponse::error('publishAt is not a valid timestamp', 400);
+    }
+    $publishAt = date('Y-m-d H:i:s', $ts);
+}
+$expiresAt = null;
+if (isset($body['expiresAt']) === true && trim((string) $body['expiresAt']) !== '') {
+    $ts = strtotime((string) $body['expiresAt']);
+    if ($ts === false) {
+        ApiResponse::error('expiresAt is not a valid timestamp', 400);
+    }
+    $expiresAt = date('Y-m-d H:i:s', $ts);
+}
+
+$slug = strtolower(trim(preg_replace('/[^a-zA-Z0-9]+/', '-', $title), '-'));
+$slug = substr($slug !== '' ? $slug : 'announcement-' . bin2hex(random_bytes(4)), 0, 200);
+
+$siteId    = Site::id();
+$creatorId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+$stmt = $db->prepare(
+    'INSERT INTO tblAnnouncements '
+    . '(siteID, title, slug, body, priority, isPinned, publishAt, expiresAt, isPublished, createdByID) '
+    . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)'
+);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_ANNOUNCEMENT_CREATE_PREP', $db->error, '');
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param(
+    'issssisiii',
+    $siteId, $title, $slug, $text, $priority, $isPinned,
+    $publishAt, $expiresAt, $isPublished, $creatorId
+);
+$ok    = $stmt->execute();
+$newId = (int) $stmt->insert_id;
+$stmt->close();
+
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_ANNOUNCEMENT_CREATE_FAIL', $db->error, '');
+    ApiResponse::error('Failed to create announcement', 500);
+}
+
+Logger::activity('ApiAnnouncementCreate', 'API: created announcement #' . $newId . ' "' . $title . '"');
+
+ApiResponse::success([
+    'announcementID' => $newId,
+    'slug'           => $slug,
+], 201);

--- a/web/_apps/announcements/api/delete.php
+++ b/web/_apps/announcements/api/delete.php
@@ -1,0 +1,67 @@
+<?php
+// Path: _apps/announcements/api/delete.php
+/**
+ * Announcements API — Delete (soft, sets isDeleted = 1)
+ *
+ *   POST /api/announcements/delete
+ *   Content-Type: application/json
+ *   { "announcementID": 42 }
+ *
+ * @package   Portal\API\Announcements
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+ApiResponse::requireAdmin();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$id = (int) ($body['announcementID'] ?? 0);
+if ($id <= 0) {
+    ApiResponse::error('announcementID is required', 400);
+}
+
+$siteId    = Site::id();
+$updaterId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+$stmt = $db->prepare('UPDATE tblAnnouncements SET isDeleted = 1, isPublished = 0, updatedByID = ? WHERE announcementID = ? AND siteID = ?');
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_ANNOUNCEMENT_DELETE_PREP', $db->error, '');
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('iii', $updaterId, $id, $siteId);
+$ok = $stmt->execute();
+$affected = $stmt->affected_rows;
+$stmt->close();
+if ($ok === false) {
+    ApiResponse::error('Failed to delete announcement', 500);
+}
+if ($affected === 0) {
+    ApiResponse::error('Announcement not found', 404);
+}
+
+Logger::activity('ApiAnnouncementDelete', 'API: soft-deleted announcement #' . $id);
+
+ApiResponse::success(['announcementID' => $id, 'deleted' => true]);

--- a/web/_apps/announcements/api/update.php
+++ b/web/_apps/announcements/api/update.php
@@ -1,0 +1,167 @@
+<?php
+// Path: _apps/announcements/api/update.php
+/**
+ * Announcements API — Update (partial)
+ *
+ *   POST /api/announcements/update
+ *   Content-Type: application/json
+ *   {
+ *     "announcementID": 42,                     (required)
+ *     "title":          "…",                     (optional)
+ *     "body":           "…",                     (optional)
+ *     "priority":       "important",             (optional)
+ *     "isPinned":       false,                   (optional)
+ *     "publishAt":      "2026-06-07T08:00:00", (optional)
+ *     "expiresAt":      null,                    (optional)
+ *     "isPublished":    true                     (optional)
+ *   }
+ *
+ * @package   Portal\API\Announcements
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+ApiResponse::requireAdmin();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$id = (int) ($body['announcementID'] ?? 0);
+if ($id <= 0) {
+    ApiResponse::error('announcementID is required', 400);
+}
+
+$siteId    = Site::id();
+$updaterId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+$stmt = $db->prepare('SELECT * FROM tblAnnouncements WHERE announcementID = ? AND siteID = ? AND isDeleted = 0 LIMIT 1');
+if ($stmt === false) {
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('ii', $id, $siteId);
+$stmt->execute();
+$existing = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if ($existing === null) {
+    ApiResponse::error('Announcement not found', 404);
+}
+
+// Build the SET clause from supplied fields only — partial update.
+$updates = [];
+$types   = '';
+$params  = [];
+
+if (array_key_exists('title', $body) === true) {
+    $title = trim((string) $body['title']);
+    if ($title === '') {
+        ApiResponse::error('title cannot be empty', 400);
+    }
+    $updates[] = 'title = ?';
+    $types    .= 's';
+    $params[]  = $title;
+}
+if (array_key_exists('body', $body) === true) {
+    $text = trim((string) $body['body']);
+    if ($text === '') {
+        ApiResponse::error('body cannot be empty', 400);
+    }
+    $updates[] = 'body = ?';
+    $types    .= 's';
+    $params[]  = $text;
+}
+if (array_key_exists('priority', $body) === true) {
+    $priority = (string) $body['priority'];
+    if (in_array($priority, ['normal', 'important', 'urgent'], true) === false) {
+        ApiResponse::error('priority must be one of normal|important|urgent', 400);
+    }
+    $updates[] = 'priority = ?';
+    $types    .= 's';
+    $params[]  = $priority;
+}
+if (array_key_exists('isPinned', $body) === true) {
+    $updates[] = 'isPinned = ?';
+    $types    .= 'i';
+    $params[]  = (bool) $body['isPinned'] === true ? 1 : 0;
+}
+if (array_key_exists('isPublished', $body) === true) {
+    $updates[] = 'isPublished = ?';
+    $types    .= 'i';
+    $params[]  = (bool) $body['isPublished'] === true ? 1 : 0;
+}
+if (array_key_exists('publishAt', $body) === true) {
+    if ($body['publishAt'] === null || trim((string) $body['publishAt']) === '') {
+        $updates[] = 'publishAt = NULL';
+    } else {
+        $ts = strtotime((string) $body['publishAt']);
+        if ($ts === false) {
+            ApiResponse::error('publishAt is not a valid timestamp', 400);
+        }
+        $updates[] = 'publishAt = ?';
+        $types    .= 's';
+        $params[]  = date('Y-m-d H:i:s', $ts);
+    }
+}
+if (array_key_exists('expiresAt', $body) === true) {
+    if ($body['expiresAt'] === null || trim((string) $body['expiresAt']) === '') {
+        $updates[] = 'expiresAt = NULL';
+    } else {
+        $ts = strtotime((string) $body['expiresAt']);
+        if ($ts === false) {
+            ApiResponse::error('expiresAt is not a valid timestamp', 400);
+        }
+        $updates[] = 'expiresAt = ?';
+        $types    .= 's';
+        $params[]  = date('Y-m-d H:i:s', $ts);
+    }
+}
+
+if ($updates === []) {
+    ApiResponse::error('No updatable fields supplied', 400);
+}
+
+$updates[] = 'updatedByID = ?';
+$types    .= 'i';
+$params[]  = $updaterId;
+
+$sql = 'UPDATE tblAnnouncements SET ' . implode(', ', $updates) . ' WHERE announcementID = ? AND siteID = ?';
+$types  .= 'ii';
+$params[] = $id;
+$params[] = $siteId;
+
+$stmt = $db->prepare($sql);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_ANNOUNCEMENT_UPDATE_PREP', $db->error, '');
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param($types, ...$params);
+$ok = $stmt->execute();
+$stmt->close();
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_ANNOUNCEMENT_UPDATE_FAIL', $db->error, '');
+    ApiResponse::error('Failed to update announcement', 500);
+}
+
+Logger::activity('ApiAnnouncementUpdate', 'API: updated announcement #' . $id);
+
+ApiResponse::success(['announcementID' => $id, 'updated' => true]);

--- a/web/_apps/leadership/api/assign.php
+++ b/web/_apps/leadership/api/assign.php
@@ -1,0 +1,105 @@
+<?php
+// Path: _apps/leadership/api/assign.php
+/**
+ * Leadership API — Assign a role to a user OR external person.
+ *
+ *   POST /api/leadership/assign
+ *   {
+ *     "roleID":      4,                       (required)
+ *     "userID":      12,                      (optional — internal portal user)
+ *     "personName":  "Jane Smith",            (required when userID is omitted)
+ *     "personEmail": "jane@example.com",      (optional, for external)
+ *     "startDate":   "2026-07-01",            (optional)
+ *     "endDate":     "2027-06-30",            (optional)
+ *     "notes":       "Term covers …"          (optional)
+ *   }
+ *
+ * @package   Portal\API\Leadership
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+ApiResponse::requireAdmin();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$roleId = (int) ($body['roleID'] ?? 0);
+if ($roleId <= 0) {
+    ApiResponse::error('roleID is required', 400);
+}
+$userId = isset($body['userID']) === true && (int) $body['userID'] > 0
+    ? (int) $body['userID']
+    : null;
+$personName  = trim((string) ($body['personName']  ?? ''));
+$personEmail = trim((string) ($body['personEmail'] ?? ''));
+if ($userId === null && $personName === '') {
+    ApiResponse::error('Either userID or personName must be supplied', 400);
+}
+
+$startDate = null;
+if (isset($body['startDate']) === true && trim((string) $body['startDate']) !== '') {
+    $ts = strtotime((string) $body['startDate']);
+    if ($ts === false) {
+        ApiResponse::error('startDate is not a valid date', 400);
+    }
+    $startDate = date('Y-m-d', $ts);
+}
+$endDate = null;
+if (isset($body['endDate']) === true && trim((string) $body['endDate']) !== '') {
+    $ts = strtotime((string) $body['endDate']);
+    if ($ts === false) {
+        ApiResponse::error('endDate is not a valid date', 400);
+    }
+    $endDate = date('Y-m-d', $ts);
+}
+$notes = (string) ($body['notes'] ?? '');
+
+$siteId    = Site::id();
+$creatorId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+$stmt = $db->prepare(
+    'INSERT INTO tblLeadershipAssignments '
+    . '(siteID, roleID, userID, personName, personEmail, startDate, endDate, notes, isActive, createdByID) '
+    . 'VALUES (?, ?, ?, ?, ?, ?, ?, ?, 1, ?)'
+);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_LEADERSHIP_ASSIGN_PREP', $db->error, '');
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param(
+    'iiisssssi',
+    $siteId, $roleId, $userId, $personName, $personEmail, $startDate, $endDate, $notes, $creatorId
+);
+$ok    = $stmt->execute();
+$newId = (int) $stmt->insert_id;
+$stmt->close();
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_LEADERSHIP_ASSIGN_FAIL', $db->error, '');
+    ApiResponse::error('Failed to assign role', 500);
+}
+
+Logger::activity('ApiLeadershipAssign', 'API: assignment #' . $newId . ' roleID=' . $roleId);
+
+ApiResponse::success(['assignmentID' => $newId], 201);

--- a/web/_apps/leadership/api/unassign.php
+++ b/web/_apps/leadership/api/unassign.php
@@ -1,0 +1,80 @@
+<?php
+// Path: _apps/leadership/api/unassign.php
+/**
+ * Leadership API — End an assignment (sets endDate = today, isActive = 0).
+ *
+ *   POST /api/leadership/unassign
+ *   {
+ *     "assignmentID": 42,
+ *     "endDate":      "2026-07-31"   (optional; defaults to today)
+ *   }
+ *
+ * @package   Portal\API\Leadership
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+ApiResponse::requireAdmin();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$id = (int) ($body['assignmentID'] ?? 0);
+if ($id <= 0) {
+    ApiResponse::error('assignmentID is required', 400);
+}
+
+$endDate = date('Y-m-d');
+if (isset($body['endDate']) === true && trim((string) $body['endDate']) !== '') {
+    $ts = strtotime((string) $body['endDate']);
+    if ($ts === false) {
+        ApiResponse::error('endDate is not a valid date', 400);
+    }
+    $endDate = date('Y-m-d', $ts);
+}
+
+$siteId    = Site::id();
+$updaterId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+$stmt = $db->prepare(
+    'UPDATE tblLeadershipAssignments SET endDate = ?, isActive = 0, updatedByID = ? '
+    . 'WHERE assignmentID = ? AND siteID = ?'
+);
+if ($stmt === false) {
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('siii', $endDate, $updaterId, $id, $siteId);
+$ok = $stmt->execute();
+$affected = $stmt->affected_rows;
+$stmt->close();
+if ($ok === false) {
+    ApiResponse::error('Failed to unassign', 500);
+}
+if ($affected === 0) {
+    ApiResponse::error('Assignment not found', 404);
+}
+
+Logger::activity('ApiLeadershipUnassign', 'API: ended assignment #' . $id . ' on ' . $endDate);
+
+ApiResponse::success(['assignmentID' => $id, 'endDate' => $endDate]);

--- a/web/_apps/prayer-requests/api/create.php
+++ b/web/_apps/prayer-requests/api/create.php
@@ -1,0 +1,81 @@
+<?php
+// Path: _apps/prayer-requests/api/create.php
+/**
+ * Prayer Requests API — Create (logged-in path only; anonymous submission
+ * uses the public form route at /prayer-requests/anonymous which has
+ * captcha gating).
+ *
+ *   POST /api/prayer-requests/create
+ *   {
+ *     "subject":     "Travel mercies for the youth retreat",  (required)
+ *     "body":        "…",                                       (required)
+ *     "visibility":  "congregation",                            (optional: leadership|congregation)
+ *     "isAnonymous": false                                      (optional)
+ *   }
+ *
+ * @package   Portal\API\PrayerRequests
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$subject = trim((string) ($body['subject'] ?? ''));
+$text    = trim((string) ($body['body']    ?? ''));
+if ($subject === '' || $text === '') {
+    ApiResponse::error('subject and body are required', 400);
+}
+$visibility = (string) ($body['visibility'] ?? 'leadership');
+if (in_array($visibility, ['leadership', 'congregation'], true) === false) {
+    $visibility = 'leadership';
+}
+$isAnonymous = isset($body['isAnonymous']) === true && (bool) $body['isAnonymous'] === true ? 1 : 0;
+
+$siteId      = Site::id();
+$submitterId = (int) ($_SESSION['user_id'] ?? 0);
+$submitterIp = substr((string) ($_SERVER['REMOTE_ADDR'] ?? ''), 0, 45);
+
+$db = App::db();
+$stmt = $db->prepare(
+    'INSERT INTO tblPrayerRequests '
+    . '(siteID, submitterID, submitterIP, subject, body, visibility, status, isAnonymous) '
+    . 'VALUES (?, ?, ?, ?, ?, ?, "pending", ?)'
+);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_PRAYER_CREATE_PREP', $db->error, '');
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('iissssi', $siteId, $submitterId, $submitterIp, $subject, $text, $visibility, $isAnonymous);
+$ok    = $stmt->execute();
+$newId = (int) $stmt->insert_id;
+$stmt->close();
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_PRAYER_CREATE_FAIL', $db->error, '');
+    ApiResponse::error('Failed to create prayer request', 500);
+}
+
+Logger::activity('ApiPrayerRequestCreate', 'API: created prayer request #' . $newId);
+
+ApiResponse::success(['requestID' => $newId, 'status' => 'pending'], 201);

--- a/web/_apps/prayer-requests/api/moderate.php
+++ b/web/_apps/prayer-requests/api/moderate.php
@@ -1,0 +1,92 @@
+<?php
+// Path: _apps/prayer-requests/api/moderate.php
+/**
+ * Prayer Requests API — Moderation (admin / prayer-team only)
+ *
+ *   POST /api/prayer-requests/moderate
+ *   {
+ *     "requestID": 42,
+ *     "status":    "active",                (one of: active|answered|archived)
+ *     "testimony": "Praise — got the job!"  (optional; appended when status = answered)
+ *   }
+ *
+ * @package   Portal\API\PrayerRequests
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+Auth::ensureSession();
+
+if (App::isAdmin() === false && App::hasRole('prayer_team') === false) {
+    ApiResponse::error('Forbidden — moderation requires admin or prayer_team role', 403);
+}
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$id     = (int) ($body['requestID'] ?? 0);
+$status = (string) ($body['status'] ?? '');
+if ($id <= 0) {
+    ApiResponse::error('requestID is required', 400);
+}
+if (in_array($status, ['active', 'answered', 'archived'], true) === false) {
+    ApiResponse::error('status must be one of active|answered|archived', 400);
+}
+$testimony = isset($body['testimony']) === true ? trim((string) $body['testimony']) : '';
+
+$siteId      = Site::id();
+$moderatorId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+if ($status === 'answered') {
+    $stmt = $db->prepare(
+        'UPDATE tblPrayerRequests SET status = ?, testimony = ?, answeredAt = NOW(), '
+        . 'moderatorID = ?, moderatedAt = NOW() '
+        . 'WHERE requestID = ? AND siteID = ?'
+    );
+    if ($stmt === false) {
+        ApiResponse::error('Database error', 500);
+    }
+    $stmt->bind_param('ssiii', $status, $testimony, $moderatorId, $id, $siteId);
+} else {
+    $stmt = $db->prepare(
+        'UPDATE tblPrayerRequests SET status = ?, moderatorID = ?, moderatedAt = NOW() '
+        . 'WHERE requestID = ? AND siteID = ?'
+    );
+    if ($stmt === false) {
+        ApiResponse::error('Database error', 500);
+    }
+    $stmt->bind_param('siii', $status, $moderatorId, $id, $siteId);
+}
+$ok = $stmt->execute();
+$affected = $stmt->affected_rows;
+$stmt->close();
+if ($ok === false) {
+    ApiResponse::error('Failed to moderate request', 500);
+}
+if ($affected === 0) {
+    ApiResponse::error('Prayer request not found', 404);
+}
+
+Logger::activity('ApiPrayerRequestModerate', 'API: moderated prayer request #' . $id . ' → ' . $status);
+
+ApiResponse::success(['requestID' => $id, 'status' => $status]);

--- a/web/_apps/tasks/api/complete.php
+++ b/web/_apps/tasks/api/complete.php
@@ -1,0 +1,78 @@
+<?php
+// Path: _apps/tasks/api/complete.php
+/**
+ * Tasks API — Mark complete
+ *
+ *   POST /api/tasks/complete
+ *   { "taskID": 42 }
+ *
+ *   Only the task assignee or an admin can complete it.
+ *
+ * @package   Portal\API\Tasks
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$id = (int) ($body['taskID'] ?? 0);
+if ($id <= 0) {
+    ApiResponse::error('taskID is required', 400);
+}
+
+$siteId   = Site::id();
+$callerId = (int) ($_SESSION['user_id'] ?? 0);
+$isAdmin  = App::isAdmin();
+
+$db = App::db();
+$stmt = $db->prepare('SELECT assignedToID, status FROM tblTasks WHERE taskID = ? AND siteID = ? LIMIT 1');
+if ($stmt === false) {
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('ii', $id, $siteId);
+$stmt->execute();
+$task = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if ($task === null) {
+    ApiResponse::error('Task not found', 404);
+}
+if ((int) $task['assignedToID'] !== $callerId && $isAdmin === false) {
+    ApiResponse::error('Only the assignee or an admin can complete this task', 403);
+}
+if ((string) $task['status'] === 'completed') {
+    ApiResponse::error('Task is already completed', 409);
+}
+
+$stmt = $db->prepare('UPDATE tblTasks SET status = "completed", completedAt = NOW() WHERE taskID = ? AND siteID = ?');
+if ($stmt === false) {
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('ii', $id, $siteId);
+$stmt->execute();
+$stmt->close();
+
+Logger::activity('ApiTaskComplete', 'API: completed task #' . $id);
+
+ApiResponse::success(['taskID' => $id, 'status' => 'completed']);

--- a/web/_apps/tasks/api/create.php
+++ b/web/_apps/tasks/api/create.php
@@ -1,0 +1,96 @@
+<?php
+// Path: _apps/tasks/api/create.php
+/**
+ * Tasks API — Create
+ *
+ *   POST /api/tasks/create
+ *   Content-Type: application/json
+ *   {
+ *     "title":         "Order baptism certificates",  (required)
+ *     "description":   "…",                            (optional)
+ *     "assignedToID":  12,                              (optional; defaults to caller)
+ *     "priority":      "high",                          (optional: low|normal|high|urgent)
+ *     "dueDate":       "2026-07-01"                    (optional, YYYY-MM-DD)
+ *   }
+ *
+ * @package   Portal\API\Tasks
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$title = trim((string) ($body['title'] ?? ''));
+if ($title === '') {
+    ApiResponse::error('title is required', 400);
+}
+$description = (string) ($body['description'] ?? '');
+
+$priority = (string) ($body['priority'] ?? 'normal');
+if (in_array($priority, ['low', 'normal', 'high', 'urgent'], true) === false) {
+    $priority = 'normal';
+}
+
+$callerId    = (int) ($_SESSION['user_id'] ?? 0);
+$assignedTo  = isset($body['assignedToID']) === true && (int) $body['assignedToID'] > 0
+    ? (int) $body['assignedToID']
+    : $callerId;
+
+$dueDate = null;
+if (isset($body['dueDate']) === true && trim((string) $body['dueDate']) !== '') {
+    $ts = strtotime((string) $body['dueDate']);
+    if ($ts === false) {
+        ApiResponse::error('dueDate is not a valid date', 400);
+    }
+    $dueDate = date('Y-m-d', $ts);
+}
+
+$siteId = Site::id();
+
+$db = App::db();
+$stmt = $db->prepare(
+    'INSERT INTO tblTasks '
+    . '(siteID, title, description, assignedToID, createdByID, priority, status, dueDate) '
+    . 'VALUES (?, ?, ?, ?, ?, ?, "pending", ?)'
+);
+if ($stmt === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_TASK_CREATE_PREP', $db->error, '');
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param(
+    'issiiss',
+    $siteId, $title, $description, $assignedTo, $callerId, $priority, $dueDate
+);
+$ok    = $stmt->execute();
+$newId = (int) $stmt->insert_id;
+$stmt->close();
+if ($ok === false) {
+    Logger::errorPlatform('MySQL', 'Error', 'API_TASK_CREATE_FAIL', $db->error, '');
+    ApiResponse::error('Failed to create task', 500);
+}
+
+Logger::activity('ApiTaskCreate', 'API: created task #' . $newId . ' "' . $title . '"');
+
+ApiResponse::success(['taskID' => $newId], 201);

--- a/web/_apps/tasks/api/delete.php
+++ b/web/_apps/tasks/api/delete.php
@@ -1,0 +1,74 @@
+<?php
+// Path: _apps/tasks/api/delete.php
+/**
+ * Tasks API — Delete (hard delete)
+ *
+ *   POST /api/tasks/delete
+ *   { "taskID": 42 }
+ *
+ *   Only the creator or an admin can delete a task.
+ *
+ * @package   Portal\API\Tasks
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/157
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiResponse;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Logger;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    ApiResponse::error('POST required', 405);
+}
+ApiResponse::requireAuth();
+Auth::ensureSession();
+
+$csrfHeader = $_SERVER['HTTP_X_CSRF_TOKEN'] ?? '';
+$rawBody    = (string) file_get_contents('php://input');
+$body       = json_decode($rawBody, true);
+if (is_array($body) === false) {
+    $body = [];
+}
+$csrfBody = (string) ($body['csrf_token'] ?? '');
+if (Auth::verifyCsrf($csrfHeader !== '' ? $csrfHeader : $csrfBody) === false) {
+    ApiResponse::error('CSRF check failed', 403);
+}
+
+$id = (int) ($body['taskID'] ?? 0);
+if ($id <= 0) {
+    ApiResponse::error('taskID is required', 400);
+}
+
+$siteId   = Site::id();
+$callerId = (int) ($_SESSION['user_id'] ?? 0);
+
+$db = App::db();
+$stmt = $db->prepare('SELECT createdByID FROM tblTasks WHERE taskID = ? AND siteID = ? LIMIT 1');
+if ($stmt === false) {
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('ii', $id, $siteId);
+$stmt->execute();
+$task = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if ($task === null) {
+    ApiResponse::error('Task not found', 404);
+}
+if ((int) $task['createdByID'] !== $callerId && App::isAdmin() === false) {
+    ApiResponse::error('Only the creator or an admin can delete this task', 403);
+}
+
+$stmt = $db->prepare('DELETE FROM tblTasks WHERE taskID = ? AND siteID = ?');
+if ($stmt === false) {
+    ApiResponse::error('Database error', 500);
+}
+$stmt->bind_param('ii', $id, $siteId);
+$stmt->execute();
+$stmt->close();
+
+Logger::activity('ApiTaskDelete', 'API: deleted task #' . $id);
+
+ApiResponse::success(['taskID' => $id, 'deleted' => true]);

--- a/web/_sql/106_api_write_crud.sql
+++ b/web/_sql/106_api_write_crud.sql
@@ -1,0 +1,41 @@
+-- =============================================================================
+-- Migration 106: REST API write-side CRUD endpoints (#157)
+-- =============================================================================
+-- Registers route targetFiles so check_route_targets.py confirms each is
+-- reachable. ApiRouter::dispatch() actually routes by URL pattern
+-- (`api/{appName}/{action}`) and resolves to {appName}/api/{action}.php,
+-- so the targetFile values here are informational — the audit still
+-- needs them.
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    -- Announcements
+    ('api/announcements/create', 'announcements/api/create.php', 1),
+    ('api/announcements/update', 'announcements/api/update.php', 1),
+    ('api/announcements/delete', 'announcements/api/delete.php', 1),
+    -- Tasks
+    ('api/tasks/create',         'tasks/api/create.php',         1),
+    ('api/tasks/complete',       'tasks/api/complete.php',       1),
+    ('api/tasks/delete',         'tasks/api/delete.php',         1),
+    -- Prayer Requests
+    ('api/prayer-requests/create',   'prayer-requests/api/create.php',   1),
+    ('api/prayer-requests/moderate', 'prayer-requests/api/moderate.php', 1),
+    -- Leadership
+    ('api/leadership/assign',   'leadership/api/assign.php',   1),
+    ('api/leadership/unassign', 'leadership/api/unassign.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    -- Mirror the existing per-action enabled-flag convention from v1.0.
+    -- Defaults to enabled — admins can turn individual endpoints off via
+    -- /admin/settings if they don't want the API surface exposed.
+    (NULL, 'api.announcements.create.enabled',     'true', 'true', 0),
+    (NULL, 'api.announcements.update.enabled',     'true', 'true', 0),
+    (NULL, 'api.announcements.delete.enabled',     'true', 'true', 0),
+    (NULL, 'api.tasks.create.enabled',             'true', 'true', 0),
+    (NULL, 'api.tasks.complete.enabled',           'true', 'true', 0),
+    (NULL, 'api.tasks.delete.enabled',             'true', 'true', 0),
+    (NULL, 'api.prayer-requests.create.enabled',   'true', 'true', 0),
+    (NULL, 'api.prayer-requests.moderate.enabled', 'true', 'true', 0),
+    (NULL, 'api.leadership.assign.enabled',        'true', 'true', 0),
+    (NULL, 'api.leadership.unassign.enabled',      'true', 'true', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);

--- a/web/_sql/full_schema.sql
+++ b/web/_sql/full_schema.sql
@@ -4331,3 +4331,45 @@ ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
 INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
     ('help/disaster-recovery', 'help/disaster-recovery.php', 1)
 ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+-- =============================================================================
+-- Migration 106: REST API write-side CRUD endpoints (#157)
+-- =============================================================================
+-- Registers route targetFiles so check_route_targets.py confirms each is
+-- reachable. ApiRouter::dispatch() actually routes by URL pattern
+-- (`api/{appName}/{action}`) and resolves to {appName}/api/{action}.php,
+-- so the targetFile values here are informational — the audit still
+-- needs them.
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    -- Announcements
+    ('api/announcements/create', 'announcements/api/create.php', 1),
+    ('api/announcements/update', 'announcements/api/update.php', 1),
+    ('api/announcements/delete', 'announcements/api/delete.php', 1),
+    -- Tasks
+    ('api/tasks/create',         'tasks/api/create.php',         1),
+    ('api/tasks/complete',       'tasks/api/complete.php',       1),
+    ('api/tasks/delete',         'tasks/api/delete.php',         1),
+    -- Prayer Requests
+    ('api/prayer-requests/create',   'prayer-requests/api/create.php',   1),
+    ('api/prayer-requests/moderate', 'prayer-requests/api/moderate.php', 1),
+    -- Leadership
+    ('api/leadership/assign',   'leadership/api/assign.php',   1),
+    ('api/leadership/unassign', 'leadership/api/unassign.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);
+
+INSERT INTO `tblSettings` (`siteID`, `settingKey`, `settingValue`, `defaultValue`, `isSensitive`) VALUES
+    -- Mirror the existing per-action enabled-flag convention from v1.0.
+    -- Defaults to enabled — admins can turn individual endpoints off via
+    -- /admin/settings if they don't want the API surface exposed.
+    (NULL, 'api.announcements.create.enabled',     'true', 'true', 0),
+    (NULL, 'api.announcements.update.enabled',     'true', 'true', 0),
+    (NULL, 'api.announcements.delete.enabled',     'true', 'true', 0),
+    (NULL, 'api.tasks.create.enabled',             'true', 'true', 0),
+    (NULL, 'api.tasks.complete.enabled',           'true', 'true', 0),
+    (NULL, 'api.tasks.delete.enabled',             'true', 'true', 0),
+    (NULL, 'api.prayer-requests.create.enabled',   'true', 'true', 0),
+    (NULL, 'api.prayer-requests.moderate.enabled', 'true', 'true', 0),
+    (NULL, 'api.leadership.assign.enabled',        'true', 'true', 0),
+    (NULL, 'api.leadership.unassign.enabled',      'true', 'true', 0)
+ON DUPLICATE KEY UPDATE `defaultValue` = VALUES(`defaultValue`);
+

--- a/web/public_html/openapi.json
+++ b/web/public_html/openapi.json
@@ -14,32 +14,62 @@
     }
   },
   "servers": [
-    { "url": "/", "description": "Same-origin (whichever portal is serving this page)" }
+    {
+      "url": "/",
+      "description": "Same-origin (whichever portal is serving this page)"
+    }
   ],
   "security": [
-    { "sessionCookie": [], "csrfToken": [] }
+    {
+      "sessionCookie": [],
+      "csrfToken": []
+    }
   ],
   "tags": [
-    { "name": "Events",          "description": "Events / calendar entries" },
-    { "name": "Attendance",      "description": "Headcount sessions" },
-    { "name": "Announcements",   "description": "Per-site noticeboard" },
-    { "name": "Leadership",      "description": "Roles + assignments" },
-    { "name": "Tasks",           "description": "Reminders / tasks" },
-    { "name": "Prayer Requests", "description": "Prayer requests (visibility-aware)" },
-    { "name": "Documents",       "description": "Document library" },
-    { "name": "Users",           "description": "User directory (admin only)" }
+    {
+      "name": "Events",
+      "description": "Events / calendar entries"
+    },
+    {
+      "name": "Attendance",
+      "description": "Headcount sessions"
+    },
+    {
+      "name": "Announcements",
+      "description": "Per-site noticeboard"
+    },
+    {
+      "name": "Leadership",
+      "description": "Roles + assignments"
+    },
+    {
+      "name": "Tasks",
+      "description": "Reminders / tasks"
+    },
+    {
+      "name": "Prayer Requests",
+      "description": "Prayer requests (visibility-aware)"
+    },
+    {
+      "name": "Documents",
+      "description": "Document library"
+    },
+    {
+      "name": "Users",
+      "description": "User directory (admin only)"
+    }
   ],
   "components": {
     "securitySchemes": {
       "sessionCookie": {
-        "type":  "apiKey",
-        "in":    "cookie",
-        "name":  "PHPSESSID",
+        "type": "apiKey",
+        "in": "cookie",
+        "name": "PHPSESSID",
         "description": "Portal session cookie set on sign-in."
       },
       "csrfToken": {
         "type": "apiKey",
-        "in":   "header",
+        "in": "header",
         "name": "X-CSRF-TOKEN",
         "description": "CSRF token. Read from `<meta name=\"csrf-token\">` in the portal HTML or from the session. Required on POST endpoints; ignored on read-only GETs."
       }
@@ -47,27 +77,65 @@
     "schemas": {
       "Error": {
         "type": "object",
-        "required": ["status", "message"],
+        "required": [
+          "status",
+          "message"
+        ],
         "properties": {
-          "status":  { "type": "string", "example": "error" },
-          "message": { "type": "string", "example": "Forbidden" },
-          "detail":  { "type": "string", "nullable": true }
+          "status": {
+            "type": "string",
+            "example": "error"
+          },
+          "message": {
+            "type": "string",
+            "example": "Forbidden"
+          },
+          "detail": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "PaginatedListResponse": {
         "type": "object",
-        "required": ["status", "data"],
+        "required": [
+          "status",
+          "data"
+        ],
         "properties": {
-          "status": { "type": "string", "example": "success" },
+          "status": {
+            "type": "string",
+            "example": "success"
+          },
           "data": {
             "type": "object",
             "properties": {
-              "count":      { "type": "integer", "example": 12 },
-              "page":       { "type": "integer", "example": 1 },
-              "limit":      { "type": "integer", "example": 20 },
-              "totalItems": { "type": "integer", "example": 142 },
-              "totalPages": { "type": "integer", "example": 8 },
-              "items":      { "type": "array", "items": { "type": "object" } }
+              "count": {
+                "type": "integer",
+                "example": 12
+              },
+              "page": {
+                "type": "integer",
+                "example": 1
+              },
+              "limit": {
+                "type": "integer",
+                "example": 20
+              },
+              "totalItems": {
+                "type": "integer",
+                "example": 142
+              },
+              "totalPages": {
+                "type": "integer",
+                "example": 8
+              },
+              "items": {
+                "type": "array",
+                "items": {
+                  "type": "object"
+                }
+              }
             }
           }
         }
@@ -75,38 +143,143 @@
       "Event": {
         "type": "object",
         "properties": {
-          "eventID":       { "type": "integer", "example": 1234 },
-          "eventName":     { "type": "string",  "example": "Sunday Service" },
-          "eventSlug":     { "type": "string",  "example": "sunday-service" },
-          "description":   { "type": "string",  "nullable": true },
-          "startDateTime": { "type": "string",  "format": "date-time" },
-          "endDateTime":   { "type": "string",  "format": "date-time", "nullable": true },
-          "timezone":      { "type": "string",  "example": "Europe/London", "nullable": true },
-          "isAllDay":      { "type": "integer", "enum": [0, 1] },
-          "locationName":  { "type": "string",  "nullable": true },
-          "status":        { "type": "string",  "enum": ["draft", "published", "cancelled", "archived"] },
-          "isPublic":      { "type": "integer", "enum": [0, 1] },
-          "isFeatured":    { "type": "integer", "enum": [0, 1] },
-          "categoryName":  { "type": "string",  "nullable": true },
-          "typeName":      { "type": "string",  "nullable": true }
+          "eventID": {
+            "type": "integer",
+            "example": 1234
+          },
+          "eventName": {
+            "type": "string",
+            "example": "Sunday Service"
+          },
+          "eventSlug": {
+            "type": "string",
+            "example": "sunday-service"
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "timezone": {
+            "type": "string",
+            "example": "Europe/London",
+            "nullable": true
+          },
+          "isAllDay": {
+            "type": "integer",
+            "enum": [
+              0,
+              1
+            ]
+          },
+          "locationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "published",
+              "cancelled",
+              "archived"
+            ]
+          },
+          "isPublic": {
+            "type": "integer",
+            "enum": [
+              0,
+              1
+            ]
+          },
+          "isFeatured": {
+            "type": "integer",
+            "enum": [
+              0,
+              1
+            ]
+          },
+          "categoryName": {
+            "type": "string",
+            "nullable": true
+          },
+          "typeName": {
+            "type": "string",
+            "nullable": true
+          }
         }
       },
       "EventCreate": {
         "type": "object",
-        "required": ["eventName", "startDateTime"],
+        "required": [
+          "eventName",
+          "startDateTime"
+        ],
         "properties": {
-          "eventName":     { "type": "string", "example": "Worship Service" },
-          "startDateTime": { "type": "string", "format": "date-time", "example": "2026-06-01T10:00:00" },
-          "endDateTime":   { "type": "string", "format": "date-time", "nullable": true },
-          "isAllDay":      { "type": "boolean", "default": false },
-          "locationName":  { "type": "string",  "nullable": true },
-          "categoryID":    { "type": "integer", "nullable": true },
-          "typeID":        { "type": "integer", "nullable": true },
-          "status":        { "type": "string",  "enum": ["draft", "published", "cancelled", "archived"], "default": "draft" },
-          "isPublic":      { "type": "boolean", "default": true },
-          "isFeatured":    { "type": "boolean", "default": false },
-          "description":   { "type": "string",  "nullable": true },
-          "csrf_token":    { "type": "string",  "description": "CSRF token (or use X-CSRF-TOKEN header)" }
+          "eventName": {
+            "type": "string",
+            "example": "Worship Service"
+          },
+          "startDateTime": {
+            "type": "string",
+            "format": "date-time",
+            "example": "2026-06-01T10:00:00"
+          },
+          "endDateTime": {
+            "type": "string",
+            "format": "date-time",
+            "nullable": true
+          },
+          "isAllDay": {
+            "type": "boolean",
+            "default": false
+          },
+          "locationName": {
+            "type": "string",
+            "nullable": true
+          },
+          "categoryID": {
+            "type": "integer",
+            "nullable": true
+          },
+          "typeID": {
+            "type": "integer",
+            "nullable": true
+          },
+          "status": {
+            "type": "string",
+            "enum": [
+              "draft",
+              "published",
+              "cancelled",
+              "archived"
+            ],
+            "default": "draft"
+          },
+          "isPublic": {
+            "type": "boolean",
+            "default": true
+          },
+          "isFeatured": {
+            "type": "boolean",
+            "default": false
+          },
+          "description": {
+            "type": "string",
+            "nullable": true
+          },
+          "csrf_token": {
+            "type": "string",
+            "description": "CSRF token (or use X-CSRF-TOKEN header)"
+          }
         }
       }
     }
@@ -114,150 +287,393 @@
   "paths": {
     "/api/events/list": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "List published events for the current site",
         "parameters": [
-          { "name": "page",  "in": "query", "schema": { "type": "integer", "minimum": 1, "default": 1 } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer", "minimum": 1, "maximum": 100, "default": 20 } }
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "minimum": 1,
+              "maximum": 100,
+              "default": 20
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/PaginatedListResponse" } } } },
-          "401": { "description": "Auth required", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Error" } } } },
-          "403": { "description": "Endpoint disabled" }
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/PaginatedListResponse"
+                }
+              }
+            }
+          },
+          "401": {
+            "description": "Auth required",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Error"
+                }
+              }
+            }
+          },
+          "403": {
+            "description": "Endpoint disabled"
+          }
         }
       }
     },
     "/api/events/detail": {
       "get": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Fetch a single event by ID or slug",
         "parameters": [
-          { "name": "id",   "in": "query", "schema": { "type": "integer" } },
-          { "name": "slug", "in": "query", "schema": { "type": "string" } }
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "slug",
+            "in": "query",
+            "schema": {
+              "type": "string"
+            }
+          }
         ],
         "responses": {
-          "200": { "description": "OK", "content": { "application/json": { "schema": { "$ref": "#/components/schemas/Event" } } } },
-          "404": { "description": "Not found" }
+          "200": {
+            "description": "OK",
+            "content": {
+              "application/json": {
+                "schema": {
+                  "$ref": "#/components/schemas/Event"
+                }
+              }
+            }
+          },
+          "404": {
+            "description": "Not found"
+          }
         }
       }
     },
     "/api/events/create": {
       "post": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Create a new event (admin only)",
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "$ref": "#/components/schemas/EventCreate" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "$ref": "#/components/schemas/EventCreate"
+              }
+            }
+          }
         },
         "responses": {
-          "201": { "description": "Created" },
-          "400": { "description": "Validation error" },
-          "403": { "description": "Admin required or CSRF failed" }
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Admin required or CSRF failed"
+          }
         }
       }
     },
     "/api/events/update": {
       "post": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Update event fields (PATCH-style; only present fields are touched)",
         "parameters": [
-          { "name": "id", "in": "query", "schema": { "type": "integer" }, "description": "Or pass eventID in body" }
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Or pass eventID in body"
+          }
         ],
         "requestBody": {
           "required": true,
-          "content": { "application/json": { "schema": { "type": "object", "description": "Subset of EventCreate fields + eventID" } } }
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "description": "Subset of EventCreate fields + eventID"
+              }
+            }
+          }
         },
         "responses": {
-          "200": { "description": "OK" },
-          "400": { "description": "Validation error" },
-          "404": { "description": "Event not found" }
+          "200": {
+            "description": "OK"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "404": {
+            "description": "Event not found"
+          }
         }
       }
     },
     "/api/events/delete": {
       "post": {
-        "tags": ["Events"],
+        "tags": [
+          "Events"
+        ],
         "summary": "Soft-delete an event (isDeleted = 1)",
         "parameters": [
-          { "name": "id", "in": "query", "schema": { "type": "integer" }, "description": "Or pass eventID in body" }
+          {
+            "name": "id",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Or pass eventID in body"
+          }
         ],
         "responses": {
-          "200": { "description": "OK" },
-          "404": { "description": "Event not found or already deleted" }
+          "200": {
+            "description": "OK"
+          },
+          "404": {
+            "description": "Event not found or already deleted"
+          }
         }
       }
     },
     "/api/attendance/list": {
       "get": {
-        "tags": ["Attendance"],
+        "tags": [
+          "Attendance"
+        ],
         "summary": "List attendance sessions for the current site",
         "parameters": [
-          { "name": "page",  "in": "query", "schema": { "type": "integer", "default": 1 } },
-          { "name": "limit", "in": "query", "schema": { "type": "integer", "default": 20 } }
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
         ],
-        "responses": { "200": { "description": "OK" } }
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/announcements/list": {
       "get": {
-        "tags": ["Announcements"],
+        "tags": [
+          "Announcements"
+        ],
         "summary": "List active announcements for the current site",
-        "responses": { "200": { "description": "OK" } }
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/leadership/list": {
       "get": {
-        "tags": ["Leadership"],
+        "tags": [
+          "Leadership"
+        ],
         "summary": "List leadership roles and current assignees",
         "parameters": [
-          { "name": "role", "in": "query", "schema": { "type": "integer" }, "description": "Optional roleID filter" }
+          {
+            "name": "role",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Optional roleID filter"
+          }
         ],
-        "responses": { "200": { "description": "OK" } }
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/tasks/list": {
       "get": {
-        "tags": ["Tasks"],
+        "tags": [
+          "Tasks"
+        ],
         "summary": "List tasks (own by default; admins can filter via userID)",
         "parameters": [
-          { "name": "status", "in": "query", "schema": { "type": "string", "enum": ["open", "completed", "all"], "default": "open" } },
-          { "name": "userID", "in": "query", "schema": { "type": "integer" }, "description": "Admin-only filter" },
-          { "name": "page",   "in": "query", "schema": { "type": "integer", "default": 1 } },
-          { "name": "limit",  "in": "query", "schema": { "type": "integer", "default": 20 } }
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "open",
+                "completed",
+                "all"
+              ],
+              "default": "open"
+            }
+          },
+          {
+            "name": "userID",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            },
+            "description": "Admin-only filter"
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
         ],
-        "responses": { "200": { "description": "OK" } }
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/prayer-requests/list": {
       "get": {
-        "tags": ["Prayer Requests"],
+        "tags": [
+          "Prayer Requests"
+        ],
         "summary": "List prayer requests visible to the current user",
         "description": "Non-admins see their own requests plus congregation-visible ones. Admins see all. Anonymous-flagged requests have `submitterID` nulled for non-admin readers.",
         "parameters": [
-          { "name": "status", "in": "query", "schema": { "type": "string", "enum": ["pending", "active", "answered", "archived", "all"], "default": "active" } }
+          {
+            "name": "status",
+            "in": "query",
+            "schema": {
+              "type": "string",
+              "enum": [
+                "pending",
+                "active",
+                "answered",
+                "archived",
+                "all"
+              ],
+              "default": "active"
+            }
+          }
         ],
-        "responses": { "200": { "description": "OK" } }
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/documents/list": {
       "get": {
-        "tags": ["Documents"],
+        "tags": [
+          "Documents"
+        ],
         "summary": "List documents for the current site",
         "parameters": [
-          { "name": "categoryID", "in": "query", "schema": { "type": "integer" } },
-          { "name": "page",       "in": "query", "schema": { "type": "integer", "default": 1 } },
-          { "name": "limit",      "in": "query", "schema": { "type": "integer", "default": 20 } }
+          {
+            "name": "categoryID",
+            "in": "query",
+            "schema": {
+              "type": "integer"
+            }
+          },
+          {
+            "name": "page",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 1
+            }
+          },
+          {
+            "name": "limit",
+            "in": "query",
+            "schema": {
+              "type": "integer",
+              "default": 20
+            }
+          }
         ],
-        "responses": { "200": { "description": "OK" } }
+        "responses": {
+          "200": {
+            "description": "OK"
+          }
+        }
       }
     },
     "/api/users/list": {
       "get": {
-        "tags": ["Users"],
+        "tags": [
+          "Users"
+        ],
         "summary": "List users (admin only)",
         "responses": {
-          "200": { "description": "OK" },
-          "403": { "description": "Admin required" }
+          "200": {
+            "description": "OK"
+          },
+          "403": {
+            "description": "Admin required"
+          }
         }
       }
     },
@@ -274,19 +690,598 @@
                 "schema": {
                   "type": "object",
                   "properties": {
-                    "status":     { "type": "string", "example": "ok" },
-                    "env":        { "type": "string", "example": "prod" },
-                    "version":    { "type": "string", "example": "1.0.0" },
-                    "phpVersion": { "type": "string", "example": "8.5.5" },
-                    "siteID":     { "type": "integer", "example": 1 },
-                    "db":         { "type": "string", "example": "ok" },
-                    "time":       { "type": "string", "format": "date-time" }
+                    "status": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "env": {
+                      "type": "string",
+                      "example": "prod"
+                    },
+                    "version": {
+                      "type": "string",
+                      "example": "1.0.0"
+                    },
+                    "phpVersion": {
+                      "type": "string",
+                      "example": "8.5.5"
+                    },
+                    "siteID": {
+                      "type": "integer",
+                      "example": 1
+                    },
+                    "db": {
+                      "type": "string",
+                      "example": "ok"
+                    },
+                    "time": {
+                      "type": "string",
+                      "format": "date-time"
+                    }
                   }
                 }
               }
             }
           },
-          "503": { "description": "Degraded — DB unreachable" }
+          "503": {
+            "description": "Degraded \u2014 DB unreachable"
+          }
+        }
+      }
+    },
+    "/api/announcements/create": {
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "summary": "Create an announcement (admin)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title",
+                  "body"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "normal",
+                      "important",
+                      "urgent"
+                    ]
+                  },
+                  "isPinned": {
+                    "type": "boolean"
+                  },
+                  "isPublished": {
+                    "type": "boolean"
+                  },
+                  "publishAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/announcements/update": {
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "summary": "Update an announcement partially (admin)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "announcementID"
+                ],
+                "properties": {
+                  "announcementID": {
+                    "type": "integer"
+                  },
+                  "title": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "normal",
+                      "important",
+                      "urgent"
+                    ]
+                  },
+                  "isPinned": {
+                    "type": "boolean"
+                  },
+                  "isPublished": {
+                    "type": "boolean"
+                  },
+                  "publishAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true
+                  },
+                  "expiresAt": {
+                    "type": "string",
+                    "format": "date-time",
+                    "nullable": true
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Updated"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/announcements/delete": {
+      "post": {
+        "tags": [
+          "Announcements"
+        ],
+        "summary": "Soft-delete an announcement (admin)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "announcementID"
+                ],
+                "properties": {
+                  "announcementID": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/tasks/create": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Create a task",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "title"
+                ],
+                "properties": {
+                  "title": {
+                    "type": "string"
+                  },
+                  "description": {
+                    "type": "string"
+                  },
+                  "assignedToID": {
+                    "type": "integer"
+                  },
+                  "priority": {
+                    "type": "string",
+                    "enum": [
+                      "low",
+                      "normal",
+                      "high",
+                      "urgent"
+                    ]
+                  },
+                  "dueDate": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/tasks/complete": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Mark a task complete (assignee or admin only)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "taskID"
+                ],
+                "properties": {
+                  "taskID": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Completed"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/tasks/delete": {
+      "post": {
+        "tags": [
+          "Tasks"
+        ],
+        "summary": "Delete a task (creator or admin only)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "taskID"
+                ],
+                "properties": {
+                  "taskID": {
+                    "type": "integer"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Deleted"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/prayer-requests/create": {
+      "post": {
+        "tags": [
+          "Prayer Requests"
+        ],
+        "summary": "Submit a prayer request (logged-in)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "subject",
+                  "body"
+                ],
+                "properties": {
+                  "subject": {
+                    "type": "string"
+                  },
+                  "body": {
+                    "type": "string"
+                  },
+                  "visibility": {
+                    "type": "string",
+                    "enum": [
+                      "leadership",
+                      "congregation"
+                    ]
+                  },
+                  "isAnonymous": {
+                    "type": "boolean"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/prayer-requests/moderate": {
+      "post": {
+        "tags": [
+          "Prayer Requests"
+        ],
+        "summary": "Moderate a prayer request (admin or prayer_team role)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "requestID",
+                  "status"
+                ],
+                "properties": {
+                  "requestID": {
+                    "type": "integer"
+                  },
+                  "status": {
+                    "type": "string",
+                    "enum": [
+                      "active",
+                      "answered",
+                      "archived"
+                    ]
+                  },
+                  "testimony": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Moderated"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/leadership/assign": {
+      "post": {
+        "tags": [
+          "Leadership"
+        ],
+        "summary": "Assign a leadership role to a user or external person (admin)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "roleID"
+                ],
+                "properties": {
+                  "roleID": {
+                    "type": "integer"
+                  },
+                  "userID": {
+                    "type": "integer",
+                    "nullable": true
+                  },
+                  "personName": {
+                    "type": "string"
+                  },
+                  "personEmail": {
+                    "type": "string"
+                  },
+                  "startDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  },
+                  "notes": {
+                    "type": "string"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Created"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
+        }
+      }
+    },
+    "/api/leadership/unassign": {
+      "post": {
+        "tags": [
+          "Leadership"
+        ],
+        "summary": "End an active leadership assignment (admin)",
+        "requestBody": {
+          "required": true,
+          "content": {
+            "application/json": {
+              "schema": {
+                "type": "object",
+                "required": [
+                  "assignmentID"
+                ],
+                "properties": {
+                  "assignmentID": {
+                    "type": "integer"
+                  },
+                  "endDate": {
+                    "type": "string",
+                    "format": "date"
+                  }
+                }
+              }
+            }
+          }
+        },
+        "responses": {
+          "200": {
+            "description": "Updated / OK"
+          },
+          "201": {
+            "description": "Unassigned"
+          },
+          "400": {
+            "description": "Validation error"
+          },
+          "403": {
+            "description": "Auth / role check failed"
+          },
+          "404": {
+            "description": "Not found"
+          }
         }
       }
     }


### PR DESCRIPTION
## REST API write-side CRUD for the high-priority modules

Brings the REST API up to parity for **four modules** that previously only exposed `list`. Pattern matches the canonical `events/api/{create,update,delete}` shape from v1.0.

## 10 new endpoints

| Module | Endpoint | Role check |
|---|---|---|
| Announcements | `POST /api/announcements/create` | admin |
| Announcements | `POST /api/announcements/update` (partial) | admin |
| Announcements | `POST /api/announcements/delete` (soft) | admin |
| Tasks | `POST /api/tasks/create` | any user |
| Tasks | `POST /api/tasks/complete` | assignee OR admin |
| Tasks | `POST /api/tasks/delete` | creator OR admin |
| Prayer Requests | `POST /api/prayer-requests/create` | any user |
| Prayer Requests | `POST /api/prayer-requests/moderate` | admin OR `prayer_team` |
| Leadership | `POST /api/leadership/assign` | admin |
| Leadership | `POST /api/leadership/unassign` | admin |

## Pattern (every endpoint)

- Lives at `_apps/{appName}/api/{action}.php`.
- POST required; `ApiResponse::requireAuth()` + role check.
- CSRF via `X-CSRF-TOKEN` header OR `csrf_token` body field.
- Site-scoped: every query filters by `Site::id()`.
- `Logger::activity()` audit row on success.
- `ApiResponse::success` / `error` with appropriate HTTP code (201 / 200 / 400 / 403 / 404 / 500).
- Soft delete where appropriate (`announcements` sets `isDeleted = 1` rather than hard delete).
- Per-row authorisation where the actor isn't admin (Tasks: assignee-or-admin to complete, creator-or-admin to delete).

## Migration 106

- 10 new `tblRoutes` entries pointing at the new files.
- 10 new `api.{module}.{action}.enabled` settings, default `true` — matches v1.0 convention so admins can disable any endpoint at `/admin/settings` without code change.

## OpenAPI spec

`web/public_html/openapi.json` patched with **10 new paths**:
- Full `requestBody` schemas (required fields, enum constraints, date-time/date formats).
- All four module tags gain write-side coverage.
- Total paths now **23** (up from 13).
- Swagger UI's "Try it out" works against every new endpoint.

## Acceptance criteria

- [x] **Announcements**: list + create + update + delete ✅
- [x] **Tasks**: list + create + complete + delete ✅
- [x] **Prayer Requests**: list + create + moderate ✅
- [x] **Leadership**: list + assign + unassign ✅
- [x] OpenAPI spec updated end-to-end
- [x] Swagger UI "Try it out" works against every endpoint

## Deferred to follow-up PRs (different module shapes)

- **Documents** `upload` — `multipart/form-data`, not JSON; needs the file-stream + MIME-detection path from `documents/upload.php` exposed.
- **Attendance** `record` / `delete` — depends on the session model (open session, headcount per service type); shape doesn't fit the simple `{ID}` payload.
- **Expenses** `submit` / `approve` / `withdraw` — multi-step state machine with approver chain; warrants its own targeted PR with the state-transition matrix in the spec.

## Audits

```
check_route_targets.py     → 0 missing
check_sql_columns.py       → 0 mismatches
check_no_native_confirm.py → 0 findings
php -l ✅ on all 10 new files
openapi.json parses cleanly (23 paths)
```

Closes #157 partially — Documents/Attendance/Expenses tracked as remaining work; happy to split-PR those if you'd like them in this sweep.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_