### PR TITLE
feat: #317 Virtual Host Console + #323 API key infrastructure — Phase 1 of each

### DIFF
--- a/web/_apps/admin/host-console/event.php
+++ b/web/_apps/admin/host-console/event.php
@@ -1,0 +1,171 @@
+<?php
+// Path: _apps/admin/host-console/event.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Host Console event dashboard 🎙️📊 (#317 Phase 1)
+ * -----------------------------------------------------------------------------
+ * The per-event "during-the-service" cockpit. Read-only composition of:
+ *   • tblLivestreamSessions — live viewer count + 7-day trend
+ *   • tblDecisionMoments    — per-moment-type tallies
+ *   • tblSalvationCards     — recent intake stream
+ *
+ * Auto-refreshes every 30s via <meta refresh> — deliberately NOT JS polling
+ * to keep Phase 1 within the 2-day budget. JS / SSE upgrade is Phase 2.
+ *
+ * Auth: admin OR Auth::isCoordinatorOf(eventID).
+ *
+ * @link https://github.com/MWBMPartners/WebMS-Intra/issues/317
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\HostConsole;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$eventId = (int) ($_GET['id'] ?? 0);
+$siteId  = Site::id();
+
+if (HostConsole::eventBelongsToSite($eventId, $siteId) === false) {
+    http_response_code(404);
+    exit('Event not found');
+}
+if (App::isAdmin() === false && Auth::isCoordinatorOf($eventId) === false) {
+    http_response_code(403);
+    exit('Forbidden');
+}
+
+// 📋 Compose all reads via the helper class.
+$liveNow   = HostConsole::liveViewerCount($eventId, $siteId);
+$trend     = HostConsole::sessionTrend7d($eventId, $siteId);
+$decisions = HostConsole::decisionTallies($eventId);
+$cards     = HostConsole::recentCards($eventId, $siteId, 15);
+
+// 📋 Event header (cheap query — the gate above already touched the row).
+$stmt = $mysqli->prepare('SELECT eventName, startDateTime, locationName FROM tblEvents WHERE eventID = ?');
+$stmt->bind_param('i', $eventId);
+$stmt->execute();
+$event = $stmt->get_result()->fetch_assoc();
+$stmt->close();
+
+// 🎨 Decision moment metadata — labels + icons + accent colours.
+$momentMeta = [
+    'first-decision'      => ['label' => 'First decision',      'icon' => 'fa-hand-holding-heart', 'colour' => 'success'],
+    'rededication'        => ['label' => 'Rededication',        'icon' => 'fa-arrow-rotate-left', 'colour' => 'info'],
+    'baptism-request'     => ['label' => 'Baptism request',     'icon' => 'fa-water',             'colour' => 'primary'],
+    'membership-interest' => ['label' => 'Membership interest', 'icon' => 'fa-handshake',         'colour' => 'warning'],
+    'prayer-request'      => ['label' => 'Prayer request',      'icon' => 'fa-hands-praying',     'colour' => 'secondary'],
+    'other'               => ['label' => 'Other',               'icon' => 'fa-circle-question',   'colour' => 'dark'],
+];
+
+// 📊 Sparkline scale.
+$maxTrend = max(1, max(array_column($trend, 'count')));
+
+$pageTitle = 'Host Console — ' . (string) $event['eventName'];
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+<meta http-equiv="refresh" content="30">
+<div class="container-fluid py-3">
+    <div class="d-flex justify-content-between align-items-start mb-3 flex-wrap gap-2">
+        <div>
+            <h1 class="h4 mb-1"><i class="fa-solid fa-headset me-2 text-primary"></i><?php echo htmlspecialchars((string) $event['eventName'], ENT_QUOTES, 'UTF-8'); ?></h1>
+            <p class="text-muted small mb-0">
+                <?php echo htmlspecialchars(date('l j M Y, H:i', strtotime((string) $event['startDateTime'])), ENT_QUOTES, 'UTF-8'); ?>
+                <?php if (!empty($event['locationName'])): ?>
+                    &middot; <?php echo htmlspecialchars((string) $event['locationName'], ENT_QUOTES, 'UTF-8'); ?>
+                <?php endif; ?>
+                &middot; refreshes every 30s
+            </p>
+        </div>
+        <a href="/admin/host-console" class="btn btn-sm btn-outline-secondary"><i class="fa-solid fa-arrow-left me-1"></i>Back</a>
+    </div>
+
+    <div class="row g-3 mb-3">
+        <div class="col-md-4">
+            <div class="card text-center h-100">
+                <div class="card-body">
+                    <div class="display-3 fw-bold <?php echo $liveNow > 0 ? 'text-success' : 'text-muted'; ?>"><?php echo $liveNow; ?></div>
+                    <p class="text-muted mb-0">
+                        Watching now
+                        <?php if ($liveNow > 0): ?>
+                            <span class="badge bg-success ms-1">LIVE</span>
+                        <?php endif; ?>
+                    </p>
+                </div>
+            </div>
+        </div>
+        <div class="col-md-8">
+            <div class="card h-100">
+                <div class="card-body">
+                    <h2 class="h6 mb-2 small text-muted">Sessions — last 7 days</h2>
+                    <div class="d-flex align-items-end justify-content-between" style="height:80px; gap:4px;">
+                        <?php foreach ($trend as $t): ?>
+                            <?php $h = (int) (($t['count'] / $maxTrend) * 100); ?>
+                            <div class="text-center" style="flex:1;">
+                                <div title="<?php echo (int) $t['count']; ?> sessions" style="height:<?php echo max(2, $h); ?>%; background:#5e6ad2; border-radius:2px;"></div>
+                                <div class="small text-muted mt-1" style="font-size:.65rem;"><?php echo htmlspecialchars(date('D', strtotime((string) $t['date'])), ENT_QUOTES, 'UTF-8'); ?></div>
+                            </div>
+                        <?php endforeach; ?>
+                    </div>
+                </div>
+            </div>
+        </div>
+    </div>
+
+    <h2 class="h6">Decision moments</h2>
+    <div class="row g-2 mb-3">
+        <?php foreach ($momentMeta as $key => $meta):
+            $d = $decisions[$key];
+        ?>
+            <div class="col-md-2 col-6">
+                <div class="card text-center h-100">
+                    <div class="card-body p-2">
+                        <i class="fa-solid <?php echo htmlspecialchars($meta['icon'], ENT_QUOTES, 'UTF-8'); ?> text-<?php echo $meta['colour']; ?>"></i>
+                        <div class="h4 mb-0 mt-1"><?php echo (int) $d['count']; ?></div>
+                        <div class="small text-muted" style="font-size:.7rem;"><?php echo htmlspecialchars($meta['label'], ENT_QUOTES, 'UTF-8'); ?></div>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+    </div>
+    <p class="small text-muted mb-3">
+        Increment counters at <a href="/calendar/event/decisions?eventID=<?php echo $eventId; ?>">Decision moments</a>.
+    </p>
+
+    <h2 class="h6">Latest salvation cards (<?php echo count($cards); ?>)</h2>
+    <?php if (count($cards) === 0): ?>
+        <p class="text-muted small">No cards received for this event yet. Public form: <a href="/decision-card?eventID=<?php echo $eventId; ?>">/decision-card?eventID=<?php echo $eventId; ?></a></p>
+    <?php else: ?>
+        <div class="portal-data-list">
+        <?php foreach ($cards as $c):
+            $badge = ['new' => 'bg-info text-dark', 'assigned' => 'bg-primary', 'contacted' => 'bg-warning text-dark', 'complete' => 'bg-success', 'archived' => 'bg-secondary'][$c['status']] ?? 'bg-secondary';
+        ?>
+            <div class="portal-data-row">
+                <div class="portal-data-row-main">
+                    <strong><?php echo htmlspecialchars((string) $c['fullName'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                    <span class="badge bg-secondary ms-1"><?php echo htmlspecialchars((string) $c['decision'], ENT_QUOTES, 'UTF-8'); ?></span>
+                    <span class="badge <?php echo $badge; ?> ms-1"><?php echo htmlspecialchars(ucfirst((string) $c['status']), ENT_QUOTES, 'UTF-8'); ?></span>
+                    <div class="small text-muted">
+                        <?php if (!empty($c['email'])): ?>
+                            <?php echo htmlspecialchars((string) $c['email'], ENT_QUOTES, 'UTF-8'); ?> &middot;
+                        <?php endif; ?>
+                        <?php echo htmlspecialchars(date('H:i', strtotime((string) $c['createdAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                        <?php if (!empty($c['assigneeName'])): ?>
+                            &middot; → <?php echo htmlspecialchars((string) $c['assigneeName'], ENT_QUOTES, 'UTF-8'); ?>
+                        <?php endif; ?>
+                    </div>
+                </div>
+            </div>
+        <?php endforeach; ?>
+        </div>
+        <p class="small text-muted mt-2">
+            Manage all cards at <a href="/admin/decision-cards">/admin/decision-cards</a>.
+        </p>
+    <?php endif; ?>
+</div>
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/_apps/admin/host-console/index.php
+++ b/web/_apps/admin/host-console/index.php
@@ -1,0 +1,119 @@
+<?php
+// Path: _apps/admin/host-console/index.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Host Console event picker (#317 Phase 1)
+ * -----------------------------------------------------------------------------
+ * Landing page when an admin / coordinator visits /admin/host-console.
+ * Lists every event that:
+ *   • Belongs to the active site
+ *   • Has at least one livestream session OR is scheduled to start today
+ *   • Is not deleted
+ * Click an event row to open the cockpit (/admin/host-console/event?id=N).
+ *
+ * @link https://github.com/MWBMPartners/WebMS-Intra/issues/317
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+
+$siteId = Site::id();
+
+// 🛡️ Admin OR ANY active event coordinator can land here. The per-event
+//    dashboard re-checks isCoordinatorOf for the SPECIFIC event.
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$isCoordOfSomething = false;
+if (App::isAdmin() === false) {
+    $stmt = $mysqli->prepare(
+        'SELECT 1 FROM tblEventCoordinators WHERE userID = ? AND revokedAt IS NULL LIMIT 1'
+    );
+    if ($stmt !== false) {
+        $stmt->bind_param('i', $userId);
+        $stmt->execute();
+        $isCoordOfSomething = (bool) $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+    }
+    if ($isCoordOfSomething === false) {
+        http_response_code(403);
+        exit('Forbidden');
+    }
+}
+
+// 📋 Events with livestream activity OR starting today.
+$events = [];
+$stmt = $mysqli->prepare(
+    'SELECT e.eventID, e.eventName, e.eventSlug, e.startDateTime, '
+    . '       (SELECT COUNT(*) FROM tblLivestreamSessions s '
+    . '         WHERE s.eventID = e.eventID AND s.leftAt IS NULL '
+    . '           AND s.lastPingAt >= DATE_SUB(NOW(), INTERVAL 90 SECOND)) AS liveNow, '
+    . '       (SELECT MAX(s.lastPingAt) FROM tblLivestreamSessions s '
+    . '         WHERE s.eventID = e.eventID) AS lastActivity '
+    . 'FROM tblEvents e '
+    . 'WHERE e.siteID = ? AND e.isDeleted = 0 AND e.status = "published" '
+    . '  AND ('
+    . '    EXISTS (SELECT 1 FROM tblLivestreamSessions s WHERE s.eventID = e.eventID) '
+    . '    OR DATE(e.startDateTime) = CURDATE() '
+    . '  ) '
+    . 'ORDER BY liveNow DESC, e.startDateTime DESC LIMIT 30'
+);
+$stmt->bind_param('i', $siteId);
+$stmt->execute();
+$result = $stmt->get_result();
+while ($r = $result->fetch_assoc()) {
+    $events[] = $r;
+}
+$stmt->close();
+
+$pageTitle = 'Host Console';
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+?>
+<div class="container py-3" style="max-width:880px;">
+    <h1 class="h4 mb-2"><i class="fa-solid fa-headset me-2 text-primary"></i>Host Console</h1>
+    <p class="text-muted small">Pick an event to open the host cockpit — viewer count, decision tallies, and salvation card intake in one view.</p>
+
+    <?php if (count($events) === 0): ?>
+        <div class="alert alert-info small">
+            No events with livestream activity or scheduled to start today.
+            <a href="/admin/livestream">Livestream analytics</a> shows all sessions.
+        </div>
+    <?php else: ?>
+        <div class="portal-data-list">
+        <?php foreach ($events as $e): ?>
+            <div class="portal-data-row">
+                <div class="portal-data-row-main">
+                    <a href="/admin/host-console/event?id=<?php echo (int) $e['eventID']; ?>" class="text-decoration-none fw-semibold h6 mb-1">
+                        <?php echo htmlspecialchars((string) $e['eventName'], ENT_QUOTES, 'UTF-8'); ?>
+                    </a>
+                    <?php if ((int) $e['liveNow'] > 0): ?>
+                        <span class="badge bg-success ms-1"><i class="fa-solid fa-circle me-1" style="font-size:.5em; vertical-align:middle;"></i>LIVE — <?php echo (int) $e['liveNow']; ?></span>
+                    <?php endif; ?>
+                    <div class="small text-muted">
+                        <?php echo htmlspecialchars(date('l j M Y, H:i', strtotime((string) $e['startDateTime'])), ENT_QUOTES, 'UTF-8'); ?>
+                        <?php if (!empty($e['lastActivity'])): ?>
+                            &middot; last ping: <?php echo htmlspecialchars(date('j M H:i', strtotime((string) $e['lastActivity'])), ENT_QUOTES, 'UTF-8'); ?>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <div class="portal-data-row-aside">
+                    <a href="/admin/host-console/event?id=<?php echo (int) $e['eventID']; ?>" class="btn btn-sm btn-outline-primary">
+                        Open <i class="fa-solid fa-arrow-right ms-1"></i>
+                    </a>
+                </div>
+            </div>
+        <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+
+    <p class="text-muted small mt-4">
+        Phase 1 is read-only. Phase 2 will add host-side push prompts to viewers
+        (decision-call overlays, prayer requests, give-now CTAs).
+    </p>
+</div>
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/_apps/admin/integrations/api-keys-revoke.php
+++ b/web/_apps/admin/integrations/api-keys-revoke.php
@@ -1,0 +1,42 @@
+<?php
+// Path: _apps/admin/integrations/api-keys-revoke.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Revoke API key POST (#323 Phase 1)
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiKey;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /admin/integrations/api-keys', true, 302); exit();
+}
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) { http_response_code(403); exit('Forbidden'); }
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) { http_response_code(400); exit('Bad request'); }
+
+$keyId  = (int) ($_POST['keyID'] ?? 0);
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$siteId = Site::id();
+
+// 🛡️ Cross-site guard — key must belong to this site.
+$stmt = $mysqli->prepare('SELECT keyID FROM tblApiKeys WHERE keyID = ? AND siteID = ?');
+$stmt->bind_param('ii', $keyId, $siteId);
+$stmt->execute();
+$ok = (bool) $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if ($ok === false) { http_response_code(404); exit('Key not found'); }
+
+ApiKey::revoke($keyId, $userId);
+
+$_SESSION['flash_msg']  = 'API key revoked.';
+$_SESSION['flash_type'] = 'warning';
+header('Location: /admin/integrations/api-keys', true, 302);
+exit();

--- a/web/_apps/admin/integrations/api-keys-rotate.php
+++ b/web/_apps/admin/integrations/api-keys-rotate.php
@@ -1,0 +1,52 @@
+<?php
+// Path: _apps/admin/integrations/api-keys-rotate.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Rotate API key POST (#323 Phase 1)
+ * -----------------------------------------------------------------------------
+ * Revoke + re-mint with the same metadata. New plaintext flashed once.
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiKey;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /admin/integrations/api-keys', true, 302); exit();
+}
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) { http_response_code(403); exit('Forbidden'); }
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) { http_response_code(400); exit('Bad request'); }
+
+$keyId  = (int) ($_POST['keyID'] ?? 0);
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$siteId = Site::id();
+
+$stmt = $mysqli->prepare('SELECT keyID FROM tblApiKeys WHERE keyID = ? AND siteID = ? AND isActive = 1');
+$stmt->bind_param('ii', $keyId, $siteId);
+$stmt->execute();
+$ok = (bool) $stmt->get_result()->fetch_assoc();
+$stmt->close();
+if ($ok === false) { http_response_code(404); exit('Active key not found'); }
+
+try {
+    $result = ApiKey::rotate($keyId, $userId);
+    $_SESSION['api_key_minted'] = [
+        'plaintext' => $result['plaintext'],
+        'keyID'     => $result['keyID'],
+        'prefix'    => $result['prefix'],
+    ];
+    $_SESSION['flash_msg']  = 'API key rotated. Copy the new plaintext now.';
+    $_SESSION['flash_type'] = 'success';
+} catch (\RuntimeException $e) {
+    $_SESSION['flash_msg']  = 'Rotate failed: ' . $e->getMessage();
+    $_SESSION['flash_type'] = 'danger';
+}
+
+header('Location: /admin/integrations/api-keys', true, 302);
+exit();

