### PR TITLE
ci(deps): bump actions/setup-python from 6 to 7 in the gh-actions group (alpha copy of #368)

### DIFF
--- a/.github/workflows/repo-config-audit.yml
+++ b/.github/workflows/repo-config-audit.yml
@@ -58,7 +58,7 @@ jobs:
         uses: actions/checkout@v7
 
       - name: Setup Python
-        uses: actions/setup-python@v6
+        uses: actions/setup-python@v7
         with:
           python-version: '3.11'
 


### PR DESCRIPTION
## Summary

Alpha-targeted copy of #368 (which targets `main`). Bumps `actions/setup-python` from **6 to 7** in `.github/workflows/repo-config-audit.yml` so the **alpha** deploy tier receives the same GitHub Actions dependency bump instead of drifting behind `main`. Functionally identical one-line change to #368, re-based onto `alpha`.

> **Opened as a DRAFT deliberately.** `auto-merge-alpha.yml` enables squash auto-merge on any *non-draft* PR based on `alpha`. Per instruction this must **not** merge yet — mark **Ready for review** when you want it to land.

## Scope of changes

- [ ] Backend (PHP under `web/`)
- [ ] Frontend (CSS/JS under `web/public_html/assets/`)
- [ ] SQL migrations
- [x] CI / workflows (`.github/workflows/`)
- [ ] Documentation

## Test plan

- [x] One-line action version bump; `actions/setup-python@v7` is the current major and API-compatible for the `python-version: '3.11'` usage here.
- [x] `repo-config-audit.yml` job (`Setup Python` step) is the only consumer; no inputs changed.

## Security review

Not applicable to a GitHub Actions version bump — no PHP, SQL, input/output handling, CSRF, auth, secrets, migrations, or vendored libraries are touched. `actions/setup-python@v7` is the upstream-maintained action; the bump reduces (does not add) supply-chain drift.

### Dependencies

- [x] No new vendored library added; this is a first-party GitHub Action version bump mirroring Dependabot's own #368.

## Deployment notes

- [x] No manual server steps required.
- [ ] Targets: alpha → ☑ &nbsp;&nbsp; beta → ☐ &nbsp;&nbsp; main → ☐ (main is handled by #368)

## Related issues

Refs #368 (this is the alpha-targeted twin of that Dependabot PR).


---
_Generated by [Claude Code](https://claude.ai/code/session_01SSuB5QuUCydDQm5Bh7UKtB)_