### PR TITLE
ci: fix 3 workflow-lint errors (broken heredoc, empty option, injection) + add actionlint CI

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -70,12 +70,12 @@ on:
   workflow_dispatch:
     inputs:
       target:
-        description: "Override deploy target (alpha / beta / main). Leave blank to use the current branch."
+        description: "Override deploy target (alpha / beta / main). Use 'auto' to deploy the current branch."
         required: false
         type: choice
-        default: ""
+        default: "auto"
         options:
-          - ""
+          - "auto"
           - alpha
           - beta
           - main
@@ -156,7 +156,7 @@ jobs:
           DEV_PATH:  ${{ secrets.SFTP_DEV_PATH }}
         run: |
           MANUAL_TARGET="${{ github.event.inputs.target }}"
-          if [[ -n "$MANUAL_TARGET" ]]; then
+          if [[ -n "$MANUAL_TARGET" && "$MANUAL_TARGET" != "auto" ]]; then
             CHANNEL="$MANUAL_TARGET"
             echo "Manual dispatch override: $CHANNEL"
           else

--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -1,0 +1,48 @@
+# Lint GitHub Actions workflow files with actionlint.
+#
+# Added org-wide to catch real workflow bugs early — undefined `needs:`
+# jobs, malformed `${{ }}` expressions, invalid `runs-on`, deprecated
+# syntax, and genuine shell errors inside `run:` blocks. It is tuned to be
+# non-disruptive: the embedded shellcheck runs at `--severity=error`, so
+# cosmetic style/info/warning lint (SC2129 "group your redirects", SC2086
+# quoting info, …) never fails the build — only genuine breakage does.
+#
+# Runs only when workflow files change, so it costs no CI minutes on
+# ordinary code pushes.
+name: Lint Workflows
+
+on:
+  push:
+    paths:
+      - '.github/workflows/**'
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+  workflow_dispatch:
+
+# Least-privilege: this job only reads the checked-out tree.
+permissions:
+  contents: read
+
+concurrency:
+  group: lint-workflows-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  actionlint:
+    name: actionlint
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install actionlint (pinned, checksum-verified by the official script)
+        run: |
+          bash <(curl -sSfL "https://raw.githubusercontent.com/rhysd/actionlint/v1.7.12/scripts/download-actionlint.bash") 1.7.12
+
+      - name: Lint workflow files
+        env:
+          # Suppress cosmetic shellcheck style/info/warning; fail only on
+          # genuine errors (plus all of actionlint's own native checks).
+          SHELLCHECK_OPTS: --severity=error
+        run: ./actionlint -color

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -83,21 +83,21 @@ jobs:
             echo "Release ${VERSION}" > "$NOTES_FILE"
           else
             python3 - "$VERSION" <<'PYEOF' > "$NOTES_FILE"
-            import re, sys
-            version = sys.argv[1]
-            with open('CHANGELOG.md', 'r') as f:
-                content = f.read()
-            # Capture every "## [VERSION] ..." section until the next "## ["
-            pattern = (
-                r'## \[' + re.escape(version) + r'\][^\n]*\n'
-                r'(?:(?!^## \[).*\n?)*'
-            )
-            matches = re.findall(pattern, content, flags=re.MULTILINE)
-            if matches:
-                print('\n'.join(m.rstrip() for m in matches))
-            else:
-                print(f'Release {version}')
-            PYEOF
+          import re, sys
+          version = sys.argv[1]
+          with open('CHANGELOG.md', 'r') as f:
+              content = f.read()
+          # Capture every "## [VERSION] ..." section until the next "## ["
+          pattern = (
+              r'## \[' + re.escape(version) + r'\][^\n]*\n'
+              r'(?:(?!^## \[).*\n?)*'
+          )
+          matches = re.findall(pattern, content, flags=re.MULTILINE)
+          if matches:
+              print('\n'.join(m.rstrip() for m in matches))
+          else:
+              print(f'Release {version}')
+          PYEOF
           fi
 
           echo "----- release notes -----"

--- a/.github/workflows/version-bump.yml
+++ b/.github/workflows/version-bump.yml
@@ -85,9 +85,10 @@ jobs:
       # -----------------------------------------------------------------------
       - name: Determine bump type
         id: bump
+        env:
+          COMMIT_MSG: ${{ github.event.head_commit.message }}
         run: |
           BRANCH="${{ github.ref_name }}"
-          COMMIT_MSG="${{ github.event.head_commit.message }}"
           echo "Branch:  $BRANCH"
           echo "Commit:  $COMMIT_MSG"
 


### PR DESCRIPTION
Closes #366

Fixes the actionlint-flagged workflow errors and adds the `Lint Workflows` (actionlint) CI job. Verified green locally at `--severity=error` (cosmetic style/info is not failed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)