--- a/web/_apps/admin/integrations/api-keys-save.php
+++ b/web/_apps/admin/integrations/api-keys-save.php
@@ -1,0 +1,56 @@
+<?php
+// Path: _apps/admin/integrations/api-keys-save.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — Mint API key POST (#323 Phase 1)
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\ApiKey;
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+if ($_SERVER['REQUEST_METHOD'] !== 'POST') {
+    header('Location: /admin/integrations/api-keys', true, 302); exit();
+}
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) { http_response_code(403); exit('Forbidden'); }
+if (Auth::verifyCsrf($_POST['csrf_token'] ?? '') === false) { http_response_code(400); exit('Bad request'); }
+
+$siteId = Site::id();
+$userId = (int) ($_SESSION['user_id'] ?? 0);
+$name   = (string) ($_POST['name'] ?? '');
+$scopes = trim((string) ($_POST['scopes'] ?? ''));
+$exp    = trim((string) ($_POST['expiresAt'] ?? ''));
+
+if (trim($name) === '') {
+    $_SESSION['flash_msg']  = 'Name is required.';
+    $_SESSION['flash_type'] = 'danger';
+    header('Location: /admin/integrations/api-keys', true, 302); exit();
+}
+
+$scopeList = $scopes === ''
+    ? []
+    : array_values(array_filter(array_map('trim', explode(',', $scopes)), static fn($s) => $s !== ''));
+
+$expiresAt = null;
+if ($exp !== '' && preg_match('/^\d{4}-\d{2}-\d{2}$/', $exp) === 1) {
+    $expiresAt = new DateTimeImmutable($exp . ' 23:59:59');
+}
+
+$result = ApiKey::mint($siteId, $name, $scopeList, $expiresAt, $userId);
+
+$_SESSION['api_key_minted'] = [
+    'plaintext' => $result['plaintext'],
+    'keyID'     => $result['keyID'],
+    'prefix'    => $result['prefix'],
+];
+$_SESSION['flash_msg']  = 'API key minted.';
+$_SESSION['flash_type'] = 'success';
+header('Location: /admin/integrations/api-keys', true, 302);
+exit();

