### PR TITLE
docs: FEATURES + CHANGELOG sweep — waves 3/4/5 + post-wave hardening

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -88,6 +88,49 @@ Substantial pre-production-rollout hardening. Each item shipped, scaffolded, or 
 
 Net-new feature surface across security, ops, UX, and core → minor bump per semver.
 
+### Added — Waves 3 / 4 / 5 install-on-demand apps (PRs #283 / #284 / #285)
+
+16 new apps shipped across three branches, all on top of the App Registry pattern (`_core/apps/{slug}.php` auto-discovery, `enabled = 0` default, per-site toggle at `/admin/apps`).
+
+**Wave 3 (#283):** `#265` Reading Plans (Bible-in-a-Year, streak counter) · `#275` QR generator + CueRCode adapter slot · `#239` Invite-based onboarding (SHA-256 hashed tokens, public acceptance route) · `#240` One-click offboarding (7-step atomic revocation + 7-day rehire window).
+
+**Wave 4 (#284):** `#263` Resources (room/asset booking with overlap conflict detection) · `#262` Service Plans (printable run-sheet builder) · `#273` Livestream (YouTube/Vimeo/Twitch/Facebook embed + countdown) · `#264` Recordings (RSS podcast feed + HTTP Range streaming + FULLTEXT search) · `#274` Zoom (OAuth + meeting creation from calendar + webhook HMAC verification) · `#269` Newsletter (composer with auto-pulled content blocks, provider abstraction reserves a `webMailerMatt` slot) · `#266` Giving (tithe log, Gift Aid digital declaration, HMRC Schedule CSV, dompdf year-end statement) · `#272` SMS (Twilio + MessageBird + SigV4-signed AWS SNS, verification, per-category opt-in, Sabbath quiet hours) · `#267` Projects (public fundraising pages with captcha-gated anonymous pledges, thermometer, updates feed) · `#268` Payments (Stripe Checkout + v1 HMAC webhook + refund; side-effects route into Giving + Projects via `tblPayment.purpose`).
+
+**Wave 5 (#285):** `#276` Transcription (Whisper / AssemblyAI / local whisper.cpp, FULLTEXT search, click-to-timestamp) · `#278` Translation (Anthropic / OpenAI / Google / DeepL / LibreTranslate, content-addressable cache, 10-locale heuristic detection including Welsh) · `#277` AI Assist (Anthropic / OpenAI / ollama, 4 editable prompt-template kinds, monthly cap + per-user daily limit + audit trail) · `#235` GDPR Article 17 erasure engine (19-table catalogue, sealed audit chain via chained SHA-256, one-month SLA queue) · `#236` Photos (4-tier role visibility, moderation queue, EXIF-aware GD re-encode strips metadata for non-privileged downloads) · `#249` Off-site backup (weekly AES-256-CBC to rclone/S3/SFTP) · `#250` Disaster-recovery runbook + in-portal landing · `#161` CDN SRI audit + Asset helpers for Sortable + Swagger UI · `#248` End-to-end MySQL migration test harness · `#225` Static mobile readiness audit + worksheet.
+
+### Added — Post-wave-5 infrastructure hardening (PRs #286-#293)
+
+- **PR #286** — Doc sweep cleaning up `core/` / `vendor/` / `sql/` → `_core/` / `_vendor/` / `_sql/` references (#189, #182, #183, #194). Issues #190, #191, #192, #193 verified already-resolved.
+- **PR #287** — `auto-merge-alpha.yml` verification (#147). Workflow structurally correct; 0 runs to date because no PR has ever targeted `alpha`. Documented re-verification procedure + 6-month delete-if-still-unused criterion in DEV_NOTES.
+- **PR #288** — Defence-in-depth refactor (#159): **317 PHP files** in 37 app dirs `git mv`'d from `web/public_html/` to `web/_apps/`. Only entry-point files (`index.php`, `error.php`, `api-docs/index.php`) remain in the webroot. Router falls back to `public_html/` for legitimate-entry-point routes.
+- **PR #289** — Nonce-based CSP `script-src` tightening (#144). New `App::cspNonce()` static method (16-byte hex, request-memoised). Modern browsers strictly enforce the nonce; `'unsafe-inline'` retained as a fallback for older browsers per CSP3 semantics.
+- **PR #290** — External error monitor (#143). New `Portal\Core\ErrorMonitor` adapter — Sentry- and GlitchTip-compatible store-API envelope; SigV4-style auth via `X-Sentry-Auth` header; 2 s connect + 5 s total timeout; sample-rate gate; admin smoke-test endpoint. Hooked into `Logger::errorPlatform()` alongside the existing critical-alert dispatch.
+- **PR #291** — REST API write-side CRUD (#157): 10 new endpoints — Announcements full CRUD; Tasks create/complete/delete; Prayer Requests create/moderate; Leadership assign/unassign. OpenAPI spec now has 23 paths (up from 13). Documents/Attendance/Expenses deferred (different module shapes).
+- **PR #292** — PWA offline write queue (#233). New `Portal.OfflineQueue` IndexedDB module; `data-offline-queueable` form interceptor; Background Sync API integration in `sw.js`; `/account/offline-queue` user inspector; connection indicator dot in footer. `X-Offline-Queued-At` header carries the original submission timestamp to receiving endpoints.
+- **PR #293** — Codebase audit sweep: duplicate cookie banner in `footer.php` removed (was bypassing the GDPR consent pipeline); missing `Auth` import in `footer.php` fixed (would have thrown `ClassNotFoundException` on first cookie-banner render); 6 SQL `int`-concatenation queries converted to prepared statements for consistency with the rest of the codebase (no security impact — all int-cast at source).
+
+### Changed — `_apps/` defence-in-depth refactor (PR #288)
+
+Architectural-level change: every app controller now lives **outside** `public_html/`. The `PORTAL_APPS` constant in `bootstrap.php` now points at `web/_apps/`. Router-level fallback to `public_html/` for the small set of routes that legitimately render entry-point pages (Swagger UI, openapi.json, PWA offline fallback). `.htaccess` deny-`.php` rule simplified — exempts only the 3 known entry points (`index.php`, `api-docs/index.php`, `error.php`). All 7 audit scripts updated to scan `_apps/` alongside `public_html/`.
+
+### Audit scripts (`tools/audit-checks/`)
+
+Three new static-analysis scripts added across the post-wave-5 work:
+
+- `check_cdn_sri.py` (#161) — flags `<script>`/`<link>` tags pointing at known CDN hosts without `integrity=` attributes.
+- `check_migration_idempotency.py` (#248) — flags `CREATE TABLE` / `ADD COLUMN` / `CREATE INDEX` without `IF NOT EXISTS` and `INSERT` without `ON DUPLICATE KEY UPDATE` / `INSERT IGNORE`. Quote-aware splitter respects `;` inside string literals.
+- `check_mobile_readiness.py` (#225) — flags missing `<meta viewport>`, hard-coded widths > 320 px, bare `<table>` outside `.table-responsive`, file inputs without `accept=`, modals without `modal-fullscreen-sm-down`.
+
+### Audit pass status (2026-06-03)
+
+- `check_route_targets.py`: 304 routes, **0 missing target files**
+- `check_sql_columns.py`: 109 tables, **0 mismatches**
+- `check_no_native_confirm.py`: **0 findings**
+- `check_cdn_sri.py`: **0 findings**
+- `check_settings_keys.py`: 3 informational (all have `??` fallbacks)
+- `check_migration_idempotency.py`: 19 informational (pre-multi-site historical cohort, Migrator-protected)
+- `check_mobile_readiness.py`: 29 informational fix targets (concrete sweep candidates)
+
 ## [1.1.1] - Unreleased
 
 ### Added — Authorised-use notice on the login screen (#221)

--- a/FEATURES.md
+++ b/FEATURES.md
@@ -4,7 +4,11 @@
 > [CHANGELOG.md](CHANGELOG.md) for chronological history and to [README.md](README.md)
 > for setup, deployment, and licence info.
 >
-> **Snapshot:** 2026-05-22 · **Version on `main`:** 0.11.0
+> **Snapshot:** 2026-06-03 · **Version on `main`:** 1.2.0
+> · **Major recent landings:** waves 3/4/5 apps (~16 new apps),
+> `_apps/` defence-in-depth refactor (#159), nonce-based CSP (#144),
+> external error monitor (#143), PWA offline write queue (#233),
+> REST API write-side CRUD (#157).
 > · **In-flight branches:** `feat/calendar-view-modes` (PR #137),
 > `feat/calendar-themes-and-display-style` (PR #138)
 
@@ -410,3 +414,92 @@ When these merge, the 🛠️ markers above flip to ✅ without further edits to
 | #106 | Enforce signed commits |
 | #105 | Prod secrets behind GitHub Environment + reviewer gate |
 | #107 | SFTP `--delete` operational documentation (partially addressed by PR #134) |
+
+---
+
+## Waves 3 / 4 / 5 — install-on-demand apps (2026-06)
+
+All apps default `enabled = 0` and toggle per-site via `/admin/apps`. Every app
+ships with a `_core/apps/{slug}.php` config that AppRegistry auto-discovers,
+a `_core/{Slug}.php` helper class, a numbered SQL migration, and route +
+setting seeds.
+
+### Wave 3 (#283) — PR landed 2026-06-02
+
+| App | Issue | Migration | Status |
+|---|---|---|---|
+| Reading Plans (Bible-in-a-year, chronological, streak counter) | #265 | 084 | ✅ |
+| QR generator + CueRCode adapter slot | #275 | 085 | ✅ (CueRCode hash empty pending its public API) |
+| Invite-based onboarding (SHA-256 hashed tokens, public acceptance route) | #239 | 086 | ✅ |
+| One-click offboarding (7-step atomic revocation + 7-day rehire window) | #240 | 087 | ✅ |
+
+### Wave 4 (#284) — PR landed 2026-06-02
+
+| App | Issue | Migration | Status |
+|---|---|---|---|
+| Resources (room/asset booking with overlap conflict detection) | #263 | 088 | ✅ |
+| Service Plans (run-sheet builder, printable) | #262 | 089 | ✅ |
+| Livestream (YouTube/Vimeo/Twitch/Facebook embed + countdown) | #273 | 090 | ✅ |
+| Recordings (RSS podcast feed + HTTP Range streaming + FULLTEXT search) | #264 | 091 | ✅ |
+| Zoom (OAuth, meeting creation from calendar, webhook HMAC) | #274 | 092 | ✅ |
+| Newsletter (composer with auto-pulled content blocks, provider abstraction → MailerMatt slot) | #269 | 093 | ✅ |
+| Giving (tithe log, Gift Aid digital declaration, HMRC schedule CSV, year-end PDF) | #266 | 094 | ✅ |
+| SMS (Twilio + MessageBird + SigV4-signed AWS SNS; verification + per-category opt-in + Sabbath quiet hours) | #272 | 095 | ✅ |
+| Projects (public fundraising page, pledge thermometer, captcha-gated anonymous pledges) | #267 | 096 | ✅ |
+| Payments (Stripe Checkout + v1 HMAC webhook + refund; side-effects into Giving/Projects) | #268 | 097 | ✅ |
+
+### Wave 5 (#285) — PR landed 2026-06-03
+
+| Item | Issue | Migration | Status |
+|---|---|---|---|
+| Transcription (Whisper / AssemblyAI / local; FULLTEXT search; click-to-timestamp) | #276 | 098 | ✅ |
+| Translation (Anthropic / OpenAI / Google / DeepL / LibreTranslate; content-addressable cache) | #278 | 099 | ✅ |
+| AI Assist (Anthropic / OpenAI / ollama; editable prompt templates; cap + daily limit + audit) | #277 | 100 | ✅ |
+| GDPR Article 17 erasure engine (19-table catalogue, sealed audit chain, 1-month SLA queue) | #235 | 101 | ✅ |
+| Photos (4-tier visibility, moderation queue, EXIF-aware GD re-encode for non-privileged downloads) | #236 | 102 | ✅ |
+| Off-site backup (weekly AES-256-CBC to rclone/S3/SFTP) | #249 | 103 | ✅ |
+| Disaster-recovery runbook + `/help/disaster-recovery` | #250 | 104 | ✅ |
+| CDN SRI audit script + Asset helpers for Sortable + Swagger UI | #161 | — | ✅ (4 hashes empty pending curl-and-fill) |
+| End-to-end MySQL migration test harness (docker-compose 8.0.36 + 3-phase script) | #248 | — | ✅ (Docker required to actually run) |
+| Static mobile readiness audit + worksheet (29 fix targets surfaced) | #225 | — | ✅ (device walk-through still needs hardware) |
+
+### Post-wave-5 hardening (PRs #286-#293, 2026-06-03)
+
+| Item | Issue | PR | Status |
+|---|---|---|---|
+| Rename-aftermath doc sweep (README, CLAUDE.md, DEV_NOTES, full_schema header) | #189, #182, #183, #194, #190, #191, #192, #193 | #286 | ✅ |
+| `auto-merge-alpha.yml` verification (0 runs — workflow correct, awaiting first alpha PR) | #147 | #287 | ✅ |
+| App controllers moved from `public_html/` into `_apps/` outside the webroot | #159 | #288 | ✅ |
+| Nonce-based CSP `script-src` tightening + `App::cspNonce()` | #144 | #289 | ✅ |
+| External error monitor — `Portal\Core\ErrorMonitor` adapter for Sentry / GlitchTip | #143 | #290 | ✅ |
+| REST API write-side CRUD: Announcements / Tasks / Prayer Requests / Leadership (10 new endpoints) | #157 | #291 | 🟡 (Documents / Attendance / Expenses deferred) |
+| PWA offline write queue + sync-on-reconnect (`Portal.OfflineQueue` IndexedDB module + `/account/offline-queue`) | #233 | #292 | ✅ |
+| Codebase audit sweep — duplicate cookie banner removed; missing `Auth` import fixed; 6 SQL int-concat queries → prepared statements | — | #293 | ✅ |
+
+---
+
+## Audit scripts (`tools/audit-checks/`)
+
+CI-runnable static audits invoked from PHP-static-analysis workflow:
+
+| Script | What it catches |
+|---|---|
+| `check_route_targets.py` | `tblRoutes.targetFile` pointing at a non-existent file |
+| `check_sql_columns.py` | INSERT/UPDATE/SELECT referencing a column not in `full_schema.sql` |
+| `check_no_native_confirm.py` | Inline `confirm()` calls bypassing `Portal.Confirm` modal |
+| `check_settings_keys.py` | Code reading a setting key not seeded in any migration |
+| `check_cdn_sri.py` | `<script>`/`<link>` to a known CDN host without `integrity=` |
+| `check_migration_idempotency.py` | DDL without `IF NOT EXISTS` / inserts without `ON DUPLICATE KEY UPDATE` |
+| `check_mobile_readiness.py` | Hard-coded widths > 320 px, bare `<table>`, missing `accept=`, modal without `modal-fullscreen-sm-down` |
+
+Audit pass status as of 2026-06-03: **0 missing routes · 0 column mismatches · 0 native confirms · 0 CDN tags without SRI**. Mobile readiness reports 29 informational findings (concrete fix targets); migration idempotency reports 19 historical (pre-multi-site cohort, already deployed and Migrator-protected).
+
+---
+
+## Infrastructure helpers (`tools/`)
+
+| Path | Purpose |
+|---|---|
+| `tools/audit-checks/` | Static-analysis scripts (above) |
+| `tools/e2e-migrations/` | docker-compose MySQL 8.0.36 + `run.sh` 3-phase migration smoke test (#248) |
+| `tools/offsite-backup/` | Reference `sync-offsite.sh` + `log-offsite-result.php` (admin copies into gitignored `web/_backups/`) (#249) |


### PR DESCRIPTION
## Comprehensive documentation sweep

Brings the two top-level living docs up to date with everything shipped since the **2026-05-22** snapshot.

## `FEATURES.md`

- **Snapshot header** updated to 2026-06-03, version 1.2.0, with major recent landings called out.
- New section **"Waves 3 / 4 / 5 — install-on-demand apps (2026-06)"** enumerating each shipped app with its issue + migration + status:
  - **Wave 3** (#283) — Reading Plans, QR generator, Invite onboarding, Offboarding.
  - **Wave 4** (#284) — Resources, Service Plans, Livestream, Recordings, Zoom, Newsletter, Giving, SMS, Projects, Payments.
  - **Wave 5** (#285) — Transcription, Translation, AI Assist, GDPR erasure, Photos, Off-site backup, DR runbook, SRI audit, e2e MySQL harness, Mobile audit.
- New section **"Post-wave-5 hardening (PRs #286-#293)"** covering rename-aftermath sweep, auto-merge verification, `_apps/` refactor, CSP nonce, error monitor, REST API write CRUD, PWA offline queue, codebase audit sweep.
- New section **"Audit scripts"** cataloguing the seven static-analysis scripts under `tools/audit-checks/` with current pass status.
- New section **"Infrastructure helpers (`tools/`)"** pointing at the three `tools/` subdirs and what they're for.

## `CHANGELOG.md` — 1.2.0 section

- **"Waves 3 / 4 / 5 install-on-demand apps"** entry naming every shipped app with its issue number.
- **"Post-wave-5 infrastructure hardening (PRs #286-#293)"** entry listing each PR + closed issue + headline change.
- **"`_apps/` defence-in-depth refactor"** architecture note covering the `PORTAL_APPS` constant change, `.htaccess` simplification, and audit-script path extensions.
- **"Audit scripts"** entry covering the three new static scripts.
- **"Audit pass status (2026-06-03)"** snapshot — 0 findings on every blocking script, informational counts on the non-blocking ones.

## Already updated elsewhere

- **OpenAPI/Swagger spec** — updated in PR #291 (10 new write endpoints; total 23 paths).
- **In-app docs** — `/help/disaster-recovery`, `/help/admin-first-steps`, `/help/translations` already updated by their respective shipping PRs.

Pure documentation — no code or schema changes.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UhZoZxQzJWPJdoWzdvPoe2)_