--- a/web/_apps/admin/integrations/api-keys.php
+++ b/web/_apps/admin/integrations/api-keys.php
@@ -1,0 +1,146 @@
+<?php
+// Path: _apps/admin/integrations/api-keys.php
+/**
+ * -----------------------------------------------------------------------------
+ * Admin — API key management 🔑 (#323 Phase 1)
+ * -----------------------------------------------------------------------------
+ * List + mint UI for tblApiKeys. The plaintext token is shown ONCE here on
+ * mint, via a flash message — never persisted, never queryable later.
+ *
+ * @link https://github.com/MWBMPartners/WebMS-Intra/issues/323
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+use Portal\Core\App;
+use Portal\Core\Auth;
+use Portal\Core\Site;
+
+Auth::ensureSession();
+Auth::requireLogin();
+if (App::isAdmin() === false) { http_response_code(403); exit('Forbidden'); }
+
+$siteId = Site::id();
+
+$keys = [];
+$stmt = $mysqli->prepare(
+    'SELECT k.keyID, k.name, k.keyPrefix, k.scopes, k.expiresAt, k.lastUsedAt, k.lastUsedIP, '
+    . '       k.isActive, k.createdAt, k.revokedAt, u.fullName AS creatorName '
+    . 'FROM tblApiKeys k LEFT JOIN tblUsers u ON u.userID = k.createdByID '
+    . 'WHERE k.siteID = ? ORDER BY k.isActive DESC, k.createdAt DESC LIMIT 200'
+);
+$stmt->bind_param('i', $siteId);
+$stmt->execute();
+$result = $stmt->get_result();
+while ($r = $result->fetch_assoc()) { $keys[] = $r; }
+$stmt->close();
+
+$pageTitle = 'API Keys';
+$csrf = htmlspecialchars(Auth::csrfToken(), ENT_QUOTES, 'UTF-8');
+require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'header.php';
+
+// 🎟️ Flash for newly-minted plaintext — shown ONCE.
+if (isset($_SESSION['api_key_minted']) === true) {
+    $minted = $_SESSION['api_key_minted'];
+    unset($_SESSION['api_key_minted']);
+    echo '<div class="container py-2" style="max-width:880px;">';
+    echo '<div class="alert alert-warning">';
+    echo '<h2 class="h5"><i class="fa-solid fa-key me-1"></i>Copy your new API key NOW</h2>';
+    echo '<p class="mb-2">This is the only time the full plaintext will be shown. The portal stores only a hashed copy.</p>';
+    echo '<code class="d-block p-2 bg-light" style="font-family:monospace; word-break:break-all; user-select:all;">';
+    echo htmlspecialchars((string) $minted['plaintext'], ENT_QUOTES, 'UTF-8');
+    echo '</code>';
+    echo '<p class="small mt-2 mb-0">Key #' . (int) $minted['keyID'] . ' &middot; prefix <code>' . htmlspecialchars((string) $minted['prefix'], ENT_QUOTES, 'UTF-8') . '</code></p>';
+    echo '</div></div>';
+}
+?>
+<div class="container py-3" style="max-width:880px;">
+    <h1 class="h4 mb-2"><i class="fa-solid fa-key me-2 text-primary"></i>API Keys</h1>
+    <p class="text-muted small">
+        Bearer tokens for the public REST API. Plaintext is shown ONCE at mint —
+        copy it then. The portal stores only an SHA-256 hash. Phase 1 ships the
+        infrastructure; Phase 2 wires the write endpoints.
+    </p>
+
+    <details class="mb-4" <?php echo count($keys) === 0 ? 'open' : ''; ?>>
+        <summary class="btn btn-sm btn-outline-primary"><i class="fa-solid fa-plus me-1"></i>Mint a new key</summary>
+        <form method="post" action="/admin/integrations/api-keys/save" class="row g-2 mt-2 p-3 bg-light rounded">
+            <input type="hidden" name="csrf_token" value="<?php echo $csrf; ?>">
+            <div class="col-md-5">
+                <label class="form-label small">Name <span class="text-danger">*</span></label>
+                <input type="text" name="name" required maxlength="120" class="form-control form-control-sm" placeholder="e.g. Mobile app — production">
+            </div>
+            <div class="col-md-4">
+                <label class="form-label small">Scopes (comma separated)</label>
+                <input type="text" name="scopes" maxlength="500" class="form-control form-control-sm" placeholder="events:read, attendance:write">
+                <div class="form-text small">Wildcard: <code>events:*</code> matches every events scope.</div>
+            </div>
+            <div class="col-md-3">
+                <label class="form-label small">Expires (optional)</label>
+                <input type="date" name="expiresAt" class="form-control form-control-sm">
+            </div>
+            <div class="col-12">
+                <button class="btn btn-primary btn-sm"><i class="fa-solid fa-plus me-1"></i>Mint key</button>
+            </div>
+        </form>
+    </details>
+
+    <?php if (count($keys) === 0): ?>
+        <div class="alert alert-info small">No API keys minted yet.</div>
+    <?php else: ?>
+        <div class="portal-data-list">
+        <?php foreach ($keys as $k):
+            $isActive = (int) $k['isActive'] === 1;
+            $isExpired = $k['expiresAt'] !== null && strtotime((string) $k['expiresAt']) < time();
+        ?>
+            <div class="portal-data-row">
+                <div class="portal-data-row-main">
+                    <strong><?php echo htmlspecialchars((string) $k['name'], ENT_QUOTES, 'UTF-8'); ?></strong>
+                    <?php if ($isActive === false): ?>
+                        <span class="badge bg-danger ms-1">Revoked</span>
+                    <?php elseif ($isExpired): ?>
+                        <span class="badge bg-warning text-dark ms-1">Expired</span>
+                    <?php else: ?>
+                        <span class="badge bg-success ms-1">Active</span>
+                    <?php endif; ?>
+                    <code class="ms-2 small text-muted"><?php echo htmlspecialchars((string) $k['keyPrefix'], ENT_QUOTES, 'UTF-8'); ?>…</code>
+                    <div class="small text-muted">
+                        <?php if (!empty($k['scopes'])): ?>
+                            scopes: <code><?php echo htmlspecialchars((string) $k['scopes'], ENT_QUOTES, 'UTF-8'); ?></code>
+                            &middot;
+                        <?php endif; ?>
+                        <?php if (!empty($k['expiresAt'])): ?>
+                            expires <?php echo htmlspecialchars(date('j M Y', strtotime((string) $k['expiresAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                            &middot;
+                        <?php endif; ?>
+                        created <?php echo htmlspecialchars(date('j M Y', strtotime((string) $k['createdAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                        <?php if (!empty($k['creatorName'])): ?>
+                            by <?php echo htmlspecialchars((string) $k['creatorName'], ENT_QUOTES, 'UTF-8'); ?>
+                        <?php endif; ?>
+                        <?php if (!empty($k['lastUsedAt'])): ?>
+                            <br>last used <?php echo htmlspecialchars(date('j M, H:i', strtotime((string) $k['lastUsedAt'])), ENT_QUOTES, 'UTF-8'); ?>
+                            <?php if (!empty($k['lastUsedIP'])): ?> from <code><?php echo htmlspecialchars((string) $k['lastUsedIP'], ENT_QUOTES, 'UTF-8'); ?></code><?php endif; ?>
+                        <?php endif; ?>
+                    </div>
+                </div>
+                <?php if ($isActive === true): ?>
+                    <div class="portal-data-row-aside">
+                        <form method="post" action="/admin/integrations/api-keys/rotate" class="d-inline" onsubmit="return confirm('Rotate this key? The existing key becomes invalid and a new plaintext is shown ONCE.');">
+                            <input type="hidden" name="csrf_token" value="<?php echo $csrf; ?>">
+                            <input type="hidden" name="keyID" value="<?php echo (int) $k['keyID']; ?>">
+                            <button class="btn btn-sm btn-outline-warning" title="Rotate"><i class="fa-solid fa-arrows-rotate"></i></button>
+                        </form>
+                        <form method="post" action="/admin/integrations/api-keys/revoke" class="d-inline" onsubmit="return confirm('Revoke this key? Cannot be undone.');">
+                            <input type="hidden" name="csrf_token" value="<?php echo $csrf; ?>">
+                            <input type="hidden" name="keyID" value="<?php echo (int) $k['keyID']; ?>">
+                            <button class="btn btn-sm btn-outline-danger" title="Revoke"><i class="fa-solid fa-ban"></i></button>
+                        </form>
+                    </div>
+                <?php endif; ?>
+            </div>
+        <?php endforeach; ?>
+        </div>
+    <?php endif; ?>
+</div>
+<?php require PORTAL_CORE . DIRECTORY_SEPARATOR . 'templates' . DIRECTORY_SEPARATOR . 'footer.php'; ?>

--- a/web/_core/ApiKey.php
+++ b/web/_core/ApiKey.php
@@ -1,0 +1,246 @@
+<?php
+// Path: _core/ApiKey.php
+/**
+ * -----------------------------------------------------------------------------
+ * Portal Core — ApiKey 🔑
+ * -----------------------------------------------------------------------------
+ * Bearer-token issuance + verification for the public REST API (#323).
+ *
+ * SECURITY MODEL:
+ *   • Plaintext token (40 chars: 'wbms_' + 32 hex) is returned ONLY at mint.
+ *   • DB stores sha256(plaintext) in tblApiKeys.keyHash.
+ *   • Verification is constant-time: SELECT by keyHash directly, then
+ *     hash_equals on the row's keyHash vs sha256(submitted plaintext).
+ *   • Updates lastUsedAt + lastUsedIP on every successful match.
+ *   • Expired keys (expiresAt < NOW) fail verification.
+ *   • Revoked keys (isActive = 0) fail verification.
+ *
+ * Public methods:
+ *   ApiKey::mint(siteId, name, scopes, expiresAt, createdById)   → ['plaintext'=>, 'keyID'=>, 'prefix'=>]
+ *   ApiKey::findByPlaintext(plaintext)                           → ?array (full row + side-effect update)
+ *   ApiKey::hasScope(keyRow, required)                           → bool
+ *   ApiKey::revoke(keyID, byUserID)                              → bool
+ *   ApiKey::rotate(keyID, byUserID)                              → ['plaintext'=>, 'keyID'=>, 'prefix'=>]
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/323
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class ApiKey
+{
+    /** @var string Plaintext token prefix — human-recognisable in operator paste-bins */
+    public const TOKEN_PREFIX = 'wbms_';
+
+    /** @var int Random bytes for the token body — 32 bytes → 64 hex chars → 256 bits entropy */
+    public const TOKEN_BYTES = 16; // 16 bytes → 32 hex chars → 128 bits — sufficient post-hashing
+
+    /**
+     * Mint a new API key. Returns the plaintext EXACTLY ONCE — caller MUST
+     * show it to the admin and never persist it.
+     *
+     * @param array<int, string>      $scopes    Scope strings (e.g. ['events:read', 'attendance:write'])
+     * @param \DateTimeImmutable|null $expiresAt Optional hard expiry; null = no expiry
+     *
+     * @return array{plaintext: string, keyID: int, prefix: string}
+     */
+    public static function mint(int $siteId, string $name, array $scopes, ?\DateTimeImmutable $expiresAt, int $createdById): array
+    {
+        $plaintext = self::TOKEN_PREFIX . bin2hex(random_bytes(self::TOKEN_BYTES));
+        $keyHash   = hash('sha256', $plaintext);
+        $keyPrefix = mb_substr($plaintext, 0, 12); // 'wbms_' + first 7 chars
+        $nameClean = mb_substr(trim($name), 0, 120);
+        if ($nameClean === '') {
+            $nameClean = 'Unnamed key';
+        }
+        $scopeStr  = implode(',', array_map(static fn($s) => trim((string) $s), $scopes));
+        $scopeStr  = mb_substr($scopeStr, 0, 500);
+        $scopeArg  = $scopeStr !== '' ? $scopeStr : null;
+        $expArg    = $expiresAt !== null ? $expiresAt->format('Y-m-d H:i:s') : null;
+
+        $db = App::db();
+        $stmt = $db->prepare(
+            'INSERT INTO tblApiKeys (siteID, name, keyHash, keyPrefix, scopes, expiresAt, createdByID) '
+            . 'VALUES (?, ?, ?, ?, ?, ?, ?)'
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare ApiKey insert');
+        }
+        $stmt->bind_param('isssssi', $siteId, $nameClean, $keyHash, $keyPrefix, $scopeArg, $expArg, $createdById);
+        $stmt->execute();
+        $newId = (int) $stmt->insert_id;
+        $stmt->close();
+
+        Logger::activity('ApiKeyMinted', 'Key #' . $newId . ' (' . $keyPrefix . '…) siteID=' . $siteId);
+
+        return ['plaintext' => $plaintext, 'keyID' => $newId, 'prefix' => $keyPrefix];
+    }
+
+    /**
+     * Look up the key row by plaintext token. Returns the row on success
+     * AND updates lastUsedAt + lastUsedIP. Returns null on any failure path
+     * (wrong prefix, no match, expired, revoked).
+     *
+     * @return array<string, mixed>|null
+     */
+    public static function findByPlaintext(string $plaintext): ?array
+    {
+        // 🛡️ Format gate BEFORE any DB hit.
+        if (str_starts_with($plaintext, self::TOKEN_PREFIX) === false) {
+            return null;
+        }
+        $bodyLen = self::TOKEN_BYTES * 2;
+        if (strlen($plaintext) !== strlen(self::TOKEN_PREFIX) + $bodyLen) {
+            return null;
+        }
+        $body = substr($plaintext, strlen(self::TOKEN_PREFIX));
+        if (ctype_xdigit($body) === false) {
+            return null;
+        }
+
+        $keyHash = hash('sha256', $plaintext);
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT keyID, siteID, name, keyHash, keyPrefix, scopes, expiresAt, isActive '
+            . 'FROM tblApiKeys WHERE keyHash = ? LIMIT 1'
+        );
+        if ($stmt === false) {
+            return null;
+        }
+        $stmt->bind_param('s', $keyHash);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if ($row === null) {
+            return null;
+        }
+
+        // 🛡️ Constant-time confirmation against the stored hash (belt + braces
+        //    in case of any indexing/collision weirdness).
+        if (hash_equals((string) $row['keyHash'], $keyHash) === false) {
+            return null;
+        }
+        if ((int) $row['isActive'] !== 1) {
+            return null;
+        }
+        if ($row['expiresAt'] !== null && strtotime((string) $row['expiresAt']) < time()) {
+            return null;
+        }
+
+        // 📋 Stamp last-used. Best-effort — failure here doesn't reject the key.
+        $ip = mb_substr((string) ($_SERVER['REMOTE_ADDR'] ?? ''), 0, 45);
+        $stmt = $db->prepare('UPDATE tblApiKeys SET lastUsedAt = NOW(), lastUsedIP = ? WHERE keyID = ?');
+        if ($stmt !== false) {
+            $kid = (int) $row['keyID'];
+            $stmt->bind_param('si', $ip, $kid);
+            @$stmt->execute();
+            $stmt->close();
+        }
+
+        return $row;
+    }
+
+    /**
+     * Does the given key row carry the required scope? Supports wildcard
+     * matching — a key with scope 'events:*' satisfies 'events:read'.
+     *
+     * @param array<string, mixed> $keyRow Row returned by findByPlaintext
+     */
+    public static function hasScope(array $keyRow, string $required): bool
+    {
+        $scopes = (string) ($keyRow['scopes'] ?? '');
+        if ($scopes === '') {
+            return false;
+        }
+        $required = trim($required);
+        if ($required === '') {
+            return true;
+        }
+        $list = array_map('trim', explode(',', $scopes));
+        foreach ($list as $scope) {
+            if ($scope === '*' || $scope === $required) {
+                return true;
+            }
+            // Wildcard tail: 'events:*' matches 'events:read' / 'events:write' / etc.
+            if (str_ends_with($scope, ':*') === true) {
+                $base = substr($scope, 0, -2);
+                if (str_starts_with($required, $base . ':') === true) {
+                    return true;
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Revoke a key. Idempotent — re-revoking is a no-op.
+     */
+    public static function revoke(int $keyId, int $byUserId): bool
+    {
+        if ($keyId <= 0) {
+            return false;
+        }
+        $db = App::db();
+        $stmt = $db->prepare(
+            'UPDATE tblApiKeys SET isActive = 0, revokedAt = NOW(), revokedByID = ? '
+            . 'WHERE keyID = ? AND isActive = 1'
+        );
+        if ($stmt === false) {
+            return false;
+        }
+        $stmt->bind_param('ii', $byUserId, $keyId);
+        $stmt->execute();
+        $affected = $stmt->affected_rows;
+        $stmt->close();
+        if ($affected > 0) {
+            Logger::activity('ApiKeyRevoked', 'Key #' . $keyId);
+        }
+        return $affected > 0;
+    }
+
+    /**
+     * Rotate: revoke the existing key and mint a replacement with the same
+     * siteID / name / scopes / expiresAt. Returns the new plaintext.
+     *
+     * @return array{plaintext: string, keyID: int, prefix: string}
+     */
+    public static function rotate(int $keyId, int $byUserId): array
+    {
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT siteID, name, scopes, expiresAt FROM tblApiKeys WHERE keyID = ? AND isActive = 1'
+        );
+        if ($stmt === false) {
+            throw new \RuntimeException('Failed to prepare rotate lookup');
+        }
+        $stmt->bind_param('i', $keyId);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        if ($row === null) {
+            throw new \RuntimeException('Key not found or not active');
+        }
+
+        self::revoke($keyId, $byUserId);
+
+        $scopes  = array_map('trim', explode(',', (string) ($row['scopes'] ?? '')));
+        $scopes  = array_values(array_filter($scopes, static fn($s) => $s !== ''));
+        $expires = $row['expiresAt'] !== null ? new \DateTimeImmutable((string) $row['expiresAt']) : null;
+
+        return self::mint(
+            (int) $row['siteID'],
+            (string) $row['name'],
+            $scopes,
+            $expires,
+            $byUserId
+        );
+    }
+}

--- a/web/_core/ApiResponse.php
+++ b/web/_core/ApiResponse.php
@@ -141,6 +141,45 @@ class ApiResponse
     }
 
     /**
+     * Require a valid API key on the request (#323 Phase 1). Bypasses the
+     * session entirely — reads the bearer token from the Authorization
+     * header, verifies via ApiKey::findByPlaintext, optionally checks scopes.
+     *
+     * Use INSTEAD of requireAuth in API handlers that want to be reachable
+     * by external integrations. Use ALONGSIDE if a handler can accept either
+     * (try requireApiKey first, fall back to requireAuth).
+     *
+     * Returns the key row so the handler can read keyID + siteID + scopes
+     * without re-querying.
+     *
+     * @param array<int, string> $requiredScopes Empty = any active key OK
+     *
+     * @return array<string, mixed> The matched key row
+     */
+    public static function requireApiKey(array $requiredScopes = []): array
+    {
+        $auth = (string) (
+            $_SERVER['HTTP_AUTHORIZATION']
+            ?? $_SERVER['REDIRECT_HTTP_AUTHORIZATION']
+            ?? ''
+        );
+        if (str_starts_with($auth, 'Bearer ') === false) {
+            self::error('Bearer token required in Authorization header', 401);
+        }
+        $token = trim(substr($auth, 7));
+        $row   = ApiKey::findByPlaintext($token);
+        if ($row === null) {
+            self::error('Invalid or expired API key', 401);
+        }
+        foreach ($requiredScopes as $scope) {
+            if (ApiKey::hasScope($row, (string) $scope) === false) {
+                self::error('API key missing required scope: ' . (string) $scope, 403);
+            }
+        }
+        return $row;
+    }
+
+    /**
      * Filter sensitive fields from data before sending via API.
      * Removes any keys that are marked as sensitive or contain personal data.
      *
@@ -154,6 +193,7 @@ class ApiResponse
         // 📌 Default sensitive field names that should never appear in API output
         $defaultSensitive = [
             'passwordHash',
+            'keyHash',       // tblApiKeys (#323 Phase 1) — never leak the hashed token
             'clientSecret',
             'secretKey',
             'encKey',

--- a/web/_core/HostConsole.php
+++ b/web/_core/HostConsole.php
@@ -1,0 +1,195 @@
+<?php
+// Path: _core/HostConsole.php
+/**
+ * -----------------------------------------------------------------------------
+ * Portal Core — HostConsole 🎙️📊
+ * -----------------------------------------------------------------------------
+ * Pure read-side composition helpers for the virtual host console (#317).
+ * Wraps existing COP primitives:
+ *   • tblLivestreamSessions (#318) — viewer count + 7-day session trend
+ *   • tblDecisionMoments    (#315) — per-moment-type counters
+ *   • tblSalvationCards     (#316) — recent intake stream
+ *
+ * NO writes. NO new tables. NO new infrastructure. Phase 1 of #317 ships
+ * the dashboard composition only — Phase 2 will add host → viewer push
+ * prompts which need their own schema.
+ *
+ * @package   Portal\Core
+ * @author    MWBM Partners Ltd (t/a MWservices)
+ * @copyright 2025-present MWBM Partners Ltd (t/a MWservices)
+ * @license   All Rights Reserved
+ * @version   1.0.0
+ * @link      https://github.com/MWBMPartners/webMS-Intra/issues/317
+ * -----------------------------------------------------------------------------
+ */
+
+declare(strict_types=1);
+
+namespace Portal\Core;
+
+class HostConsole
+{
+    /**
+     * Count of concurrent viewers for a livestream event right now.
+     * "Now" = lastPingAt within $windowSeconds AND leftAt IS NULL.
+     *
+     * 90s default tolerates the 30-60s ping cadence from the embed snippet
+     * shipped in #318 admin/livestream/dashboard.php without false-zeros
+     * during brief network blips.
+     */
+    public static function liveViewerCount(int $eventId, int $siteId, int $windowSeconds = 90): int
+    {
+        if ($eventId <= 0 || $siteId <= 0) {
+            return 0;
+        }
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT COUNT(*) AS c FROM tblLivestreamSessions '
+            . 'WHERE siteID = ? AND eventID = ? AND leftAt IS NULL '
+            . '  AND lastPingAt >= DATE_SUB(NOW(), INTERVAL ? SECOND)'
+        );
+        if ($stmt === false) {
+            return 0;
+        }
+        $stmt->bind_param('iii', $siteId, $eventId, $windowSeconds);
+        $stmt->execute();
+        $row = $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return (int) ($row['c'] ?? 0);
+    }
+
+    /**
+     * Per-day session counts for the last 7 days. Returned as an ordered
+     * array of ['date' => 'YYYY-MM-DD', 'count' => int] dictionaries so the
+     * caller can render a sparkline or a small bar chart.
+     *
+     * @return array<int, array{date: string, count: int}>
+     */
+    public static function sessionTrend7d(int $eventId, int $siteId): array
+    {
+        if ($eventId <= 0 || $siteId <= 0) {
+            return [];
+        }
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT DATE(joinedAt) AS d, COUNT(*) AS c FROM tblLivestreamSessions '
+            . 'WHERE siteID = ? AND eventID = ? '
+            . '  AND joinedAt >= DATE_SUB(CURDATE(), INTERVAL 7 DAY) '
+            . 'GROUP BY DATE(joinedAt) ORDER BY d ASC'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        $stmt->bind_param('ii', $siteId, $eventId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $byDate = [];
+        while ($r = $result->fetch_assoc()) {
+            $byDate[(string) $r['d']] = (int) $r['c'];
+        }
+        $stmt->close();
+
+        // 📅 Zero-fill missing days so the sparkline doesn't have gaps.
+        $out = [];
+        for ($i = 6; $i >= 0; $i--) {
+            $d = date('Y-m-d', strtotime('-' . $i . ' days'));
+            $out[] = ['date' => $d, 'count' => $byDate[$d] ?? 0];
+        }
+        return $out;
+    }
+
+    /**
+     * Per-momentType counter tallies for an event. Returns ALL six ENUM
+     * values zero-filled (so the dashboard's six tiles always render the
+     * same shape).
+     *
+     * @return array<string, array{count: int, updatedAt: ?string}>
+     */
+    public static function decisionTallies(int $eventId): array
+    {
+        $out = [];
+        foreach (['first-decision', 'rededication', 'baptism-request', 'membership-interest', 'prayer-request', 'other'] as $type) {
+            $out[$type] = ['count' => 0, 'updatedAt' => null];
+        }
+        if ($eventId <= 0) {
+            return $out;
+        }
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT momentType, count, updatedAt FROM tblDecisionMoments WHERE eventID = ?'
+        );
+        if ($stmt === false) {
+            return $out;
+        }
+        $stmt->bind_param('i', $eventId);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        while ($r = $result->fetch_assoc()) {
+            $key = (string) $r['momentType'];
+            if (isset($out[$key]) === true) {
+                $out[$key] = ['count' => (int) $r['count'], 'updatedAt' => (string) $r['updatedAt']];
+            }
+        }
+        $stmt->close();
+        return $out;
+    }
+
+    /**
+     * Latest salvation cards for the event. siteID-scoped (cards have a
+     * nullable eventID column from #316 migration 132, so cards without an
+     * event don't appear here — they're visible at /admin/decision-cards).
+     *
+     * @return array<int, array<string, mixed>>
+     */
+    public static function recentCards(int $eventId, int $siteId, int $limit = 20): array
+    {
+        if ($eventId <= 0 || $siteId <= 0) {
+            return [];
+        }
+        $limit = max(1, min(50, $limit));
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT c.cardID, c.fullName, c.email, c.decision, c.status, c.createdAt, '
+            . '       u.fullName AS assigneeName '
+            . 'FROM tblSalvationCards c LEFT JOIN tblUsers u ON u.userID = c.assignedToID '
+            . 'WHERE c.siteID = ? AND c.eventID = ? '
+            . 'ORDER BY c.createdAt DESC LIMIT ?'
+        );
+        if ($stmt === false) {
+            return [];
+        }
+        $stmt->bind_param('iii', $siteId, $eventId, $limit);
+        $stmt->execute();
+        $result = $stmt->get_result();
+        $out = [];
+        while ($r = $result->fetch_assoc()) {
+            $out[] = $r;
+        }
+        $stmt->close();
+        return $out;
+    }
+
+    /**
+     * Single-row probe: does the event exist AND belong to this site?
+     * Used as the 404 gate before any other read query — avoids leaking
+     * the existence of cross-site events through count-zero responses.
+     */
+    public static function eventBelongsToSite(int $eventId, int $siteId): bool
+    {
+        if ($eventId <= 0 || $siteId <= 0) {
+            return false;
+        }
+        $db = App::db();
+        $stmt = $db->prepare(
+            'SELECT eventID FROM tblEvents WHERE eventID = ? AND siteID = ? AND isDeleted = 0 LIMIT 1'
+        );
+        if ($stmt === false) {
+            return false;
+        }
+        $stmt->bind_param('ii', $eventId, $siteId);
+        $stmt->execute();
+        $found = (bool) $stmt->get_result()->fetch_assoc();
+        $stmt->close();
+        return $found;
+    }
+}

--- a/web/_sql/140_host_console.sql
+++ b/web/_sql/140_host_console.sql
@@ -1,0 +1,17 @@
+-- =============================================================================
+-- Migration 140: Virtual Host Console — Phase 1 of #317
+-- =============================================================================
+-- Read-only "during-the-service" dashboard composing the COP primitives shipped
+-- in PR #340 (tblLivestreamSessions #318, tblDecisionMoments #315,
+-- tblSalvationCards #316). NO new tables — pure read-side composition.
+--
+-- Phase 2 will add a push-prompt surface (host → viewer chat overlay) which
+-- needs its own schema; that's a separate migration.
+--
+-- @link https://github.com/MWBMPartners/WebMS-Intra/issues/317
+-- =============================================================================
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/host-console',       'admin/host-console/index.php', 1),
+    ('admin/host-console/event', 'admin/host-console/event.php', 1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);

--- a/web/_sql/141_api_keys.sql
+++ b/web/_sql/141_api_keys.sql
@@ -1,0 +1,45 @@
+-- =============================================================================
+-- Migration 141: API key infrastructure — Phase 1 of #323
+-- =============================================================================
+-- Stores bearer-token API keys for the public REST API. Plaintext tokens are
+-- returned EXACTLY ONCE at mint time and never persisted — the DB holds only
+-- their sha256 hash. keyPrefix (first ~6 chars + 'wbms_' prefix) is plain so
+-- the admin UI can identify keys at a glance ("wbms_3f2c…").
+--
+-- Phase 1 ships the infrastructure ONLY: schema, admin CRUD, ApiKey class,
+-- and ApiResponse::requireApiKey() helper. No /api/v1/* router refactor and
+-- no write endpoints are wired in this PR — those are Phase 2+.
+--
+-- @link https://github.com/MWBMPartners/WebMS-Intra/issues/323
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS `tblApiKeys` (
+    `keyID`        INT          NOT NULL AUTO_INCREMENT,
+    `siteID`       INT          NOT NULL,
+    `name`         VARCHAR(120) NOT NULL COMMENT 'Human-readable label shown in the admin UI',
+    `keyHash`      CHAR(64)     NOT NULL COMMENT 'sha256(plaintext) — plaintext is never stored',
+    `keyPrefix`    VARCHAR(12)  NOT NULL COMMENT 'Visible prefix for admin identification (e.g. wbms_3f2c)',
+    `scopes`       VARCHAR(500) DEFAULT NULL COMMENT 'CSV of scope strings — Phase 2 enforces, Phase 1 stores',
+    `expiresAt`    DATETIME     DEFAULT NULL COMMENT 'Optional hard expiry; NULL = no expiry',
+    `lastUsedAt`   DATETIME     DEFAULT NULL,
+    `lastUsedIP`   VARCHAR(45)  DEFAULT NULL COMMENT 'IPv4 (15 chars) or IPv6 (45 chars max)',
+    `isActive`     TINYINT(1)   NOT NULL DEFAULT 1,
+    `createdByID`  INT          DEFAULT NULL,
+    `createdAt`    DATETIME     NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    `revokedAt`    DATETIME     DEFAULT NULL,
+    `revokedByID`  INT          DEFAULT NULL,
+    PRIMARY KEY (`keyID`),
+    UNIQUE KEY `uq_apikey_hash`     (`keyHash`),
+    KEY        `idx_apikey_site`    (`siteID`, `isActive`),
+    KEY        `idx_apikey_expires` (`expiresAt`),
+    CONSTRAINT `fk_apikey_site`    FOREIGN KEY (`siteID`)      REFERENCES `tblSites`(`siteID`) ON DELETE CASCADE,
+    CONSTRAINT `fk_apikey_creator` FOREIGN KEY (`createdByID`) REFERENCES `tblUsers`(`userID`) ON DELETE SET NULL,
+    CONSTRAINT `fk_apikey_revoker` FOREIGN KEY (`revokedByID`) REFERENCES `tblUsers`(`userID`) ON DELETE SET NULL
+) ENGINE=InnoDB DEFAULT CHARSET=utf8mb4 COLLATE=utf8mb4_general_ci;
+
+INSERT INTO `tblRoutes` (`routeKey`, `targetFile`, `isProtected`) VALUES
+    ('admin/integrations/api-keys',        'admin/integrations/api-keys.php',         1),
+    ('admin/integrations/api-keys/save',   'admin/integrations/api-keys-save.php',    1),
+    ('admin/integrations/api-keys/revoke', 'admin/integrations/api-keys-revoke.php',  1),
+    ('admin/integrations/api-keys/rotate', 'admin/integrations/api-keys-rotate.php',  1)
+ON DUPLICATE KEY UPDATE `targetFile` = VALUES(`targetFile`);


### PR DESCRIPTION
## Summary

Phase 1 of two foundational initiatives, landing on one branch per the standing single-PR rule. Both are scoped TIGHTLY to the one piece each issue most needs first — no router refactors, no write endpoints, no push prompts. Two commits, both <2.5 days of effort.

### Commits

| Commit | Phase | What |
|---|---|---|
| (host-console) | **#317 Phase 1** — read-only host cockpit | New `Portal\Core\HostConsole` helper class (5 static methods composing existing tblLivestreamSessions / tblDecisionMoments / tblSalvationCards reads). New `/admin/host-console` event picker + `/admin/host-console/event?id=N` cockpit with live viewer count tile, 7-day sparkline, 6-tile decision tallies, latest-15 salvation cards stream. Auto-refresh via `<meta refresh content=30>` — JS / SSE upgrade is Phase 2. |
| (api-keys) | **#323 Phase 1** — API key infra | New `tblApiKeys` schema. New `Portal\Core\ApiKey` class with `mint` / `findByPlaintext` / `hasScope` / `revoke` / `rotate`. New `ApiResponse::requireApiKey()` helper. Admin CRUD at `/admin/integrations/api-keys` with one-time plaintext display banner. NO router refactor, NO write endpoints — Phase 2/3. |

### Migrations
- **140** — host console routes only (no new tables; pure read composition)
- **141** — tblApiKeys + 4 admin routes

### Composes with

- **#341** `Auth::isCoordinatorOf` — host console per-event gate
- **#315** tblDecisionMoments — read in dashboard
- **#316** tblSalvationCards — read in dashboard
- **#318** tblLivestreamSessions — read in dashboard
- **PR #340** Settings + Logger primitives — used in ApiKey class

### Security review

- **API key plaintext**: 128 bits entropy, sha256-hashed at rest, returned EXACTLY ONCE on mint/rotate via a session-flash banner with `user-select:all` for triple-click-to-copy, unset on next render.
- **`requireApiKey()` verification path**: format gate → SELECT by keyHash → `hash_equals` re-confirm → isActive → expiresAt. Constant-time. No info leak about WHICH step failed.
- **`keyHash` added to ApiResponse `$defaultSensitive`** — future JSON handlers can't leak it.
- **Cross-site guard** on revoke + rotate (`WHERE keyID = ? AND siteID = ?`).
- **CSRF + admin-only** on every API-key endpoint.
- **Host console**: 404-gate (`HostConsole::eventBelongsToSite`) BEFORE any read so cross-site event existence doesn't leak via count-zero.

### Known gaps acknowledged

- **#317**: `/api/livestream/ping` has NO active emitter in the embed page yet — 'Watching now' tile will read 0 until the embed snippet (documented at `/admin/livestream`) is wired into a live page. Phase 2 fix.
- **#323**: No router refactor → key auth works only via existing handlers that explicitly call `ApiResponse::requireApiKey()`. Phase 2 will refactor ApiRouter to support `/api/v1/{resource}/{id}` with method discrimination. Phase 3 wires write-side endpoints.

### NOT in this PR (deliberately)

- **#313 COP live chat Phase 1** — design referenced a `stream_moderator` role and `tblRoles` schema that recon didn't confirm. Held for the post-3pm-London verify pass that hit the session limit on this morning's workflow.
- **#303 Discipleship pathway Phase 1** — design referenced `_core/apps/discipleship.php` + AppRegistry discovery pattern that needs a 30-second sanity check before committing schema. Also held for verify.

🤖 Generated with [Claude Code](https://claude.com/claude-code)